### PR TITLE
Issues with secondsToTimestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vue-cli-service test:unit",
     "api-server": "nodemon app.js",
     "dev": "NODE_ENV=development concurrently \"npm:api-server\" \"npm:serve\"",
-    "dev-windows": "SET NODE_ENV=development && concurrently \"npm:api-server\" \"npm:serve\""
+    "dev-windows": "SET NODE_ENV=development&&concurrently \"npm:api-server\" \"npm:serve\""
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",

--- a/src/store.js
+++ b/src/store.js
@@ -10,7 +10,8 @@ export default new Vuex.Store({
 			message: '',
 			reconnectError: false,
 		},
-		joinFailureReason: null,
+        joinFailureReason: null,
+        production: process.env.NODE_ENV === 'production',
 		room: {
 			name: "",
 			title: "",

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -44,8 +44,8 @@
             <div class="video-add" v-if="queueTab === 1">
               <v-text-field placeholder="Video URL to add to queue" @change="onInputAddChange" v-model="inputAddUrlText"></v-text-field>
               <v-btn @click="addToQueue">Add</v-btn>
-              <v-btn @click="postTestVideo(0)">Add test video 0</v-btn>
-              <v-btn @click="postTestVideo(1)">Add test video 1</v-btn>
+              <v-btn v-if="!production" @click="postTestVideo(0)">Add test video 0</v-btn>
+              <v-btn v-if="!production" @click="postTestVideo(1)">Add test video 1</v-btn>
 
               <VideoQueueItem v-for="(itemdata, index) in addPreview" :key="index" :item="itemdata" isPreview/>
             </div>

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -119,11 +119,14 @@ export default {
       return this.$store.state.room.playbackPosition;
     },
     playbackPercentage() {
+      if (this.$store.state.room.playbackDuration === 0) {
+        return 0
+      }
       return this.$store.state.room.playbackPosition / this.$store.state.room.playbackDuration;
     },
     timestampDisplay(){
       const position = secondsToTimestamp(this.$store.state.room.playbackPosition);
-      const duration = secondsToTimestamp(this.$store.state.room.currentSource.length);
+      const duration = secondsToTimestamp(this.$store.state.room.currentSource.length || 0);
       return position + " / " + duration;
     }
   },


### PR DESCRIPTION
Two issues caused this function to error in development:
- A zero division error when playback duration was 0 (default)
- Attribute error when accessing length property of a source that doesn't exist (default empty object)

This PR fixes both of these issues.