### PR TITLE
Fix db config for production deployment

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -18,7 +18,7 @@ module.exports = {
   },
   "production": {
     "username": "root",
-    "password": null,
+    "password": process.env.DB_PASSWORD,
     "database": "db_opentogethertube_prod",
     "host": "127.0.0.1",
     "dialect": "postgres",

--- a/config/config.js
+++ b/config/config.js
@@ -17,7 +17,7 @@ module.exports = {
     "operatorsAliases": false
   },
   "production": {
-    "username": "root",
+    "username": "ott",
     "password": process.env.DB_PASSWORD,
     "database": "db_opentogethertube_prod",
     "host": "127.0.0.1",


### PR DESCRIPTION
The db config now grabs the password for production from the environment variable `DB_PASSWORD`