### PR TITLE
Fix misc warnings

### DIFF
--- a/client/src/.eslintrc.js
+++ b/client/src/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     browser: true,
   },
   rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-console': 'off',
 
     '@typescript-eslint/explicit-module-boundary-types': 'off',
   },

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -79,9 +79,9 @@
         </div>
       </template>
     </v-navigation-drawer>
-    <v-content>
+    <v-main>
       <router-view/>
-    </v-content>
+    </v-main>
     <v-container>
       <v-dialog v-model="showCreateRoomForm" persistent max-width="600">
         <CreateRoomForm @roomCreated="showCreateRoomForm = false" @cancel="showCreateRoomForm = false" />

--- a/client/src/components/RoomSettings.vue
+++ b/client/src/components/RoomSettings.vue
@@ -74,7 +74,6 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
 import _ from "lodash";
 import Component, { mixins } from "vue-class-component";
 import PermissionsEditor from "@/components/PermissionsEditor.vue";

--- a/client/src/components/YoutubePlayer.vue
+++ b/client/src/components/YoutubePlayer.vue
@@ -12,7 +12,9 @@ import DebugPlayerWatcher from "./debug/DebugPlayerWatcher.vue";
 import { getSdk } from "@/util/playerHelper.js";
 
 const YOUTUBE_IFRAME_API_URL = "https://www.youtube.com/iframe_api";
+// TODO: convert to ts and use an enum for this.
 // eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const YT_STATUS_UNSTARTED = -1;
 const YT_STATUS_ENDED = 0;
 const YT_STATUS_PLAYING = 1;

--- a/client/src/stores/events.ts
+++ b/client/src/stores/events.ts
@@ -1,3 +1,5 @@
+// Ignoring because this rule is wrong. all the template strings in here use strings.
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { Module } from 'vuex';
 import { ToastStyle } from '@/models/toast';
 import { RoomRequestType, ServerMessageEvent, ServerMessageEventCustom } from 'common/models/messages';

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -620,9 +620,6 @@ export default {
     },
   },
   mounted() {
-    console.log(this.$store.state.joinFailReason);
-    console.log(this.showJoinFailOverlay);
-    console.log(this.joinFailReason);
     this.$events.on("playVideo", () => {
       this.$refs.player.play();
     });

--- a/client/tests/unit/Faq.spec.js
+++ b/client/tests/unit/Faq.spec.js
@@ -8,6 +8,7 @@ import Faq from "@/views/Faq.vue";
 Vue.use(Vuetify);
 
 describe("FAQ view", () => {
+	// eslint-disable-next-line jest/expect-expect
 	it("should render without failing", () => {
 		shallowMount(Faq);
 	});

--- a/client/tests/unit/NotFound.spec.js
+++ b/client/tests/unit/NotFound.spec.js
@@ -8,6 +8,7 @@ import NotFound from "@/views/NotFound.vue";
 Vue.use(Vuetify);
 
 describe("NotFound view", () => {
+	// eslint-disable-next-line jest/expect-expect
 	it("should render without failing", () => {
 		shallowMount(NotFound);
 	});


### PR DESCRIPTION
- client: switch to v-main, as v-content is deprecated
- client: remove unused import
- client: ignore an unused var warning
- client: ignore some more warnings because something about the rule is broken
- client: ignore jest/expect-expect for render tests
- client: turn off no-console lint because sometimes it's useful for debugging
