### PR TITLE
disabled duplicates in the queue

### DIFF
--- a/api.js
+++ b/api.js
@@ -43,6 +43,19 @@ function handleGetRoomFailure(res, err) {
 	}
 }
 
+function handlePostVideoFailure(res, err) {
+	/*
+	not sure what to do with this function, I know that I'm supposed to call this function in 
+	the router.post("/room/:name/queue" ..... route but I don't know where to do it
+	*/
+	if (err.name === "VideoAlreadyQueuedException") {
+		res.status(400).json({
+			success: false,
+			error: "Video already in queue",
+		});
+	}
+}
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function(_roommanager, storage) {
 	const roommanager = _roommanager;

--- a/api.js
+++ b/api.js
@@ -44,10 +44,6 @@ function handleGetRoomFailure(res, err) {
 }
 
 function handlePostVideoFailure(res, err) {
-	/*
-	not sure what to do with this function, I know that I'm supposed to call this function in 
-	the router.post("/room/:name/queue" ..... route but I don't know where to do it
-	*/
 	if (err.name === "VideoAlreadyQueuedException") {
 		res.status(400).json({
 			success: false,
@@ -313,14 +309,14 @@ module.exports = function(_roommanager, storage) {
 					res.json({
 						success,
 					});
-				});
+				}).catch(err => handlePostVideoFailure(res, err));
 			}
 			else if (req.body.service && req.body.id) {
 				room.addToQueue({ service: req.body.service, id: req.body.id }, req.session).then(success => {
 					res.json({
 						success,
 					});
-				});
+				}).catch(err => handlePostVideoFailure(res, err));
 			}
 			else {
 				res.status(400).json({

--- a/api.js
+++ b/api.js
@@ -47,7 +47,14 @@ function handlePostVideoFailure(res, err) {
 	if (err.name === "VideoAlreadyQueuedException") {
 		res.status(400).json({
 			success: false,
-			error: "Video already in queue",
+			error: err.message,
+		});
+	}
+	else {
+		log.error("Unhandled exception when getting video:", err);
+		res.status(500).json({
+			success: false,
+			error: "Failed to get video",
 		});
 	}
 }

--- a/roommanager.js
+++ b/roommanager.js
@@ -219,16 +219,15 @@ class Room {
 		}
 
 		if (SUPPORTED_SERVICES.includes(queueItem.service)) {
+			if (_.find(this.queue, queueItem)) {
+				throw new VideoAlreadyQueuedException(queueItem.title);
+			} 
 			return InfoExtract.getVideoInfo(queueItem.service, queueItem.id).then(result => {
 				queueItem = result;
 			}).catch(err => {
 				this.log.error(`Failed to get video info: ${err}`);
 				queueItem.title = queueItem.id;
 			}).then(() => {
-				if (this.queue.id.includes(queueItem.id) && this.queue.service.includes(queueItem.service)) {
-					throw new VideoAlreadyQueuedException(queueItem.title);
-					// is this the right place to do this?
-				} 
 				this.queue.push(queueItem);
 				this._dirtyProps.push("queue");
 				this.update();

--- a/roommanager.js
+++ b/roommanager.js
@@ -747,8 +747,8 @@ class RoomNameTakenException extends Error {
 }
 
 class VideoAlreadyQueuedException extends Error {
-	constructor(video) {
-		super(`The video "${video}" is already in the queue`);
+	constructor(title) {
+		super(`The video "${title}" is already in the queue`);
 		this.name = "VideoAlreadyQueuedException";
 	}
 }

--- a/roommanager.js
+++ b/roommanager.js
@@ -225,6 +225,10 @@ class Room {
 				this.log.error(`Failed to get video info: ${err}`);
 				queueItem.title = queueItem.id;
 			}).then(() => {
+				if (this.queue.id.includes(queueItem.id) && this.queue.service.includes(queueItem.service)) {
+					throw new VideoAlreadyQueuedException(queueItem.title);
+					// is this the right place to do this?
+				} 
 				this.queue.push(queueItem);
 				this._dirtyProps.push("queue");
 				this.update();
@@ -740,6 +744,13 @@ class RoomNameTakenException extends Error {
 	constructor(roomName) {
 		super(`The room "${roomName}" is taken.`);
 		this.name = "RoomNameTakenException";
+	}
+}
+
+class VideoAlreadyQueuedException extends Error {
+	constructor(video) {
+		super(`The video "${video}" is already in the queue`);
+		this.name = "VideoAlreadyQueuedException";
 	}
 }
 

--- a/src/components/VideoQueueItem.vue
+++ b/src/components/VideoQueueItem.vue
@@ -22,7 +22,7 @@
 					<v-icon style="font-size: 18px; margin: 0 4px">fas fa-thumbs-up</v-icon>
 					<span class="vote-text">{{ item.voted ? "Unvote" : "Vote" }}</span>
 				</v-btn>
-				<v-btn icon :loading="isLoadingAdd" :disabled="existsInQueue" v-if="isPreview" @click="addToQueue">
+				<v-btn icon :loading="isLoadingAdd" :disabled="hasBeenAdded" v-if="isPreview" @click="addToQueue">
 					<v-icon v-if="hasBeenAdded">fas fa-check</v-icon>
 					<v-icon v-else>fas fa-plus</v-icon>
 				</v-btn>
@@ -50,20 +50,16 @@ export default {
 			isLoadingVote: false,
 			hasBeenAdded: false,
 			thumbnailHasError: false,
-			existsInQueue: false,
 		};
 	},
 	created() {
-		if (this.item.id === this.$store.state.room.currentSource.id) {
-			this.isLoadingAdd = false;
+		if (this.item.id === this.$store.state.room.currentSource.id && this.item.service === this.$store.state.room.currentSource.service) {
 			this.hasBeenAdded = true;
-			this.existsInQueue = true;
 		}
-		for (let i = 0; i < this.$store.state.room.queue.length; i++) {
-			if (this.item.id === this.$store.state.room.queue[i].id) {
-				this.isLoadingAdd = false;
+		for (let video of this.$store.state.room.queue) {
+			if (this.item.id === video.id && this.item.service === video.service) {
 				this.hasBeenAdded = true;
-				this.existsInQueue = true;
+				break;
 			}
 		}
 	},
@@ -95,7 +91,6 @@ export default {
 			API.post(`/room/${this.$route.params.roomId}/queue`, this.getPostData()).then(() => {
 				this.isLoadingAdd = false;
 				this.hasBeenAdded = true;
-				this.existsInQueue = true;
 			});
 		},
 		removeFromQueue() {

--- a/src/components/VideoQueueItem.vue
+++ b/src/components/VideoQueueItem.vue
@@ -55,11 +55,12 @@ export default {
 	created() {
 		if (this.item.id === this.$store.state.room.currentSource.id && this.item.service === this.$store.state.room.currentSource.service) {
 			this.hasBeenAdded = true;
+			return;
 		}
 		for (let video of this.$store.state.room.queue) {
 			if (this.item.id === video.id && this.item.service === video.service) {
 				this.hasBeenAdded = true;
-				break;
+				return;
 			}
 		}
 	},

--- a/src/components/VideoQueueItem.vue
+++ b/src/components/VideoQueueItem.vue
@@ -52,9 +52,9 @@ export default {
 			thumbnailHasError: false,
 			existsInQueue: false,
 		};
-	}, 
-	created() { 
-        if (this.item.id === this.$store.state.room.currentSource.id) {
+	},
+	created() {
+		if (this.item.id === this.$store.state.room.currentSource.id) {
 			this.isLoadingAdd = false;
 			this.hasBeenAdded = true;
 			this.existsInQueue = true;
@@ -66,7 +66,7 @@ export default {
 				this.existsInQueue = true;
 			}
 		}
-	}, 
+	},
 	computed:{
 		videoLength() {
 			return secondsToTimestamp(this.item.length);
@@ -89,9 +89,9 @@ export default {
 			}
 			console.log(data);
 			return data;
-		}, 
+		},
 		addToQueue() {
-			this.isLoadingAdd = true; 
+			this.isLoadingAdd = true;
 			API.post(`/room/${this.$route.params.roomId}/queue`, this.getPostData()).then(() => {
 				this.isLoadingAdd = false;
 				this.hasBeenAdded = true;

--- a/src/components/VideoQueueItem.vue
+++ b/src/components/VideoQueueItem.vue
@@ -22,7 +22,7 @@
 					<v-icon style="font-size: 18px; margin: 0 4px">fas fa-thumbs-up</v-icon>
 					<span class="vote-text">{{ item.voted ? "Unvote" : "Vote" }}</span>
 				</v-btn>
-				<v-btn icon :loading="isLoadingAdd" v-if="isPreview" @click="addToQueue">
+				<v-btn icon :loading="isLoadingAdd" :disabled="existsInQueue" v-if="isPreview" @click="addToQueue">
 					<v-icon v-if="hasBeenAdded">fas fa-check</v-icon>
 					<v-icon v-else>fas fa-plus</v-icon>
 				</v-btn>
@@ -50,8 +50,23 @@ export default {
 			isLoadingVote: false,
 			hasBeenAdded: false,
 			thumbnailHasError: false,
+			existsInQueue: false,
 		};
-	},
+	}, 
+	created() { 
+        if (this.item.id === this.$store.state.room.currentSource.id) {
+			this.isLoadingAdd = false;
+			this.hasBeenAdded = true;
+			this.existsInQueue = true;
+		}
+		for (let i = 0; i < this.$store.state.room.queue.length; i++) {
+			if (this.item.id === this.$store.state.room.queue[i].id) {
+				this.isLoadingAdd = false;
+				this.hasBeenAdded = true;
+				this.existsInQueue = true;
+			}
+		}
+	}, 
 	computed:{
 		videoLength() {
 			return secondsToTimestamp(this.item.length);
@@ -74,12 +89,13 @@ export default {
 			}
 			console.log(data);
 			return data;
-		},
+		}, 
 		addToQueue() {
-			this.isLoadingAdd = true;
+			this.isLoadingAdd = true; 
 			API.post(`/room/${this.$route.params.roomId}/queue`, this.getPostData()).then(() => {
 				this.isLoadingAdd = false;
 				this.hasBeenAdded = true;
+				this.existsInQueue = true;
 			});
 		},
 		removeFromQueue() {


### PR DESCRIPTION
Disabled the ability to add duplicate videos to the queue. I did this by comparing the video ids in the created hook, and then disabled the button if the video was a duplicate so the addToQueue function couldn't be triggered. Closes #20﻿
