### PR TITLE
Made the brand color a scss variable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -151,6 +151,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import "variables.scss";
+
 .link-invis {
   text-decoration: none;
   color: inherit !important;
@@ -161,7 +163,7 @@ export default {
 }
 
 .vue-slider-process {
-  background: #ffb300 !important;
+  background: $brand-color !important;
 }
 
 .announcement-container {

--- a/src/components/ProcessedText.vue
+++ b/src/components/ProcessedText.vue
@@ -70,8 +70,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import "../variables.scss";
+
 .link {
-	color: #ffb300;
+	color: $brand-color;
 	text-decoration: underline;
 }
 </style>

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -8,3 +8,4 @@ $lg-max: 1920px;
 $xl-min: $lg-max;
 
 $background-color: #121212;
+$brand-color: #ffb300;

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -807,8 +807,8 @@ export default {
   background: transparent !important;
 }
 .is-you {
-  color: #ffb300;
-  border: 1px #ffb300 solid;
+  color: $brand-color;
+  border: 1px $brand-color solid;
   border-radius: 10px;
   margin: 5px;
   padding: 0 5px;


### PR DESCRIPTION
I added #ffb300 to the `variables.scss` page as the $brand-color variable. Any page previously using #ffb300 is now using the variable name in its place except for the `logo.svg`, the `placeholder.svg`, and the `vuetify.js` page (wasn't sure if you could do this in the javascript here, but please let me know if this is possible and I will update). ﻿Closes #311 
