### PR TITLE
Improve compliance with strict null checks

### DIFF
--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -3,38 +3,13 @@ export interface VideoId {
 	id: string
 }
 
-// export type Video = VideoDefault | VideoGoogleDrive | VideoDirect
-
-export interface VideoDefault extends VideoId {
-	title: string | null
-	description: string | null
-	length: number | null
-	thumbnail: string | null
+export interface VideoMetadata {
+	title: string
+	description: string
+	length: number
+	thumbnail: string
+	mime: string
+	highlight?: true
 }
 
-export interface VideoGoogleDrive extends VideoId {
-	service: "googledrive"
-	title: string | null
-	length: number | null
-	thumbnail: string | null
-	mime: string | null
-}
-
-export interface VideoDirect extends VideoId {
-	service: "direct"
-	title: string | null
-	description: string | null
-	length: number | null
-	mime: string | null
-}
-
-export interface Video extends VideoId {
-	title?: string | null
-	description?: string | null
-	length?: number | null
-	thumbnail?: string | null
-	mime?: string | null
-	highlight?: boolean
-}
-
-export type VideoMetadata = Omit<Video, keyof VideoId | "highlight">
+export type Video = VideoId & Partial<VideoMetadata>

--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -246,7 +246,7 @@ export class Grants {
 	}
 
 	getMask(role: Role): GrantMask {
-		return this.masks.get(role);
+		return this.masks.get(role)!;
 	}
 
 	/**
@@ -263,14 +263,18 @@ export class Grants {
 		}
 		else if (grants instanceof Map) {
 			for (const role of grants.keys()) {
-				this.setRoleGrants(role, grants.get(role));
+				let mask = grants.get(role);
+				if (!mask) {
+					continue;
+				}
+				this.setRoleGrants(role, mask);
 			}
 		}
 		else {
 			for (const r in grants) {
 				const role = _normalizeRoleId(r);
 				if (Object.hasOwnProperty.call(grants, role)) {
-					this.setRoleGrants(role, grants[role]);
+					this.setRoleGrants(role, grants[role]!);
 				}
 			}
 		}

--- a/redisclient.ts
+++ b/redisclient.ts
@@ -8,7 +8,7 @@ const redisOptions: redis.ClientOpts = (process.env.REDIS_TLS_URL || process.env
 			rejectUnauthorized: false,
 		},
 } : {
-	port: parseInt(process.env.REDIS_PORT, 10) || undefined,
+	port: parseInt(process.env.REDIS_PORT ?? "", 10) || undefined,
 	host: process.env.REDIS_HOST || undefined,
 	password: process.env.REDIS_PASSWORD || undefined,
 	db: process.env.REDIS_DB || undefined,

--- a/server/services/dailymotion.ts
+++ b/server/services/dailymotion.ts
@@ -2,7 +2,7 @@ import { URL } from "url";
 import axios from "axios";
 import { ServiceAdapter } from "../serviceadapter";
 import { InvalidVideoIdException } from "../exceptions";
-import { Video, VideoDefault } from "../../common/models/video";
+import { Video } from "../../common/models/video";
 
 export default class DailyMotionAdapter extends ServiceAdapter {
   api = axios.create({
@@ -43,7 +43,7 @@ export default class DailyMotionAdapter extends ServiceAdapter {
       },
     });
 
-    const video: VideoDefault = {
+    const video: Video = {
       service: this.serviceId,
       id: videoId,
       title: result.data.title,

--- a/server/services/direct.ts
+++ b/server/services/direct.ts
@@ -5,7 +5,7 @@ import { LocalFileException, UnsupportedMimeTypeException, MissingMetadataExcept
 import { getMimeType, isSupportedMimeType } from "../mime";
 import ffprobe from "../../ffprobe";
 import { getLogger } from "../../logger";
-import { VideoDirect } from "../../common/models/video";
+import { Video } from "../../common/models/video";
 
 const log = getLogger("direct");
 
@@ -29,16 +29,16 @@ export default class DirectVideoAdapter extends ServiceAdapter {
   canHandleURL(link: string): boolean {
     const url = URL.parse(link);
     return /\/*\.(mp4(|v)|mpg4|webm|flv|mkv|avi|wmv|qt|mov|ogv|m4v|h26[1-4])$/.test(
-      url.path.split("?")[0]
+      (url.path ?? "/").split("?")[0]
     );
   }
 
-  async fetchVideoInfo(link: string): Promise<VideoDirect> {
+  async fetchVideoInfo(link: string): Promise<Video> {
     const url = URL.parse(link);
     if (url.protocol === "file:") {
       throw new LocalFileException();
     }
-    const fileName = url.pathname.split("/").slice(-1)[0].trim();
+    const fileName = (url.pathname ?? "").split("/").slice(-1)[0].trim();
     const extension = fileName.split(".").slice(-1)[0];
     const mime = getMimeType(extension);
     if (!isSupportedMimeType(mime)) {
@@ -50,7 +50,7 @@ export default class DirectVideoAdapter extends ServiceAdapter {
       log.error("Video duration could not be determined");
       throw new MissingMetadataException();
     }
-    const video: VideoDirect = {
+    const video: Video = {
       service: this.serviceId,
       id: link,
       title: fileName,

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -17,7 +17,7 @@ export const module: Module<unknown, unknown> = {
 					text = `${message.user.name} paused the video`;
 				}
 			}
-			else if (message.request.type === RoomRequestType.SkipRequest) {
+			else if (message.request.type === RoomRequestType.SkipRequest && message.additional.video) {
 				text = `${message.user.name} skipped ${message.additional.video.title}`;
 				duration = 7000;
 			}
@@ -28,20 +28,28 @@ export const module: Module<unknown, unknown> = {
 			else if (message.request.type === RoomRequestType.JoinRequest) {
 				text = `${message.user.name} joined the room`;
 			}
-			else if (message.request.type === RoomRequestType.LeaveRequest) {
+			else if (message.request.type === RoomRequestType.LeaveRequest && message.additional.user) {
 				text = `${message.additional.user.name} left the room`;
 			}
 			else if (message.request.type === RoomRequestType.AddRequest) {
 				if (message.request.videos) {
 					text = `${message.user.name} added ${message.request.videos.length} videos`;
 				}
-				else {
+				else if (message.additional.video) {
 					text = `${message.user.name} added ${message.additional.video.title}`;
+				}
+				else {
+					text = `${message.user.name} added a video`;
 				}
 				duration = 7000;
 			}
 			else if (message.request.type === RoomRequestType.RemoveRequest) {
-				text = `${message.user.name} removed ${message.additional.video.title}`;
+				if (message.additional.video) {
+					text = `${message.user.name} removed ${message.additional.video.title}`;
+				}
+				else {
+					text = `${message.user.name} removed a video`;
+				}
 				duration = 7000;
 			}
 			else {

--- a/tests/unit/server/room.spec.ts
+++ b/tests/unit/server/room.spec.ts
@@ -117,8 +117,7 @@ describe("Room", () => {
 				room.playbackPosition = 10;
 				await room.processUnauthorizedRequest({
 					type: RoomRequestType.SeekRequest,
-					// @ts-expect-error because we want to test undefined, but the type system should not allow it normally
-					value: v,
+					value: v as unknown as number,
 				}, { token: user.token });
 				expect(room.playbackPosition).toEqual(10);
 			});

--- a/tests/unit/server/room.spec.ts
+++ b/tests/unit/server/room.spec.ts
@@ -117,6 +117,7 @@ describe("Room", () => {
 				room.playbackPosition = 10;
 				await room.processUnauthorizedRequest({
 					type: RoomRequestType.SeekRequest,
+					// @ts-expect-error because we want to test undefined, but the type system should not allow it normally
 					value: v,
 				}, { token: user.token });
 				expect(room.playbackPosition).toEqual(10);

--- a/tests/unit/server/services/youtube.spec.ts
+++ b/tests/unit/server/services/youtube.spec.ts
@@ -403,7 +403,7 @@ describe("Youtube", () => {
 	describe("videoApiRequest", () => {
 		const adapter = new YouTubeAdapter("", redisClient);
 		const apiGet = jest.spyOn(adapter.api, "get");
-		const outOfQuotaResponse = { isAxiosError: true, response: { status: 403, data: { error: { code: 403, message: "", errors: [], status: "" } } } } as AxiosError<YoutubeErrorResponse>;
+		const outOfQuotaResponse = { isAxiosError: true, response: { status: 403, data: { error: { code: 403, message: "", errors: [], status: "" } } } } as unknown as AxiosError<YoutubeErrorResponse>;
 
 		beforeEach(() => {
 			apiGet.mockReset();

--- a/tests/unit/server/storage.spec.ts
+++ b/tests/unit/server/storage.spec.ts
@@ -3,6 +3,7 @@ const { CachedVideo, Room } = require("../../../models");
 import storage from "../../../storage";
 import permissions from "../../../common/permissions";
 import { Visibility, QueueMode } from "../../../common/models/types";
+import { Video } from "../../../common/models/video";
 
 describe.skip('Storage: Room Spec', () => {
   beforeEach(async () => {
@@ -285,12 +286,11 @@ describe('Storage: CachedVideos Spec', () => {
       },
     ];
     await CachedVideo.bulkCreate(_.cloneDeep(videos).map(video => {
-      // FIXME: remove ts-ignore
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      video.serviceId = video.id;
-      delete video.id;
-      return video;
+      const videoStorable: Omit<Video, "id"> & { serviceId: string } = {
+        serviceId: video.id,
+        ..._.omit(video, "id"),
+      };
+      return videoStorable;
     }));
     expect(await storage.getManyVideoInfo(videos)).toEqual(videos);
   });
@@ -322,12 +322,11 @@ describe('Storage: CachedVideos Spec', () => {
       },
     ];
     await CachedVideo.bulkCreate(_.cloneDeep(videos).splice(0, 3).map(video => {
-      // FIXME: remove ts-ignore
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      video.serviceId = video.id;
-      delete video.id;
-      return video;
+      const videoStorable: Omit<Video, "id"> & { serviceId: string } = {
+        serviceId: video.id,
+        ..._.omit(video, "id"),
+      };
+      return videoStorable;
     }));
     expect(await storage.getManyVideoInfo(videos)).toEqual(videos);
   });


### PR DESCRIPTION
- [null-checks] make infoextractor comply with strict null checks
- improve type declarations for videos
- [null-checks] make tests comply with strict null checks
- [null-checks] make permissions comply with strict null checks
- [null-checks] make redis client comply with strict null checks
- [null-checks] make client side event store comply with strict null checks
- [null-checks] make the dailymotion, direct, googledrive service adapters comply with strict null checks
- [null-checks] revert a ts-expect-error
