### PR TITLE
Add local cache for video metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 install:
   - npm ci
 before_script:
+  - NODE_ENV=test npx sequelize-cli db:migrate
   - npm run build
 script:
   - npm run lint-ci

--- a/config/config.js
+++ b/config/config.js
@@ -24,6 +24,7 @@ module.exports = {
     "host": "127.0.0.1",
     "dialect": "sqlite",
     "operatorsAliases": false,
+    "storage": "db/test.sqlite",
   },
   "production": {
     "username": "ott",

--- a/infoextract.js
+++ b/infoextract.js
@@ -165,6 +165,12 @@ module.exports = {
 					}
 					results.push(video);
 				}
+
+				// update cache
+				for (const video of results) {
+					storage.updateVideoInfo(video);
+				}
+
 				resolve(results);
 			}).catch(err => {
 				reject(err);

--- a/infoextract.js
+++ b/infoextract.js
@@ -43,9 +43,7 @@ module.exports = {
 
 			if (video.service === "youtube") {
 				return this.getVideoInfoYoutube([video.id], missingInfo).then(result => {
-					for (let field of missingInfo) {
-						video[field] = result[video.id][field];
-					}
+					video = Object.assign(video, result[video.id]);
 					return video;
 				}).catch(err => {
 					console.error("Failed to get youtube video info:", err);

--- a/infoextract.js
+++ b/infoextract.js
@@ -13,13 +13,37 @@ module.exports = {
 	/**
 	 * Gets all necessary information needed to represent a video. Handles
 	 * local caching and obtaining missing data from external sources.
+	 * Note that this function does not update the cache. That should be
+	 * handled by the functions that actually retrieve missing info.
 	 * @param	{string} service The service that hosts the source video.
 	 * @param	{string} id The id of the video on the given service.
 	 * @return	{Object} Video object
 	 */
 	getVideoInfo(service, id) {
-		storage.getVideoInfo(service, id).then(result => {
-			return result;
+		// TODO: check if service is valid
+		// TODO: check if id is valid for service
+		return storage.getVideoInfo(service, id).then(result => {
+			let video = {};
+			for (const key in result) {
+				if (result.hasOwnProperty(key)) {
+					video[key] = result[key];
+				}
+			}
+			let missingInfo = [
+				"title",
+				"description",
+				"thumbnail",
+				"length",
+			].filter(p => !video.hasOwnProperty(p));
+			if (missingInfo.length === 0) {
+				return video;
+			}
+
+			if (video.service === "youtube") {
+				return this.getVideoInfoYoutube([video.id]).then(result => {
+					return result[video.id];
+				});
+			}
 		}).catch(err => {
 			console.error("Failed to get video metadata from database:", err);
 		});

--- a/infoextract.js
+++ b/infoextract.js
@@ -218,12 +218,12 @@ module.exports = {
 		}
 		else {
 			let video = {
-				service: "youtube",
+				service: service,
 				id: queryParams.v,
 				title: queryParams.v,
 			};
-			return this.getVideoInfoYoutube([video.id]).then(results => {
-				video = results[queryParams.v];
+			return this.getVideoInfo(video.service, video.id).then(result => {
+				video = result;
 			}).catch(err => {
 				console.error("Failed to get video info");
 				console.error(err);

--- a/infoextract.js
+++ b/infoextract.js
@@ -2,6 +2,7 @@ const axios = require("axios");
 const url = require("url");
 const querystring = require('querystring');
 const moment = require("moment");
+const _ = require("lodash");
 const storage = require("./storage");
 
 const YOUTUBE_API_URL = "https://www.googleapis.com/youtube/v3";
@@ -23,12 +24,7 @@ module.exports = {
 		// TODO: check if service is valid
 		// TODO: check if id is valid for service
 		return storage.getVideoInfo(service, id).then(result => {
-			let video = {};
-			for (const key in result) {
-				if (result.hasOwnProperty(key)) {
-					video[key] = result[key];
-				}
-			}
+			let video = _.cloneDeep(result);
 			let missingInfo = [
 				"title",
 				"description",

--- a/infoextract.js
+++ b/infoextract.js
@@ -25,12 +25,8 @@ module.exports = {
 		// TODO: check if id is valid for service
 		return storage.getVideoInfo(service, id).then(result => {
 			let video = _.cloneDeep(result);
-			let missingInfo = [
-				"title",
-				"description",
-				"thumbnail",
-				"length",
-			].filter(p => !video.hasOwnProperty(p));
+			console.log("==========================", storage.getVideoInfoFields());
+			let missingInfo = storage.getVideoInfoFields().filter(p => !video.hasOwnProperty(p));
 			if (missingInfo.length === 0) {
 				return video;
 			}

--- a/infoextract.js
+++ b/infoextract.js
@@ -42,6 +42,9 @@ module.exports = {
 			if (video.service === "youtube") {
 				return this.getVideoInfoYoutube([video.id]).then(result => {
 					return result[video.id];
+				}).catch(err => {
+					console.error("Failed to get youtube video info:", err);
+					throw err;
 				});
 			}
 		}).catch(err => {
@@ -70,7 +73,6 @@ module.exports = {
 	},
 
 	getVideoInfoYoutube(ids) {
-		// TODO: local caching of results
 		if (!Array.isArray(ids)) {
 			throw "`ids` must be an array on video IDs.";
 		}
@@ -102,6 +104,12 @@ module.exports = {
 					}
 					results[item.id] = video;
 				}
+
+				// update cache
+				for (const id in results) {
+					storage.updateVideoInfo(results[id]);
+				}
+
 				resolve(results);
 			}).catch(err => {
 				reject(err);

--- a/infoextract.js
+++ b/infoextract.js
@@ -2,6 +2,7 @@ const axios = require("axios");
 const url = require("url");
 const querystring = require('querystring');
 const moment = require("moment");
+const storage = require("./storage");
 
 const YOUTUBE_API_URL = "https://www.googleapis.com/youtube/v3";
 const YtApi = axios.create({
@@ -9,6 +10,21 @@ const YtApi = axios.create({
 });
 
 module.exports = {
+	/**
+	 * Gets all necessary information needed to represent a video. Handles
+	 * local caching and obtaining missing data from external sources.
+	 * @param	{string} service The service that hosts the source video.
+	 * @param	{string} id The id of the video on the given service.
+	 * @return	{Object} Video object
+	 */
+	getVideoInfo(service, id) {
+		storage.getVideoInfo(service, id).then(result => {
+			return result;
+		}).catch(err => {
+			console.error("Failed to get video metadata from database:", err);
+		});
+	},
+
 	getService(link) {
 		let srcUrl = url.parse(link);
 		if (srcUrl.host.endsWith("youtube.com") || srcUrl.host.endsWith("youtu.be")) {

--- a/migrations/20190921194802-create-cached-video.js
+++ b/migrations/20190921194802-create-cached-video.js
@@ -11,7 +11,7 @@ module.exports = {
       service: {
         type: Sequelize.STRING,
       },
-      service_id: {
+      serviceId: {
         type: Sequelize.STRING,
       },
       title: {

--- a/migrations/20190921194802-create-cached-video.js
+++ b/migrations/20190921194802-create-cached-video.js
@@ -1,0 +1,43 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('CachedVideos', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      service: {
+        type: Sequelize.STRING,
+      },
+      service_id: {
+        type: Sequelize.STRING,
+      },
+      title: {
+        type: Sequelize.STRING,
+      },
+      description: {
+        type: Sequelize.TEXT,
+      },
+      thumbnail: {
+        type: Sequelize.STRING,
+      },
+      length: {
+        type: Sequelize.INTEGER,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  // eslint-disable-next-line no-unused-vars
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('CachedVideos');
+  },
+};

--- a/models/cachedvideo.js
+++ b/models/cachedvideo.js
@@ -1,0 +1,16 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const CachedVideo = sequelize.define('CachedVideo', {
+    service: DataTypes.STRING,
+    service_id: DataTypes.STRING,
+    title: DataTypes.STRING,
+    description: DataTypes.TEXT,
+    thumbnail: DataTypes.STRING,
+    length: DataTypes.INTEGER,
+  }, {});
+  // eslint-disable-next-line no-unused-vars
+  CachedVideo.associate = function(models) {
+    // associations can be defined here
+  };
+  return CachedVideo;
+};

--- a/models/cachedvideo.js
+++ b/models/cachedvideo.js
@@ -2,7 +2,7 @@
 module.exports = (sequelize, DataTypes) => {
   const CachedVideo = sequelize.define('CachedVideo', {
     service: DataTypes.STRING,
-    service_id: DataTypes.STRING,
+    serviceId: DataTypes.STRING,
     title: DataTypes.STRING,
     description: DataTypes.TEXT,
     thumbnail: DataTypes.STRING,

--- a/roommanager.js
+++ b/roommanager.js
@@ -145,8 +145,8 @@ module.exports = function (server, storage) {
 
 		if (queueItem.service === "youtube") {
 			// TODO: fallback to "unofficial" methods of retreiving if using the youtube API fails.
-			return InfoExtract.getVideoInfoYoutube([queueItem.id]).then(results => {
-				queueItem = results[queueItem.id];
+			return InfoExtract.getVideoInfo(queueItem.service, queueItem.id).then(result => {
+				queueItem = result;
 			}).catch(err => {
 				console.error("Failed to get video info");
 				console.error(err);

--- a/storage.js
+++ b/storage.js
@@ -25,4 +25,15 @@ module.exports = {
 	updateRoom: function(room) {
 		// TODO: update existing room in db
 	},
+	/**
+	 * Gets cached video information from the database. If cached information
+	 * is invalid, it will be omitted from the returned video object.
+	 * @param	{string} service The service that hosts the source video.
+	 * @param	{string} id The id of the video on the given service.
+	 * @return	{Object} Video object, but it may contain missing properties.
+	 */
+	getVideoInfo(service, id) {
+		// TODO: get video info from db
+		return new Promise(resolve => resolve({ service, id }));
+	},
 };

--- a/storage.js
+++ b/storage.js
@@ -1,3 +1,4 @@
+const _ = require("lodash");
 const { Room, CachedVideo } = require("./models");
 
 module.exports = {
@@ -68,6 +69,7 @@ module.exports = {
 	 * @param {Object} video Video object to store
 	 */
 	updateVideoInfo(video) {
+		video = _.cloneDeep(video);
 		video.service_id = video.id;
 		delete video.id;
 

--- a/storage.js
+++ b/storage.js
@@ -74,7 +74,7 @@ module.exports = {
 		delete video.id;
 
 		return CachedVideo.findOne({ where: { service: video.service, service_id: video.service_id } }).then(cachedVideo => {
-			console.log(`Found video {video.service}:{video.service_id} in cache`);
+			console.log(`Found video ${video.service}:${video.service_id} in cache`);
 			CachedVideo.update(video, { where: { id: cachedVideo.id } }).then(rowsUpdated => {
 				console.log("Updated database records, updated", rowsUpdated, "rows");
 				return true;
@@ -84,7 +84,7 @@ module.exports = {
 			});
 		}).catch(() => {
 			return CachedVideo.create(video).then(() => {
-				console.log(`Stored video info for {video.service}:{video.service_id} in cache`);
+				console.log(`Stored video info for ${video.service}:${video.service_id} in cache`);
 				return true;
 			}).catch(err => {
 				console.error("Failed to cache video info", err);

--- a/storage.js
+++ b/storage.js
@@ -103,4 +103,14 @@ module.exports = {
 			});
 		});
 	},
+	getVideoInfoFields() {
+		let fields = [];
+		for (let column in CachedVideo.rawAttributes) {
+			if (column === "id" || column === "createdAt" || column === "updatedAt" || column === "serviceId") {
+				continue;
+			}
+			fields.push(column);
+		}
+		return fields;
+	},
 };

--- a/storage.js
+++ b/storage.js
@@ -1,4 +1,4 @@
-const { Room } = require("./models");
+const { Room, CachedVideo } = require("./models");
 
 module.exports = {
 	getRoomByName(roomName) {
@@ -33,7 +33,61 @@ module.exports = {
 	 * @return	{Object} Video object, but it may contain missing properties.
 	 */
 	getVideoInfo(service, id) {
-		// TODO: get video info from db
-		return new Promise(resolve => resolve({ service, id }));
+		return CachedVideo.findOne({ where: { service: service, service_id: id } }).then(cachedVideo => {
+			if (cachedVideo === null) {
+				console.log("Cache missed:", service, id);
+				return { service, id };
+			}
+			let video = {
+				service: cachedVideo.service,
+				id: cachedVideo.service_id,
+			};
+			if (cachedVideo.title !== null) {
+				video.title = cachedVideo.title;
+			}
+			if (cachedVideo.description !== null) {
+				video.description = cachedVideo.description;
+			}
+			if (cachedVideo.thumbnail !== null) {
+				video.thumbnail = cachedVideo.thumbnail;
+			}
+			if (cachedVideo.length !== null) {
+				video.length = cachedVideo.length;
+			}
+			return video;
+		}).catch(err => {
+			console.warn("Cache failure", err);
+			return { service, id };
+		});
+	},
+	/**
+	 * Updates the database with the given video. If the video exists in
+	 * the database, it is overwritten. Omitted properties will not be
+	 * overwritten. If the video does not exist in the database, it will be
+	 * created.
+	 * @param {Object} video Video object to store
+	 */
+	updateVideoInfo(video) {
+		video.service_id = video.id;
+		delete video.id;
+
+		return CachedVideo.findOne({ where: { service: video.service, service_id: video.service_id } }).then(cachedVideo => {
+			console.log(`Found video {video.service}:{video.service_id} in cache`);
+			CachedVideo.update(video, { where: { id: cachedVideo.id } }).then(rowsUpdated => {
+				console.log("Updated database records, updated", rowsUpdated, "rows");
+				return true;
+			}).catch(err => {
+				console.error("Failed to cache video info", err);
+				return false;
+			});
+		}).catch(() => {
+			return CachedVideo.create(video).then(() => {
+				console.log(`Stored video info for {video.service}:{video.service_id} in cache`);
+				return true;
+			}).catch(err => {
+				console.error("Failed to cache video info", err);
+				return false;
+			});
+		});
 	},
 };

--- a/storage.js
+++ b/storage.js
@@ -35,7 +35,7 @@ module.exports = {
 	 * @return	{Object} Video object, but it may contain missing properties.
 	 */
 	getVideoInfo(service, id) {
-		return CachedVideo.findOne({ where: { service: service, service_id: id } }).then(cachedVideo => {
+		return CachedVideo.findOne({ where: { service: service, serviceId: id } }).then(cachedVideo => {
 			if (cachedVideo === null) {
 				console.log("Cache missed:", service, id);
 				return { service, id };
@@ -51,7 +51,7 @@ module.exports = {
 			const isCachedInfoValid = lastUpdatedAt.diff(today, "days") <= (origCreatedAt.diff(today, "days") <= 7) ? 7 : 30;
 			let video = {
 				service: cachedVideo.service,
-				id: cachedVideo.service_id,
+				id: cachedVideo.serviceId,
 			};
 			// We only invalidate the title and description because those are the only ones that can change.
 			if (cachedVideo.title !== null && isCachedInfoValid) {
@@ -81,11 +81,11 @@ module.exports = {
 	 */
 	updateVideoInfo(video) {
 		video = _.cloneDeep(video);
-		video.service_id = video.id;
+		video.serviceId = video.id;
 		delete video.id;
 
-		return CachedVideo.findOne({ where: { service: video.service, service_id: video.service_id } }).then(cachedVideo => {
-			console.log(`Found video ${video.service}:${video.service_id} in cache`);
+		return CachedVideo.findOne({ where: { service: video.service, serviceId: video.serviceId } }).then(cachedVideo => {
+			console.log(`Found video ${video.service}:${video.serviceId} in cache`);
 			CachedVideo.update(video, { where: { id: cachedVideo.id } }).then(rowsUpdated => {
 				console.log("Updated database records, updated", rowsUpdated, "rows");
 				return true;
@@ -95,7 +95,7 @@ module.exports = {
 			});
 		}).catch(() => {
 			return CachedVideo.create(video).then(() => {
-				console.log(`Stored video info for ${video.service}:${video.service_id} in cache`);
+				console.log(`Stored video info for ${video.service}:${video.serviceId} in cache`);
 				return true;
 			}).catch(err => {
 				console.error("Failed to cache video info", err);

--- a/tests/unit/infoextractor.spec.js
+++ b/tests/unit/infoextractor.spec.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const InfoExtract = require("../../infoextract");
+const { CachedVideo } = require("../../models");
 
 const config_path = path.resolve(process.cwd(), `env/${process.env.NODE_ENV}.env`);
 if (!fs.existsSync(config_path)) {
@@ -9,11 +10,21 @@ if (!fs.existsSync(config_path)) {
 require('dotenv').config({ path: config_path });
 
 describe('InfoExtractor Spec', () => {
-  it('should get the correct video metadata (uncached)', done => {
+  beforeEach(async () => {
+    console.warn("CLEAR CACHE");
+    await CachedVideo.destroy({ where: {} });
+  }),
+
+  afterEach(async () => {
+
+  }),
+
+  it('should get the correct video metadata', done => {
       InfoExtract.getVideoInfo("youtube", "BTZ5KVRUy1Q").then(video => {
         expect(video).toBeDefined();
         expect(video.service).toBeDefined();
         expect(video.service).toBe("youtube");
+        expect(video.service_id).toBeUndefined();
         expect(video.id).toBeDefined();
         expect(video.id).toBe("BTZ5KVRUy1Q");
         expect(video.title).toBeDefined();
@@ -25,6 +36,67 @@ describe('InfoExtractor Spec', () => {
         expect(video.length).toBeDefined();
         expect(video.length).toBe(10);
         done();
-      });
+      }).catch(err => done.fail(err));
+  });
+
+  it('should miss cache, get the correct video metadata, and store it in the cache', async done => {
+    await expect(CachedVideo.findOne({ where: { service: "youtube", service_id: "I3O9J02G67I" }})).resolves.toBeNull();
+
+    InfoExtract.getVideoInfo("youtube", "I3O9J02G67I").then(async video => {
+      expect(video).toBeDefined();
+      expect(video.service).toBeDefined();
+      expect(video.service).toBe("youtube");
+      expect(video.service_id).toBeUndefined();
+      expect(video.id).toBeDefined();
+      expect(video.id).toBe("I3O9J02G67I");
+      expect(video.title).toBeDefined();
+      expect(video.title).toBe("tmpATT2Cp");
+      expect(video.description).toBeDefined();
+      expect(video.description).toBe("tmpATT2Cp");
+      expect(video.thumbnail).toBeDefined();
+      expect(video.thumbnail).toBe("https://i.ytimg.com/vi/I3O9J02G67I/mqdefault.jpg");
+      expect(video.length).toBeDefined();
+      expect(video.length).toBe(10);
+
+      await expect(CachedVideo.count()).resolves.toEqual(1);
+      await expect(CachedVideo.findOne({ where: { service: "youtube", service_id: "I3O9J02G67I" }})).resolves.toBeDefined();
+      done();
+    }).catch(err => done.fail(err));
+  });
+
+  it('should hit cache, get the correct video metadata from the cache', async done => {
+    await expect(CachedVideo.count()).resolves.toEqual(0);
+
+    await expect(CachedVideo.create({
+      service: "fakeservice",
+      service_id: "abc123",
+      title: "Test Title",
+      description: "This is a test description.",
+      thumbnail: "http://example.com/thumbnail.jpg",
+      length: 32,
+    })).resolves.toBeDefined();
+
+    await expect(CachedVideo.count()).resolves.toEqual(1);
+
+    InfoExtract.getVideoInfo("fakeservice", "abc123").then(async video => {
+      expect(video).toBeDefined();
+      expect(video.service).toBeDefined();
+      expect(video.service).toBe("fakeservice");
+      expect(video.service_id).toBeUndefined();
+      expect(video.id).toBeDefined();
+      expect(video.id).toBe("abc123");
+      expect(video.title).toBeDefined();
+      expect(video.title).toBe("Test Title");
+      expect(video.description).toBeDefined();
+      expect(video.description).toBe("This is a test description.");
+      expect(video.thumbnail).toBeDefined();
+      expect(video.thumbnail).toBe("http://example.com/thumbnail.jpg");
+      expect(video.length).toBeDefined();
+      expect(video.length).toBe(32);
+
+      await expect(CachedVideo.count()).resolves.toEqual(1);
+      await expect(CachedVideo.findOne({ where: { service: "fakeservice", service_id: "abc123" }})).resolves.toBeDefined();
+      done();
+    }).catch(err => done.fail(err));
   });
 });

--- a/tests/unit/infoextractor.spec.js
+++ b/tests/unit/infoextractor.spec.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const InfoExtract = require("../../infoextract");
+
+const config_path = path.resolve(process.cwd(), `env/${process.env.NODE_ENV}.env`);
+if (!fs.existsSync(config_path)) {
+  console.error("No config found! Things will break!", config_path);
+}
+require('dotenv').config({ path: config_path });
+
+describe('InfoExtractor Spec', () => {
+  it('should get the correct video metadata (uncached)', done => {
+      InfoExtract.getVideoInfo("youtube", "BTZ5KVRUy1Q").then(video => {
+        expect(video).toBeDefined();
+        expect(video.service).toBeDefined();
+        expect(video.service).toBe("youtube");
+        expect(video.id).toBeDefined();
+        expect(video.id).toBe("BTZ5KVRUy1Q");
+        expect(video.title).toBeDefined();
+        expect(video.title).toBe("tmpIwT4T4");
+        expect(video.description).toBeDefined();
+        expect(video.description).toBe("tmpIwT4T4");
+        expect(video.thumbnail).toBeDefined();
+        expect(video.thumbnail).toBe("https://i.ytimg.com/vi/BTZ5KVRUy1Q/mqdefault.jpg");
+        expect(video.length).toBeDefined();
+        expect(video.length).toBe(10);
+        done();
+      });
+  });
+});

--- a/tests/unit/infoextractor.spec.js
+++ b/tests/unit/infoextractor.spec.js
@@ -24,7 +24,7 @@ describe('InfoExtractor Spec', () => {
         expect(video).toBeDefined();
         expect(video.service).toBeDefined();
         expect(video.service).toBe("youtube");
-        expect(video.service_id).toBeUndefined();
+        expect(video.serviceId).toBeUndefined();
         expect(video.id).toBeDefined();
         expect(video.id).toBe("BTZ5KVRUy1Q");
         expect(video.title).toBeDefined();
@@ -40,13 +40,13 @@ describe('InfoExtractor Spec', () => {
   });
 
   it('should miss cache, get the correct video metadata, and store it in the cache', async done => {
-    await expect(CachedVideo.findOne({ where: { service: "youtube", service_id: "I3O9J02G67I" }})).resolves.toBeNull();
+    await expect(CachedVideo.findOne({ where: { service: "youtube", serviceId: "I3O9J02G67I" }})).resolves.toBeNull();
 
     InfoExtract.getVideoInfo("youtube", "I3O9J02G67I").then(async video => {
       expect(video).toBeDefined();
       expect(video.service).toBeDefined();
       expect(video.service).toBe("youtube");
-      expect(video.service_id).toBeUndefined();
+      expect(video.serviceId).toBeUndefined();
       expect(video.id).toBeDefined();
       expect(video.id).toBe("I3O9J02G67I");
       expect(video.title).toBeDefined();
@@ -59,7 +59,7 @@ describe('InfoExtractor Spec', () => {
       expect(video.length).toBe(10);
 
       await expect(CachedVideo.count()).resolves.toEqual(1);
-      await expect(CachedVideo.findOne({ where: { service: "youtube", service_id: "I3O9J02G67I" }})).resolves.toBeDefined();
+      await expect(CachedVideo.findOne({ where: { service: "youtube", serviceId: "I3O9J02G67I" }})).resolves.toBeDefined();
       done();
     }).catch(err => done.fail(err));
   });
@@ -69,7 +69,7 @@ describe('InfoExtractor Spec', () => {
 
     await expect(CachedVideo.create({
       service: "fakeservice",
-      service_id: "abc123",
+      serviceId: "abc123",
       title: "Test Title",
       description: "This is a test description.",
       thumbnail: "http://example.com/thumbnail.jpg",
@@ -82,7 +82,7 @@ describe('InfoExtractor Spec', () => {
       expect(video).toBeDefined();
       expect(video.service).toBeDefined();
       expect(video.service).toBe("fakeservice");
-      expect(video.service_id).toBeUndefined();
+      expect(video.serviceId).toBeUndefined();
       expect(video.id).toBeDefined();
       expect(video.id).toBe("abc123");
       expect(video.title).toBeDefined();
@@ -95,7 +95,7 @@ describe('InfoExtractor Spec', () => {
       expect(video.length).toBe(32);
 
       await expect(CachedVideo.count()).resolves.toEqual(1);
-      await expect(CachedVideo.findOne({ where: { service: "fakeservice", service_id: "abc123" }})).resolves.toBeDefined();
+      await expect(CachedVideo.findOne({ where: { service: "fakeservice", serviceId: "abc123" }})).resolves.toBeDefined();
       done();
     }).catch(err => done.fail(err));
   });
@@ -103,17 +103,17 @@ describe('InfoExtractor Spec', () => {
   it('should partially hit cache, get the missing video metadata (length), and store it in the cache', async done => {
     InfoExtract.getVideoInfoYoutube = jest.fn().mockReturnValue(new Promise(resolve => resolve({ "I3O9J02G67I": { service: "youtube", id: "I3O9J02G67I", length: 10 } })));
 
-    await expect(CachedVideo.findOne({ where: { service: "youtube", service_id: "I3O9J02G67I" }})).resolves.toBeNull();
+    await expect(CachedVideo.findOne({ where: { service: "youtube", serviceId: "I3O9J02G67I" }})).resolves.toBeNull();
 
     await expect(CachedVideo.create({
       service: "youtube",
-      service_id: "I3O9J02G67I",
+      serviceId: "I3O9J02G67I",
       title: "tmpATT2Cp",
       description: "tmpATT2Cp",
       thumbnail: "https://i.ytimg.com/vi/I3O9J02G67I/mqdefault.jpg",
     })).resolves.toBeDefined();
 
-    await CachedVideo.findOne({ where: { service: "youtube", service_id: "I3O9J02G67I" }}).then(result => {
+    await CachedVideo.findOne({ where: { service: "youtube", serviceId: "I3O9J02G67I" }}).then(result => {
       expect(result).toBeDefined();
       expect(result.length).toBeNull();
     });
@@ -124,7 +124,7 @@ describe('InfoExtractor Spec', () => {
       expect(video).toBeDefined();
       expect(video.service).toBeDefined();
       expect(video.service).toBe("youtube");
-      expect(video.service_id).toBeUndefined();
+      expect(video.serviceId).toBeUndefined();
       expect(video.id).toBeDefined();
       expect(video.id).toBe("I3O9J02G67I");
       expect(video.title).toBeDefined();
@@ -137,7 +137,7 @@ describe('InfoExtractor Spec', () => {
       expect(video.length).toBe(10);
 
       await expect(CachedVideo.count()).resolves.toEqual(1);
-      await expect(CachedVideo.findOne({ where: { service: "youtube", service_id: "I3O9J02G67I" }})).resolves.toBeDefined();
+      await expect(CachedVideo.findOne({ where: { service: "youtube", serviceId: "I3O9J02G67I" }})).resolves.toBeDefined();
       done();
     }).catch(err => done.fail(err));
   });

--- a/tests/unit/storage.spec.js
+++ b/tests/unit/storage.spec.js
@@ -21,4 +21,13 @@ describe('Storage Spec', () => {
     expect(storage.updateVideoInfo(video)).resolves.toBe(true);
     done();
   });
+
+  it('should return the attributes that a video object should have', () => {
+    let attributes = storage.getVideoInfoFields();
+    expect(attributes.length).toBeGreaterThan(0);
+    expect(attributes).not.toContain("id");
+    expect(attributes).not.toContain("serviceId");
+    expect(attributes).not.toContain("createdAt");
+    expect(attributes).not.toContain("updatedAt");
+  });
 });

--- a/tests/unit/storage.spec.js
+++ b/tests/unit/storage.spec.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const storage = require("../../storage");
+
+const config_path = path.resolve(process.cwd(), `env/${process.env.NODE_ENV}.env`);
+if (!fs.existsSync(config_path)) {
+  console.error("No config found! Things will break!", config_path);
+}
+require('dotenv').config({ path: config_path });
+
+describe('Storage Spec', () => {
+  it('should create or update cached video', done => {
+    let video = {
+      service: "youtube",
+      id: "-29I-VbvPLQ",
+      title: "tmp181mfK",
+      description: "tmp181mfK",
+      thumbnail: "https://i.ytimg.com/vi/-29I-VbvPLQ/mqdefault.jpg",
+      length: 10,
+    };
+    expect(storage.updateVideoInfo(video)).resolves.toBe(true);
+    done();
+  });
+});


### PR DESCRIPTION
The purpose of this PR is to minimize usage of the youtube API. Closes #24 

Summary:
- Video metadata cache. When video information is requested by calling `getVideoInfo()`, we first check the database to see if it's cached already. If its not there, we retrieve it.
- Partial information retrieval. If certain information is missing from the cache, we can retrieve the bare minimum information needed to fill the gaps.
- `test` environment database config for unit tests to use.
- Unit tests to test caching behavior.