### PR TITLE
Convert infoextractor to typescript

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,13 +26,12 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Jest All",
-			"program": "${workspaceFolder}/node_modules/.bin/vue-cli-service",
+			"name": "Jest Server Unit Tests",
+			"program": "${workspaceFolder}/node_modules/.bin/jest",
 			"args": [
-				"test:unit",
 				"--runInBand",
 				"--config",
-				"jest.config.js",
+				"./tests/unit/server/jest.config.js",
 			],
 			"console": "integratedTerminal",
 			"internalConsoleOptions": "neverOpen",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint-ci": "vue-cli-service --no-fix lint .",
     "test": "npm run test-unit-server && npm run test-unit-client",
     "test-unit-client": "vue-cli-service test:unit --config ./tests/unit/client/jest.config.js -experimental-vm-modules --runInBand --detectOpenHandles --forceExit",
-    "test-unit-server": "jest --config ./tests/unit/server/jest.config.js -experimental-vm-modules --runInBand --detectOpenHandles --forceExit",
+    "test-unit-server": "jest --config ./tests/unit/server/jest.config.js -experimental-vm-modules --runInBand --detectOpenHandles --forceExit --coverage",
     "test-e2e": "start-server-and-test optic-dev http-get://localhost:8080 cy:run",
     "cy:run": "cypress run --config-file cypress.json --headless",
     "cy:open": "cypress open --config-file cypress.json",

--- a/server/infoextractor.ts
+++ b/server/infoextractor.ts
@@ -10,7 +10,7 @@ import NeverthinkAdapter from "./services/neverthink";
 import storage from "../storage";
 import { UnsupportedMimeTypeException, OutOfQuotaException, UnsupportedServiceException, InvalidAddPreviewInputException, FeatureDisabledException } from "./exceptions";
 import { getLogger } from "../logger";
-import { redisClient } from "../redisclient";
+import { redisClient, redisClientAsync } from "../redisclient";
 import { isSupportedMimeType } from "./mime";
 import { Video, VideoId, VideoMetadata } from "../common/models/video";
 import { ServiceAdapter } from "./serviceadapter";
@@ -93,12 +93,8 @@ export default {
     });
   },
 
-  cacheSearchResults(service: string, query: string, results: Video[]): void {
-    redisClient.set(`search:${service}:${query}`, JSON.stringify(results), "EX", 60 * 60 * 24, (err) => {
-      if (err) {
-        log.error(`Failed to cache search results: ${err}`);
-      }
-    });
+  async cacheSearchResults(service: string, query: string, results: Video[]): Promise<void> {
+    await redisClientAsync.set(`search:${service}:${query}`, JSON.stringify(results), "EX", 60 * 60 * 24);
   },
 
   /**

--- a/server/infoextractor.ts
+++ b/server/infoextractor.ts
@@ -76,21 +76,9 @@ export default {
     }
   },
 
-  getCachedSearchResults(service: string, query: string): Promise<Video[]> {
-    return new Promise((resolve, reject) => {
-      redisClient.get(`search:${service}:${query}`, (err, value) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        if (!value) {
-          resolve(null);
-          return;
-        }
-
-        resolve(JSON.parse(value));
-      });
-    });
+  async getCachedSearchResults(service: string, query: string): Promise<Video[]> {
+    const value = await redisClientAsync.get(`search:${service}:${query}`);
+    return JSON.parse(value);
   },
 
   async cacheSearchResults(service: string, query: string, results: Video[]): Promise<void> {

--- a/tests/unit/server/jest.config.js
+++ b/tests/unit/server/jest.config.js
@@ -22,7 +22,7 @@ module.exports = {
     'jest-watch-typeahead/filename',
     'jest-watch-typeahead/testname',
   ],
-  collectCoverage: true,
+  // collectCoverage: true,
   coverageReporters: [
     "text-summary",
     "text",

--- a/tests/unit/server/services/youtube.spec.ts
+++ b/tests/unit/server/services/youtube.spec.ts
@@ -2,14 +2,6 @@ import YouTubeAdapter from "../../../../server/services/youtube";
 import { Video } from "../../../../common/models/video";
 import { InvalidVideoIdException, OutOfQuotaException } from "../../../../server/exceptions";
 import { redisClient } from "../../../../redisclient";
-import { Callback } from "redis";
-
-jest
-	.spyOn(redisClient, "get")
-	.mockImplementation((key: string, callback?: Callback<string>) => {
-		callback(null, null); return true;
-	});
-jest.spyOn(redisClient, "set").mockImplementation();
 
 const validVideoLinks = [
 	["3kw2_89ym31W", "https://youtube.com/watch?v=3kw2_89ym31W"],

--- a/tests/unit/server/storage.spec.ts
+++ b/tests/unit/server/storage.spec.ts
@@ -393,7 +393,7 @@ describe('Storage: CachedVideos: bulk inserts/updates', () => {
         title: "test video 5",
       },
     ];
-    expect(await storage.updateManyVideoInfo(videos)).toBe(true);
+    await storage.updateManyVideoInfo(videos);
 
     expect(await storage.getVideoInfo("fakeservice", "abc123")).toEqual(videos[0]);
     expect(await storage.getVideoInfo("fakeservice", "abc456")).toEqual(videos[1]);


### PR DESCRIPTION
- infoextractor initial convertion to typescript
- make it easier to debug tests a little bit
- remove most of the old redis mocks
- remove unnecessary assert?
- replace redis get with promise based version

closes #432
