### PR TITLE
Extract video player into its own component

### DIFF
--- a/src/components/DailymotionPlayer.vue
+++ b/src/components/DailymotionPlayer.vue
@@ -87,7 +87,5 @@ export default {
 <style lang="scss" scoped>
 .dailymotion {
 	color: #696969;
-	border: 1px solid #666;
-	border-radius: 3px;
 }
 </style>

--- a/src/components/OmniPlayer.vue
+++ b/src/components/OmniPlayer.vue
@@ -1,0 +1,115 @@
+<template>
+  <fragment>
+    <YoutubePlayer
+      v-if="source.service == 'youtube'"
+      ref="youtube"
+      v-bind="$attrs"
+      :video-id="source.id"
+      @playing="$emit('playing')"
+      @paused="$emit('paused')"
+      @ready="$emit('ready')"
+      @buffering="$emit('buffering')"
+      @error="$emit('error')"
+    />
+    <VimeoPlayer
+      v-else-if="source.service == 'vimeo'"
+      ref="vimeo"
+      :video-id="source.id"
+      v-bind="$attrs"
+      @playing="$emit('playing')"
+      @paused="$emit('paused')"
+      @ready="$emit('ready')"
+      @buffering="$emit('buffering')"
+      @error="$emit('error')"
+    />
+    <DailymotionPlayer
+      v-else-if="source.service == 'dailymotion'"
+      ref="dailymotion"
+      v-bind="$attrs"
+      :video-id="source.id"
+      @playing="$emit('playing')"
+      @paused="$emit('paused')"
+      @ready="$emit('ready')"
+      @buffering="$emit('buffering')"
+      @error="$emit('error')"
+    />
+    <GoogleDrivePlayer
+      v-else-if="source.service == 'googledrive'"
+      ref="googledrive"
+      v-bind="$attrs"
+      :video-id="source.id"
+      @playing="$emit('playing')"
+      @paused="$emit('paused')"
+      @ready="$emit('ready')"
+      @buffering="$emit('buffering')"
+      @error="$emit('error')"
+    />
+    <DirectPlayer
+      v-else-if="source.service == 'direct'"
+      ref="direct"
+      v-bind="$attrs"
+      :video-id="source.id"
+      @playing="$emit('playing')"
+      @paused="$emit('paused')"
+      @ready="$emit('ready')"
+      @buffering="$emit('buffering')"
+      @error="$emit('error')"
+    />
+    <v-container v-else fluid fill-height v-bind="$attrs">
+      <v-row justify="center" align="center">
+        <v-col cols="auto">
+          <h1>No video is playing.</h1>
+          <span>Click "Add" below to add a video.</span>
+        </v-col>
+      </v-row>
+    </v-container>
+  </fragment>
+</template>
+
+<script>
+const services = [
+  "youtube",
+  "vimeo",
+  "dailymotion",
+  "googledrive",
+  "direct",
+];
+
+export default {
+  name: "omniplayer",
+  props: ["source"],
+  components: {
+    YoutubePlayer: () => import(/* webpackChunkName: "youtube" */"@/components/YoutubePlayer.vue"),
+    VimeoPlayer: () => import(/* webpackChunkName: "vimeo" */"@/components/VimeoPlayer.vue"),
+    DailymotionPlayer: () => import(/* webpackChunkName: "dailymotion" */"@/components/DailymotionPlayer.vue"),
+    GoogleDrivePlayer: () => import(/* webpackChunkName: "googledrive" */"@/components/GoogleDrivePlayer.vue"),
+    DirectPlayer: () => import(/* webpackChunkName: "direct" */"@/components/DirectPlayer.vue"),
+  },
+  computed: {
+    player() {
+      if (services.includes(this.source.service)) {
+        return this.$refs[this.source.service];
+      }
+
+      return null;
+    },
+  },
+  methods: {
+    play() {
+      return this.player?.play();
+    },
+    pause() {
+      return this.player?.pause();
+    },
+    setVolume(volume) {
+      return this.player?.setVolume(volume);
+    },
+    getPosition() {
+      return this.player?.getPosition();
+    },
+    setPosition(position) {
+      return this.player?.setPosition(position);
+    },
+  },
+};
+</script>

--- a/src/components/OmniPlayer.vue
+++ b/src/components/OmniPlayer.vue
@@ -1,10 +1,10 @@
 <template>
-  <fragment>
+  <div>
     <YoutubePlayer
       v-if="source.service == 'youtube'"
       ref="youtube"
-      v-bind="$attrs"
       :video-id="source.id"
+      class="player"
       @playing="$emit('playing')"
       @paused="$emit('paused')"
       @ready="$emit('ready')"
@@ -15,7 +15,7 @@
       v-else-if="source.service == 'vimeo'"
       ref="vimeo"
       :video-id="source.id"
-      v-bind="$attrs"
+      class="player"
       @playing="$emit('playing')"
       @paused="$emit('paused')"
       @ready="$emit('ready')"
@@ -25,8 +25,8 @@
     <DailymotionPlayer
       v-else-if="source.service == 'dailymotion'"
       ref="dailymotion"
-      v-bind="$attrs"
       :video-id="source.id"
+      class="player"
       @playing="$emit('playing')"
       @paused="$emit('paused')"
       @ready="$emit('ready')"
@@ -36,8 +36,8 @@
     <GoogleDrivePlayer
       v-else-if="source.service == 'googledrive'"
       ref="googledrive"
-      v-bind="$attrs"
       :video-id="source.id"
+      class="player"
       @playing="$emit('playing')"
       @paused="$emit('paused')"
       @ready="$emit('ready')"
@@ -47,15 +47,15 @@
     <DirectPlayer
       v-else-if="source.service == 'direct'"
       ref="direct"
-      v-bind="$attrs"
       :video-id="source.id"
+      class="player"
       @playing="$emit('playing')"
       @paused="$emit('paused')"
       @ready="$emit('ready')"
       @buffering="$emit('buffering')"
       @error="$emit('error')"
     />
-    <v-container v-else fluid fill-height v-bind="$attrs">
+    <v-container v-else fluid fill-height>
       <v-row justify="center" align="center">
         <v-col cols="auto">
           <h1>No video is playing.</h1>
@@ -63,7 +63,7 @@
         </v-col>
       </v-row>
     </v-container>
-  </fragment>
+  </div>
 </template>
 
 <script>
@@ -113,3 +113,10 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.player {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/src/components/VimeoPlayer.vue
+++ b/src/components/VimeoPlayer.vue
@@ -76,7 +76,5 @@ export default {
 <style lang="scss" scoped>
 .vimeo {
 	color: #696969;
-	border: 1px solid #666;
-	border-radius: 3px;
 }
 </style>

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -757,8 +757,6 @@ export default {
     left: 0;
     width: 100%;
     height: 100%;
-    border: 1px solid #666666;
-    border-radius: 3px;
   }
 
   .no-video {

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -757,6 +757,8 @@ export default {
     left: 0;
     width: 100%;
     height: 100%;
+    border: 1px solid #666666;
+    border-radius: 3px;
   }
 
   .no-video {


### PR DESCRIPTION
This pull request creates a new component that I named "OmniPlayer" (let me know if you can come up with a better name) that abstracts away the different video services that OTT supports.

The Room component currently deals with differentiating between video services, which leads to a bunch of duplicated code.

**Example:**
Before
```js
     play() { 
       if (this.currentSource.service == "youtube") { 
         this.$refs.youtube.play(); 
       } 
       else if (this.currentSource.service === "vimeo") { 
         this.$refs.vimeo.play(); 
       } 
       else if (this.currentSource.service === "dailymotion") { 
         this.$refs.dailymotion.play(); 
       } 
       else if (this.currentSource.service === "googledrive") { 
         this.$refs.googledrive.play(); 
       } 
       else if (this.currentSource.service === "direct") { 
         this.$refs.direct.play(); 
       } 
     },
```

After
```js
    play() {
      this.$refs.player.play();
    },
```