### PR TITLE
Add Windows support with npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "vue-cli-service lint",
     "test": "vue-cli-service test:unit",
     "api-server": "nodemon app.js",
-    "dev": "NODE_ENV=development concurrently \"npm:api-server\" \"npm:serve\""
+    "dev": "NODE_ENV=development concurrently \"npm:api-server\" \"npm:serve\"",
+    "dev-windows": "SET NODE_ENV=development && concurrently \"npm:api-server\" \"npm:serve\""
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",


### PR DESCRIPTION
`npm run dev-windows` will start the dev server on Windows

closes #62 