### PR TITLE
Unhide chat on 16:9 screens in fullscreen mode

### DIFF
--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -829,16 +829,6 @@ export default {
       .chat-container {
         width: calc(100% / 12 * 3);
       }
-
-      @media only screen and (max-aspect-ratio: 16/9) {
-        .video-subcontainer {
-          width: 100%;
-        }
-
-        .chat-container {
-          display: none;
-        }
-      }
     }
   }
 


### PR DESCRIPTION
Temporary solution for #622 (does not close it), because it is possible to close the chat.

