### PR TITLE
update styles and colors to improve readability

### DIFF
--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -14,8 +14,8 @@ export default new Vuetify({
 		dark: true,
 		themes: {
 			dark: {
-				primary: "#aa00ff",
-				secondary: "#ffb300"
+				primary: "#ffb300", // orange
+				secondary: "#42A5F5", // blue
 			}
 		}
 	},

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -244,9 +244,9 @@ export default {
   min-height: 500px;
 }
 .is-you {
-  color: #fff;
-  background-color: #aa00ff;
-  border-radius: 5px;
+  color: #ffb300;
+  border: 1px #ffb300 solid;
+  border-radius: 10px;
   margin: 5px;
   padding: 0 5px;
   font-size: 10px;


### PR DESCRIPTION
I've updated the primary and secondary colors. I chose an orange (#ffb300) and a blue (#42A5F5) because the purple we had before was hard to read.

I also updated the `is-you` style to use the primary color and be more readable.

Since we are following the material design guidelines, see here: https://material.io/design/color/dark-theme.html