### PR TITLE
Display number of videos in queue

### DIFF
--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -31,7 +31,7 @@
             <v-tabs grow v-model="queueTab">
               <v-tab>
                 Queue
-                <span class="bubble">{{$store.state.room.queue.length < 99? $store.state.room.queue.length : "99+"}}</span>
+                <span class="bubble">{{ $store.state.room.queue.length <= 99 ? $store.state.room.queue.length : "99+" }}</span>
               </v-tab>
               <v-tab>Add</v-tab>
             </v-tabs>
@@ -98,9 +98,7 @@ export default {
       inputAddUrlText: "",
 
       showJoinFailOverlay: false,
-      joinFailReason: "",
-
-      totalItemsInQueue: 0
+      joinFailReason: ""
     };
   },
   computed: {
@@ -161,7 +159,6 @@ export default {
       API.post(`/room/${this.$route.params.roomId}/queue`, {
         url: this.inputAddUrlText
       });
-      this.totalItemsInQueue += 1;
     },
     openEditName() {
       this.showEditName = !this.showEditName;
@@ -274,7 +271,7 @@ export default {
 .bubble{
   height: 25px;
   width: 25px;
-  left: 10px;
+  margin-left: 10px;
   background-color: #3f3838;
   border-radius: 50%;
   display: inline-block;

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -31,7 +31,7 @@
             <v-tabs grow v-model="queueTab">
               <v-tab>
                 Queue
-                <span class="bubble">{{$store.state.room.queue.length}}</span>
+                <span class="bubble">{{$store.state.room.queue.length < 99? $store.state.room.queue.length : "99+"}}</span>
               </v-tab>
               <v-tab>Add</v-tab>
             </v-tabs>

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -31,7 +31,7 @@
             <v-tabs grow v-model="queueTab">
               <v-tab>
                 Queue
-                <span class="bubble">2</span>
+                <span class="bubble">{{$store.state.room.queue.length}}</span>
               </v-tab>
               <v-tab>Add</v-tab>
             </v-tabs>
@@ -98,7 +98,9 @@ export default {
       inputAddUrlText: "",
 
       showJoinFailOverlay: false,
-      joinFailReason: ""
+      joinFailReason: "",
+
+      totalItemsInQueue: 0
     };
   },
   computed: {
@@ -159,6 +161,7 @@ export default {
       API.post(`/room/${this.$route.params.roomId}/queue`, {
         url: this.inputAddUrlText
       });
+      this.totalItemsInQueue += 1;
     },
     openEditName() {
       this.showEditName = !this.showEditName;

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -29,7 +29,10 @@
         <v-layout row justify-space-between>
           <v-flex column md8 sm12>
             <v-tabs grow v-model="queueTab">
-              <v-tab>Queue</v-tab>
+              <v-tab>
+                Queue
+                <span class="bubble">2</span>
+              </v-tab>
               <v-tab>Add</v-tab>
             </v-tabs>
             <div class="video-queue" v-if="queueTab === 0">
@@ -264,5 +267,18 @@ export default {
   left: 0;
   width: 100%;
   height: 100%;
+}
+.bubble{
+  height: 25px;
+  width: 25px;
+  left: 10px;
+  background-color: #3f3838;
+  border-radius: 50%;
+  display: inline-block;
+
+  font-weight: bold;
+  color:#fff;
+  text-align: center;
+  line-height: 1.8;
 }
 </style>


### PR DESCRIPTION
A bubble was added within the "Queue" tab that tracks the number of videos currently in the queue. A queue with over 99 videos will display "99+" instead.

closes #22 