### PR TITLE
Handle private playlists in /watch URLs with list parameter

### DIFF
--- a/server/services/youtube.js
+++ b/server/services/youtube.js
@@ -14,6 +14,8 @@ const storage = require("../../storage");
 
 const log = getLogger("youtube");
 
+const knownPrivateLists = ["LL", "WL"];
+
 class YouTubeAdapter extends ServiceAdapter {
   constructor(apiKey, redisClient) {
     super();
@@ -83,7 +85,7 @@ class YouTubeAdapter extends ServiceAdapter {
       return this.fetchPlaylistVideos(query.list);
     }
     else {
-      if (query.list) {
+      if (query.list && !knownPrivateLists.includes(query.list)) {
         try {
           return await this.fetchVideoWithPlaylist(this.getVideoId(link), query.list);
         }

--- a/server/services/youtube.js
+++ b/server/services/youtube.js
@@ -59,7 +59,7 @@ class YouTubeAdapter extends ServiceAdapter {
       url.pathname.startsWith("/c/") ||
       url.pathname.startsWith("/user/") ||
       url.pathname.startsWith("/playlist") ||
-      !!query.list;
+      (!!query.list && !knownPrivateLists.includes(query.list));
   }
 
   getVideoId(str) {

--- a/server/services/youtube.js
+++ b/server/services/youtube.js
@@ -84,7 +84,13 @@ class YouTubeAdapter extends ServiceAdapter {
     }
     else {
       if (query.list) {
-        return this.fetchVideoWithPlaylist(this.getVideoId(link), query.list);
+        try {
+          return await this.fetchVideoWithPlaylist(this.getVideoId(link), query.list);
+        }
+        catch {
+          log.debug("Falling back to fetching video without playlist");
+          return this.fetchVideoInfo(this.getVideoId(link), onlyProperties);
+        }
       }
       else {
         return this.fetchVideoInfo(this.getVideoId(link), onlyProperties);


### PR DESCRIPTION
When merged, this pull request adds checks for private playlists to the YouTube service adapter.

When the user searches for a video via a URL that links to a specific video but has a `list` parameter, the adapter will first try to return all videos in that playlist. When any error occurs during that, it will fall back to fetching only that one video's information.

When the `list` parameter in the URL is "WL" or "LL", the adapter will ignore them to save time and API quota.

~~The PR also includes a tiny fix for a potential bug where `resolveURL` didn't always return an array. This usually doesn't come into effect because `resolveURL` only gets called when we're dealing with collections, but this might change in the future.~~ (Reverted)

Fixes #330