### PR TITLE
Seconds timestamp bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vue-cli-service test:unit",
     "api-server": "nodemon app.js",
     "dev": "NODE_ENV=development concurrently \"npm:api-server\" \"npm:serve\"",
-    "dev-windows": "SET NODE_ENV=development && concurrently \"npm:api-server\" \"npm:serve\""
+    "dev-windows": "SET NODE_ENV=development&&concurrently \"npm:api-server\" \"npm:serve\""
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -125,11 +125,17 @@ export default {
       return this.$store.state.room.playbackPosition;
     },
     playbackPercentage() {
+      if (!this.$store.state.room.currentSource) {
+        return 0;
+      }
+      if (this.$store.state.room.currentSource.length == 0) {
+        return 0;
+      }
       return this.$store.state.room.playbackPosition / this.$store.state.room.playbackDuration;
     },
     timestampDisplay(){
       const position = secondsToTimestamp(this.$store.state.room.playbackPosition);
-      const duration = secondsToTimestamp(this.$store.state.room.currentSource.length);
+      const duration = secondsToTimestamp(this.$store.state.room.currentSource.length || 0);
       return position + " / " + duration;
     }
   },


### PR DESCRIPTION
Two issues caused this function to error in development:
- A zero division error when playback duration was 0 (default)
- Attribute error when accessing length property of a source that doesn't exist (default empty object)
This PR fixes both of these issues.