### PR TITLE
remove deprecated client messages in favor of ClientMessageRoomRequest

### DIFF
--- a/common/models/messages.ts
+++ b/common/models/messages.ts
@@ -62,44 +62,10 @@ export interface UserInfo extends Omit<RoomUserInfo, "status"> {
 	grants: number
 }
 
-export type ClientMessage = ClientMessagePlay | ClientMessagePause | ClientMessageSkip | ClientMessageSeek | ClientMessageOrder | ClientMessageChat | ClientMessageKickMe | ClientMessagePlayerStatus | ClientMessagePromote | ClientMessageAuthenticate | ClientMessagePlayNow | ClientMessageRoomRequest;
+export type ClientMessage = ClientMessageKickMe | ClientMessagePlayerStatus | ClientMessageAuthenticate | ClientMessageRoomRequest;
 
 interface ClientMessageBase {
 	action: string
-}
-
-/** @deprecated We can use `ClientMessageRoomRequest` instead. */
-export interface ClientMessagePlay extends ClientMessageBase {
-	action: "play"
-}
-
-/** @deprecated We can use `ClientMessageRoomRequest` instead. */
-export interface ClientMessagePause extends ClientMessageBase {
-	action: "pause"
-}
-
-/** @deprecated We can use `ClientMessageRoomRequest` instead. */
-export interface ClientMessageSkip extends ClientMessageBase {
-	action: "skip"
-}
-
-/** @deprecated We can use `ClientMessageRoomRequest` instead. */
-export interface ClientMessageSeek extends ClientMessageBase {
-	action: "seek"
-	position: number
-}
-
-/** @deprecated We can use `ClientMessageRoomRequest` instead. */
-export interface ClientMessageOrder extends ClientMessageBase {
-	action: "queue-move"
-	currentIdx: number
-	targetIdx: number
-}
-
-/** @deprecated We can use `ClientMessageRoomRequest` instead. */
-export interface ClientMessageChat extends ClientMessageBase {
-	action: "chat"
-	text: string
 }
 
 export interface ClientMessageKickMe extends ClientMessageBase {
@@ -114,22 +80,9 @@ export interface ClientMessagePlayerStatus extends ClientMessageBase {
 	status: PlayerStatus
 }
 
-/** @deprecated We can use `ClientMessageRoomRequest` instead. */
-export interface ClientMessagePromote extends ClientMessageBase {
-	action: "set-role"
-	clientId: ClientId
-	role: Role
-}
-
 export interface ClientMessageAuthenticate extends ClientMessageBase {
 	action: "auth"
 	token: AuthToken
-}
-
-/** @deprecated We can use `ClientMessageRoomRequest` instead. */
-export interface ClientMessagePlayNow extends ClientMessageBase {
-	action: "play-now",
-	video: VideoId,
 }
 
 export interface ClientMessageRoomRequest extends ClientMessageBase {

--- a/server/clientmanager.ts
+++ b/server/clientmanager.ts
@@ -82,45 +82,9 @@ export class Client {
 		log.silly(`client message: ${text}`);
 		const msg: ClientMessage = JSON.parse(text);
 		let request: RoomRequest | null = null;
-		if (msg.action === "play") {
-			request = {
-				type: RoomRequestType.PlaybackRequest,
-				state: true,
-			};
-		}
-		else if (msg.action === "pause") {
-			request = {
-				type: RoomRequestType.PlaybackRequest,
-				state: false,
-			};
-		}
-		else if (msg.action === "skip") {
-			request = {
-				type: RoomRequestType.SkipRequest,
-			};
-		}
-		else if (msg.action === "seek") {
-			request = {
-				type: RoomRequestType.SeekRequest,
-				value: msg.position,
-			};
-		}
-		else if (msg.action === "queue-move") {
-			request = {
-				type: RoomRequestType.OrderRequest,
-				fromIdx: msg.currentIdx,
-				toIdx: msg.targetIdx,
-			};
-		}
-		else if (msg.action === "kickme") {
+		if (msg.action === "kickme") {
 			this.socket.close(OttWebsocketError.UNKNOWN);
 			return;
-		}
-		else if (msg.action === "chat") {
-			request = {
-				type: RoomRequestType.ChatRequest,
-				...msg,
-			};
 		}
 		else if (msg.action === "status") {
 			request = {
@@ -129,13 +93,6 @@ export class Client {
 					id: this.id,
 					status: msg.status,
 				},
-			};
-		}
-		else if (msg.action === "set-role") {
-			request = {
-				type: RoomRequestType.PromoteRequest,
-				targetClientId: msg.clientId,
-				role: msg.role,
 			};
 		}
 		else if (msg.action === "auth") {
@@ -161,12 +118,6 @@ export class Client {
 				}
 			}
 			return;
-		}
-		else if (msg.action === "play-now") {
-			request = {
-				type: RoomRequestType.PlayNowRequest,
-				video: msg.video,
-			};
 		}
 		else if (msg.action === "req") {
 			request = msg.request;

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -40,13 +40,19 @@
 <script lang="ts">
 import Vue from "vue";
 import ProcessedText from "@/components/ProcessedText.vue";
-import connection from "@/util/connection";
+import api from "@/util/api";
 import Component from 'vue-class-component';
 
 @Component({
   name: "Chat",
   components: {
     ProcessedText,
+  },
+  data() {
+    return {
+      inputValue: "",
+      api,
+    };
   },
 })
 export default class Chat extends Vue {
@@ -62,7 +68,7 @@ export default class Chat extends Vue {
 
   onInputKeyDown(e) {
     if (e.key === "Enter" && this.inputValue.trim() !== "") {
-      connection.send({ action: "chat", text: this.inputValue });
+      api.chat(this.inputValue);
       this.inputValue = "";
       this.stickToBottom = true;
     }

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -8,19 +8,42 @@ import { RoomRequestType } from 'common/models/messages';
 export default {
 	/** Send a message to play the video. */
 	play() {
-		connection.send({ action: "play" });
+		connection.send({
+			action: "req",
+			request: {
+				type: RoomRequestType.PlaybackRequest,
+				state: true,
+			},
+		});
 	},
 	/** Send a message to pause the video. */
 	pause() {
-		connection.send({ action: "pause" });
+		connection.send({
+			action: "req",
+			request: {
+				type: RoomRequestType.PlaybackRequest,
+				state: false,
+			},
+		});
 	},
 
 	/** Send a message to skip the current video. */
 	skip() {
-		connection.send({ action: "skip" });
+		connection.send({
+			action: "req",
+			request: {
+				type: RoomRequestType.SkipRequest,
+			},
+		});
 	},
 	seek(position) {
-		connection.send({ action: "seek", position });
+		connection.send({
+			action: "req",
+			request: {
+				type: RoomRequestType.SeekRequest,
+				value: position,
+			},
+		});
 	},
 	/**
 	 * Move the video from `fromIdx` to `toIdx` in the queue.
@@ -29,9 +52,12 @@ export default {
 	 * */
 	queueMove(fromIdx, toIdx) {
 		connection.send({
-			action: "queue-move",
-			currentIdx: fromIdx,
-			targetIdx: toIdx,
+			action: "req",
+			request: {
+				type: RoomRequestType.OrderRequest,
+				fromIdx,
+				toIdx,
+			},
 		});
 	},
 	async undoEvent(event) {
@@ -48,9 +74,21 @@ export default {
 	},
 	promoteUser(clientId, role) {
 		connection.send({
-			action: "set-role",
-			clientId,
-			role,
+			action: "req",
+			request: {
+				type: RoomRequestType.PromoteRequest,
+				targetClientId: clientId,
+				role,
+			},
+		});
+	},
+	chat(text) {
+		connection.send({
+			action: "req",
+			request: {
+				type: RoomRequestType.ChatRequest,
+				text,
+			},
 		});
 	},
 	/**
@@ -58,8 +96,11 @@ export default {
 	 */
 	playNow(video) {
 		connection.send({
-			action: "play-now",
-			video,
+			action: "req",
+			request: {
+				type: RoomRequestType.PlayNowRequest,
+				video,
+			},
 		});
 	},
 	shuffle() {


### PR DESCRIPTION
Since room requests no longer contain tokens, we can safely pass them into the room rawdog. The result is massively simplified code for the clientmanager, and message definitions.
