### PR TITLE
Hide scrollbar when in fullscreen

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -187,5 +187,8 @@ export default {
 .scrollbarBeGone {
   -ms-overflow-style: none; // I think this is an old way to do this? Probably not ideal
   scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -180,10 +180,6 @@ export default {
   opacity: 0.7;
 }
 
-.scrollbarBeGone::-webkit-scrollbar {
-  display: none;
-}
-
 .scrollbarBeGone {
   -ms-overflow-style: none; // I think this is an old way to do this? Probably not ideal
   scrollbar-width: none;

--- a/src/App.vue
+++ b/src/App.vue
@@ -128,9 +128,11 @@ export default {
     document.addEventListener('fullscreenchange', () => {
       if (document.fullscreenElement) {
         this.$store.state.fullscreen = true;
+        document.fullscreenElement.classList = "scrollbarBeGone";
       }
       else {
         this.$store.state.fullscreen = false;
+        document.querySelector("html").classList.remove("scrollbarBeGone");
       }
     });
 
@@ -176,5 +178,14 @@ export default {
 
 .text-muted {
   opacity: 0.7;
+}
+
+.scrollbarBeGone::-webkit-scrollbar {
+  display: none;
+}
+
+.scrollbarBeGone {
+  -ms-overflow-style: none; // I think this is an old way to do this? Probably not ideal
+  scrollbar-width: none;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -128,7 +128,7 @@ export default {
     document.addEventListener('fullscreenchange', () => {
       if (document.fullscreenElement) {
         this.$store.state.fullscreen = true;
-        document.fullscreenElement.classList = "scrollbarBeGone";
+        document.querySelector("html").classList.add("scrollbarBeGone");
       }
       else {
         this.$store.state.fullscreen = false;


### PR DESCRIPTION
I was able to remove the scrollbar when the fullscreen event is triggered, but can't seem to add it back after the user exits fullscreen. I tried removing the class, but that didn't work, so then I tried to override the class with another, and that didn't work either. Its very possible that I wasn't doing these things correctly, so I'll take any advice, input, and suggestions anyone can give me! Thanks!

closes #273 