### PR TITLE
Added timestamp for current video playing

### DIFF
--- a/src/timestamp.js
+++ b/src/timestamp.js
@@ -1,0 +1,5 @@
+
+export default function convertSecondstoHHMMSS(seconds){    //if the time passed to it is less than an hour, it converts to mm:ss instead
+    let timeString = new Date(seconds * 1000).toISOString();
+    return seconds >= 3600 ? timeString.substr(11,8) : timeString.substr(14,5);
+}

--- a/src/timestamp.js
+++ b/src/timestamp.js
@@ -1,5 +1,5 @@
 
 export default function secondsToTimestamp(seconds) {    //formats seconds into mm:ss if less than an hour, hh:mm:ss if greater than an hour
-    let timeString = new Date(seconds * 1000).toISOString();
+    const timeString = new Date(seconds * 1000).toISOString();
     return seconds >= 3600 ? timeString.substr(11,8) : timeString.substr(14,5);
 }

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -22,6 +22,9 @@
                   <v-icon>fas fa-fast-forward</v-icon>
                 </v-btn>
                 <vue-slider v-model="volume" style="width: 150px; margin-left: 10px"></vue-slider>
+                <div style="margin-left: 20px">
+                  {{ timestampDisplay }}
+                </div>
               </v-flex>
             </v-flex>
           </v-flex>
@@ -80,6 +83,7 @@
 <script>
 import { API } from "@/common-http.js";
 import VideoQueueItem from "@/components/VideoQueueItem.vue";
+import convertSecondstoHHMMSS from "../timestamp.js";
 
 export default {
   name: 'room',
@@ -118,6 +122,11 @@ export default {
     },
     playbackPercentage() {
       return this.$store.state.room.playbackPosition / this.$store.state.room.playbackDuration;
+    },
+    timestampDisplay(){
+      const position = convertSecondstoHHMMSS(this.$store.state.room.playbackPosition);
+      const duration = convertSecondstoHHMMSS(this.$store.state.room.currentSource.length);
+      return position + " / " + duration;
     }
   },
   created() {


### PR DESCRIPTION
Added a timestamp for the current video to the left of the volume slider. It changes from a mm:ss to a hh:mm:ss format depending on how long the video is and the current position of the slider.