### PR TITLE
Video queue rework, add extra queue item metadata

### DIFF
--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -23,6 +23,9 @@
 				<div v-if="item.service === 'googledrive'" class="experimental">
 					{{ $t("video-queue-item.experimental") }}
 				</div>
+				<span v-if="item.startAt !== undefined" class="video-start-at">
+					{{ $t("video-queue-item.start-at", { timestamp: videoStartAt }) }}
+				</span>
 			</div>
 		</div>
 		<div class="d-flex" style="justify-content: center; flex-direction: column">
@@ -146,7 +149,7 @@ import { API } from "@/common-http.js";
 import { secondsToTimestamp } from "@/util/timestamp";
 import { ToastStyle } from "@/models/toast";
 import Component from "vue-class-component";
-import { Video, VideoId } from "common/models/video";
+import { QueueItem, VideoId } from "common/models/video";
 import { QueueMode } from "common/models/types";
 import api from "@/util/api";
 
@@ -159,7 +162,7 @@ import api from "@/util/api";
 	},
 })
 export default class VideoQueueItem extends Vue {
-	item: Video;
+	item: QueueItem;
 	isPreview: boolean;
 	index: number;
 
@@ -173,6 +176,10 @@ export default class VideoQueueItem extends Vue {
 
 	get videoLength(): string {
 		return secondsToTimestamp(this.item?.length ?? 0);
+	}
+
+	get videoStartAt(): string {
+		return secondsToTimestamp(this.item?.startAt ?? 0);
 	}
 
 	get thumbnailSource(): string {
@@ -431,5 +438,13 @@ export default class VideoQueueItem extends Vue {
 	bottom: 0;
 	right: 0;
 	z-index: 1000;
+}
+
+.video-start-at {
+	font-size: 1rem;
+	@media (max-width: $sm-max) {
+		font-size: 0.8rem;
+	}
+	font-style: italic;
 }
 </style>

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -242,6 +242,7 @@ export default {
 			"video-added": "Video added",
 			"video-removed": "Video removed",
 		},
+		"start-at": "Start at {timestamp}",
 	},
 	"room-settings": {
 		"title": "@:create-room-form.title",

--- a/common/models/types.ts
+++ b/common/models/types.ts
@@ -59,34 +59,6 @@ export interface RoomOptions extends RoomSettings {
 	userRoles: Map<Role, Set<number>>
 }
 
-/**
- * Things that Rooms need to remember, but can safely be forgotten when the room is unloaded.
- * This rule does not necessarily apply to inherited fields.
- */
-export interface RoomState extends RoomOptions, RoomStateComputed {
-	currentSource: Video | null
-	queue: Video[]
-	isPlaying: boolean
-	playbackPosition: number
-	users: RoomUserInfo[]
-	votes: Map<string, Set<ClientId>>
-	videoSegments: Segment[]
-}
-
-export interface RoomStateComputed {
-	hasOwner: boolean
-	voteCounts: Map<string, number>
-}
-
-// Only these should be sent to clients, all others should be considered unsafe
-export type RoomStateSyncable = Omit<RoomState, "owner" | "votes" | "userRoles" | "grants">
-
-// Only these should be stored in redis
-export type RoomStateStorable = Omit<RoomState, "hasOwner" | "votes" | "voteCounts" | "users">
-
-// Only these should be stored in persistent storage
-export type RoomStatePersistable = Omit<RoomState, "currentSource" | "queue" | "isPlaying" | "playbackPosition">
-
 export type RoomUserInfo = {
 	id: ClientId
 	name: string

--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -15,3 +15,10 @@ export interface VideoMetadata {
 }
 
 export type Video = VideoId & Partial<VideoMetadata>
+
+export interface QueueItemExtras {
+	startAt?: number
+	endAt?: number
+}
+
+export type QueueItem = Video & QueueItemExtras;

--- a/common/serialize.ts
+++ b/common/serialize.ts
@@ -17,11 +17,9 @@ export function deserializeSet<T extends unknown[]>(set: T): Set<unknown> {
 export function replacer(key, value) {
 	if (value instanceof Map) {
 		return serializeMap(value);
-	}
-	else if (value instanceof Set) {
+	} else if (value instanceof Set) {
 		return serializeSet(value);
-	}
-	else {
+	} else {
 		return value;
 	}
 }

--- a/server/api.js
+++ b/server/api.js
@@ -134,7 +134,7 @@ router.get("/room/:name", async (req, res) => {
 			users.push(client);
 		}
 		room.clients = users;
-		for (let video of room.queue) {
+		for (let video of room.queue.items) {
 			delete video._lastVotesChanged;
 			if (room.queueMode === QueueMode.Vote) {
 				video.votes = video.votes ? video.votes.length : 0;

--- a/server/clientmanager.ts
+++ b/server/clientmanager.ts
@@ -20,13 +20,13 @@ import {
 	MySession,
 	OttWebsocketError,
 	ClientId,
-	RoomStateSyncable,
 	AuthToken,
 } from "../common/models/types";
 import roommanager from "./roommanager";
 import { ANNOUNCEMENT_CHANNEL, ROOM_REQUEST_CHANNEL_PREFIX } from "../common/constants";
 import { uniqueNamesGenerator } from "unique-names-generator";
 import tokens, { SessionInfo } from "./auth/tokens";
+import { RoomStateSyncable } from "./room";
 
 const log = getLogger("clientmanager");
 const redisSubscriber = createSubscriber();

--- a/server/room.ts
+++ b/server/room.ts
@@ -36,19 +36,16 @@ import {
 	QueueMode,
 	Visibility,
 	RoomOptions,
-	RoomState,
 	RoomUserInfo,
 	Role,
 	ClientId,
 	PlayerStatus,
-	RoomStateSyncable,
 	RoomEventContext,
-	RoomStateStorable,
 	RoomSettings,
 	AuthToken,
 } from "../common/models/types";
 import { User } from "./models/user";
-import { Video, VideoId } from "../common/models/video";
+import { QueueItem, Video, VideoId } from "../common/models/video";
 import dayjs, { Dayjs } from "dayjs";
 import { PickFunctions } from "../common/typeutils";
 import { replacer } from "../common/serialize";
@@ -63,7 +60,7 @@ import statistics, { Counter } from "./statistics";
 import { OttException } from "../common/exceptions";
 import { getSponsorBlock } from "./sponsorblock";
 import { ResponseError as SponsorblockResponseError, Segment } from "sponsorblock-api";
-import { Mutex } from "@divine/synchronization";
+import { VideoQueue } from "./videoqueue";
 
 const publish = promisify(redisClient.publish).bind(redisClient);
 const set = promisify(redisClient.set).bind(redisClient);
@@ -112,6 +109,37 @@ export class RoomUser {
 	}
 }
 
+/**
+ * Things that Rooms need to remember, but can safely be forgotten when the room is unloaded.
+ * This rule does not necessarily apply to inherited fields.
+ */
+export interface RoomState extends RoomOptions, RoomStateComputed {
+	currentSource: Video | null;
+	queue: VideoQueue;
+	isPlaying: boolean;
+	playbackPosition: number;
+	users: RoomUserInfo[];
+	votes: Map<string, Set<ClientId>>;
+	videoSegments: Segment[];
+}
+
+export interface RoomStateComputed {
+	hasOwner: boolean;
+	voteCounts: Map<string, number>;
+}
+
+// Only these should be sent to clients, all others should be considered unsafe
+export type RoomStateSyncable = Omit<RoomState, "owner" | "votes" | "userRoles" | "grants">;
+
+// Only these should be stored in redis
+export type RoomStateStorable = Omit<RoomState, "hasOwner" | "votes" | "voteCounts" | "users">;
+
+/** Only these should be stored in persistent storage */
+export type RoomStatePersistable = Omit<
+	RoomState,
+	"currentSource" | "queue" | "isPlaying" | "playbackPosition"
+>;
+
 export class Room implements RoomState {
 	_name = "";
 	_title = "";
@@ -125,8 +153,7 @@ export class Room implements RoomState {
 	_autoSkipSegments = true;
 
 	_currentSource: Video | null = null;
-	queue: Video[] = [];
-	_queueMutex = new Mutex();
+	queue: VideoQueue;
 	_isPlaying = false;
 	_playbackPosition = 0;
 	realusers: RoomUser[] = [];
@@ -148,6 +175,7 @@ export class Room implements RoomState {
 
 	constructor(options: Partial<RoomOptions>) {
 		this.log = getLogger(`room/${options.name}`);
+		this.queue = new VideoQueue();
 		this.userRoles = new Map([
 			[Role.TrustedUser, new Set()],
 			[Role.Moderator, new Set()],
@@ -174,6 +202,9 @@ export class Room implements RoomState {
 				"autoSkipSegments"
 			)
 		);
+		if (Array.isArray(this.queue)) {
+			this.queue = new VideoQueue(this.queue);
+		}
 		if (options.grants instanceof Grants) {
 			this.grants = options.grants;
 		} else if (options.grants) {
@@ -207,6 +238,8 @@ export class Room implements RoomState {
 			// @ts-ignore
 			this._playbackStart = dayjs(options._playbackStart);
 		}
+
+		this.queue.onDirty(() => this.markDirty("queue"));
 	}
 
 	public get name(): string {
@@ -329,31 +362,35 @@ export class Room implements RoomState {
 		this.throttledSync();
 	}
 
-	dequeueNext(): void {
+	private cleanDirty() {
+		this._dirty.clear();
+		this.queue.clean();
+	}
+
+	async dequeueNext() {
 		this.log.debug(`dequeuing next video. mode: ${this.queueMode}`);
 		if (this.currentSource !== null) {
 			if (this.queueMode === QueueMode.Dj) {
+				this.log.debug(`queue in dj mode, restarting current item`);
 				this.playbackPosition = 0;
 				this._playbackStart = dayjs();
 				return;
 			} else if (this.queueMode === QueueMode.Loop) {
-				this._queueMutex.lock();
-				this.queue.push(this.currentSource);
-				this._queueMutex.unlock();
-				this.markDirty("queue");
+				this.log.debug(`queue in loop mode, requeuing current item`);
+				await this.queue.enqueue(this.currentSource);
 			}
 		}
 		if (this.queue.length > 0) {
-			this._queueMutex.lock();
-			this.currentSource = this.queue.shift() ?? null;
-			this._queueMutex.unlock();
-			this.markDirty("queue");
+			this.log.debug(`queue has items in it, dequeuing`);
+
+			this.currentSource = (await this.queue.dequeue()) ?? null;
 			this.playbackPosition = 0;
 			this._playbackStart = dayjs();
 			if (this.videoSegments.length > 0) {
 				this.videoSegments = [];
 			}
 		} else if (this.currentSource !== null) {
+			this.log.debug(`queue is empty, but currentSource is not, clearing currentSource`);
 			if (this.isPlaying) {
 				this.isPlaying = false;
 			}
@@ -368,6 +405,8 @@ export class Room implements RoomState {
 		if (!this.currentSource && this.videoSegments.length > 0) {
 			this.videoSegments = [];
 		}
+
+		this.log.debug(`Dirty props: ${Array.from(this._dirty)}`);
 	}
 
 	/**
@@ -541,7 +580,7 @@ export class Room implements RoomState {
 			) {
 				await statistics.bumpCounter(Counter.VideosWatched);
 			}
-			this.dequeueNext();
+			await this.dequeueNext();
 		}
 
 		if (this.users.length > 0) {
@@ -550,9 +589,7 @@ export class Room implements RoomState {
 
 		// sort queue according to queue mode
 		if (this.queueMode === QueueMode.Vote) {
-			const _oldOrder = _.clone(this.queue);
-			this.queue = _.orderBy(
-				this.queue,
+			await this.queue.orderBy(
 				[
 					video => {
 						const votes = this.votes.get(video.service + video.id);
@@ -561,12 +598,6 @@ export class Room implements RoomState {
 				],
 				["desc"]
 			);
-			if (
-				this.queue.length > 0 &&
-				!this.queue.every((value, index) => _.isEqual(value, _oldOrder[index]))
-			) {
-				this.markDirty("queue");
-			}
 		}
 
 		if (this.autoSkipSegments) {
@@ -724,7 +755,7 @@ export class Room implements RoomState {
 			});
 		}
 
-		this._dirty.clear();
+		this.cleanDirty();
 	}
 
 	public async syncUser(info: RoomUserInfo): Promise<void> {
@@ -758,14 +789,7 @@ export class Room implements RoomState {
 		) {
 			return true;
 		}
-		const matchIdx = _.findIndex(
-			this.queue,
-			item => item.service === video.service && item.id === video.id
-		);
-		if (matchIdx >= 0) {
-			return true;
-		}
-		return false;
+		return this.queue.contains(video);
 	}
 
 	/**
@@ -983,7 +1007,7 @@ export class Room implements RoomState {
 				this.log.error("video was undefined, which is bad");
 				throw new Error("video was undefined");
 			}
-			this.queue.push(video);
+			this.queue.enqueue(video);
 			this.log.info(`Video added: ${JSON.stringify(request.video)}`);
 			await this.publishRoomEvent(request, context, { video });
 			await statistics.bumpCounter(Counter.VideosQueued);
@@ -1005,9 +1029,7 @@ export class Room implements RoomState {
 				throw new VideoAlreadyQueuedException();
 			}
 
-			this._queueMutex.lock();
-			this.queue.push(...videos);
-			this._queueMutex.unlock();
+			this.queue.enqueue(...videos);
 			this.log.info(`added ${videos.length} videos`);
 			await this.publishRoomEvent(request, context, { videos });
 			await statistics.bumpCounter(Counter.VideosQueued, videos.length);
@@ -1015,36 +1037,23 @@ export class Room implements RoomState {
 			this.log.error("Invalid parameters for AddRequest");
 			return;
 		}
-
-		this.markDirty("queue");
 	}
 
 	public async removeFromQueue(
 		request: RemoveRequest,
 		context: RoomRequestContext
 	): Promise<void> {
-		this._queueMutex.lock();
-		const matchIdx = _.findIndex(
-			this.queue,
-			item => item.service === request.video.service && item.id === request.video.id
-		);
-		if (matchIdx < 0) {
+		if (!this.queue.contains(request.video)) {
 			throw new VideoNotFoundException();
 		}
 		// remove the item from the queue
-		const removed = this.queue.splice(matchIdx, 1)[0];
-		this._queueMutex.unlock();
-		this.markDirty("queue");
+		const [matchIdx, removed] = await this.queue.evict(request.video);
 		this.log.info(`Video removed: ${JSON.stringify(removed)}`);
 		await this.publishRoomEvent(request, context, { video: removed, queueIdx: matchIdx });
 	}
 
 	public async reorderQueue(request: OrderRequest, context: RoomRequestContext): Promise<void> {
-		this._queueMutex.lock();
-		const video = this.queue.splice(request.fromIdx, 1)[0];
-		this.queue.splice(request.toIdx, 0, video);
-		this._queueMutex.unlock();
-		this.markDirty("queue");
+		await this.queue.move(request.fromIdx, request.toIdx);
 	}
 
 	public async joinRoom(request: JoinRequest, context: RoomRequestContext): Promise<void> {
@@ -1124,10 +1133,7 @@ export class Room implements RoomState {
 				break;
 			case RoomRequestType.SkipRequest:
 				if (this.currentSource) {
-					this._queueMutex.lock();
-					this.queue.unshift(this.currentSource); // put current video back onto the top of the queue
-					this._queueMutex.unlock();
-					this.markDirty("queue");
+					this.queue.pushTop(this.currentSource);
 				}
 				if (request.event.additional.video && request.event.additional.prevPosition) {
 					this.currentSource = request.event.additional.video;
@@ -1146,14 +1152,15 @@ export class Room implements RoomState {
 				}
 				break;
 			case RoomRequestType.RemoveRequest:
-				this._queueMutex.lock();
-				// eslint-disable-next-line no-case-declarations
-				const newQueue = this.queue.splice(0, request.event.additional.queueIdx);
-				newQueue.push(request.event.request.video);
-				newQueue.push(...this.queue);
-				this.queue = newQueue;
-				this._queueMutex.unlock();
-				this.markDirty("queue");
+				if (
+					request.event.additional.video &&
+					request.event.additional.queueIdx !== undefined
+				) {
+					this.queue.insert(
+						request.event.additional.video,
+						request.event.additional.queueIdx
+					);
+				}
 				break;
 			default:
 				this.log.error(`Event ${request.event.request.type} is not undoable, ignoring`);
@@ -1379,16 +1386,13 @@ export class Room implements RoomState {
 
 		let videoToPlay: Video;
 		if (alreadyInQueue) {
-			const queueIdx = _.findIndex(
-				this.queue,
-				item => item.service === request.video.service && item.id === request.video.id
-			);
-			videoToPlay = this.queue.splice(queueIdx, 1)[0];
+			const [_, item] = await this.queue.evict(request.video);
+			videoToPlay = item;
 		} else {
 			videoToPlay = await InfoExtract.getVideoInfo(request.video.service, request.video.id);
 		}
 		if (this.currentSource) {
-			this.queue.unshift(this.currentSource);
+			await this.queue.pushTop(this.currentSource);
 		}
 		this.currentSource = videoToPlay;
 		this.markDirty("queue");
@@ -1402,9 +1406,6 @@ export class Room implements RoomState {
 
 	public async shuffle(request: ShuffleRequest, context: RoomRequestContext): Promise<void> {
 		this.grants.check(context.role, "manage-queue.order");
-		this._queueMutex.lock();
-		this.queue = _.shuffle(this.queue);
-		this._queueMutex.unlock();
-		this.markDirty("queue");
+		await this.queue.shuffle();
 	}
 }

--- a/server/roommanager.ts
+++ b/server/roommanager.ts
@@ -1,5 +1,5 @@
-import { Room } from "./room";
-import { AuthToken, RoomOptions, RoomState, RoomStatePersistable } from "../common/models/types";
+import { Room, RoomState, RoomStatePersistable } from "./room";
+import { AuthToken, RoomOptions } from "../common/models/types";
 import { ROOM_REQUEST_CHANNEL_PREFIX } from "../common/constants";
 import _ from "lodash";
 import { getLogger } from "./logger.js";

--- a/server/tests/unit/room.spec.ts
+++ b/server/tests/unit/room.spec.ts
@@ -7,6 +7,7 @@ import infoextractor from "../../../server/infoextractor";
 import { Video } from "../../../common/models/video";
 import permissions from "../../../common/permissions";
 import _ from "lodash";
+import { VideoQueue } from "server/videoqueue";
 
 describe("Room", () => {
 	beforeAll(() => {
@@ -100,12 +101,12 @@ describe("Room", () => {
 			});
 
 			it("skip with non-empty queue", async () => {
-				room.queue = [
+				room.queue = new VideoQueue([
 					{
 						service: "test",
 						id: "video2",
 					},
-				];
+				]);
 				await room.processUnauthorizedRequest(
 					{
 						type: RoomRequestType.SkipRequest,
@@ -173,7 +174,7 @@ describe("Room", () => {
 					service: "test",
 					id: "asdf123",
 				};
-				room.queue = [videoToPlay];
+				room.queue = new VideoQueue([videoToPlay]);
 				await room.processUnauthorizedRequest(
 					{
 						type: RoomRequestType.PlayNowRequest,
@@ -181,7 +182,7 @@ describe("Room", () => {
 					},
 					{ token: user.token }
 				);
-				for (const video of room.queue) {
+				for (const video of room.queue.items) {
 					expect(video).not.toEqual(videoToPlay);
 				}
 				expect(room.currentSource).toEqual(videoToPlay);
@@ -193,7 +194,7 @@ describe("Room", () => {
 					service: "test",
 					id: "asdf123",
 				};
-				room.queue = [videoToPlay];
+				room.queue = new VideoQueue([videoToPlay]);
 				await room.processUnauthorizedRequest(
 					{
 						type: RoomRequestType.PlayNowRequest,
@@ -205,7 +206,7 @@ describe("Room", () => {
 					service: "test",
 					id: "asdf123",
 				});
-				for (const video of room.queue) {
+				for (const video of room.queue.items) {
 					expect(video).not.toEqual(videoToPlay);
 				}
 				expect(room.currentSource).toEqual(videoToPlay);
@@ -218,7 +219,7 @@ describe("Room", () => {
 					id: "asdf123",
 				};
 				room.playbackPosition = 10;
-				room.queue = [videoToPlay];
+				room.queue = new VideoQueue([videoToPlay]);
 				await room.processUnauthorizedRequest(
 					{
 						type: RoomRequestType.PlayNowRequest,
@@ -249,13 +250,13 @@ describe("Room", () => {
 			let shuffleSpy;
 
 			beforeEach(() => {
-				room.queue = [
+				room.queue = new VideoQueue([
 					{ service: "fakeservice", id: "video1" },
 					{ service: "fakeservice", id: "video2" },
 					{ service: "fakeservice", id: "video3" },
 					{ service: "fakeservice", id: "video4" },
 					{ service: "fakeservice", id: "video5" },
-				];
+				]);
 				shuffleSpy = jest.spyOn(_, "shuffle");
 			});
 
@@ -285,12 +286,12 @@ describe("Room", () => {
 				service: "test",
 				id: "video",
 			};
-			room.queue = [
+			room.queue = new VideoQueue([
 				{
 					service: "test",
 					id: "video2",
 				},
-			];
+			]);
 		});
 
 		it.each([QueueMode.Manual, QueueMode.Vote])(
@@ -340,7 +341,7 @@ describe("Room", () => {
 			"should requeue the current item when mode is %s, with empty queue",
 			mode => {
 				room.queueMode = mode;
-				room.queue = [];
+				room.queue = new VideoQueue();
 				expect(room.queue).toHaveLength(0);
 				room.dequeueNext();
 				expect(room.currentSource).toEqual({

--- a/server/tests/unit/roommanager.spec.ts
+++ b/server/tests/unit/roommanager.spec.ts
@@ -9,6 +9,7 @@ import { RoomNotFoundException } from "../../exceptions";
 import storage from "../../storage";
 import { ROOM_REQUEST_CHANNEL_PREFIX } from "../../../common/constants";
 import { RoomRequest, RoomRequestType } from "../../../common/models/messages";
+import { VideoQueue } from "server/videoqueue";
 
 describe("Room manager", () => {
 	beforeEach(async () => {
@@ -56,11 +57,11 @@ describe("Room manager", () => {
 			room.userRoles.get(Role.Administrator)?.add(9);
 			room.grants.setRoleGrants(Role.UnregisteredUser, 1234);
 			room.currentSource = { service: "fake", id: "video" };
-			room.queue = [
+			room.queue = new VideoQueue([
 				{ service: "fake", id: "video2" },
 				{ service: "fake", id: "video3" },
 				{ service: "fake", id: "video4" },
-			];
+			]);
 			room.isPlaying = true;
 			room._playbackStart = dayjs().subtract(10, "second");
 			room.playbackPosition = 10;

--- a/server/tests/unit/roommanager.spec.ts
+++ b/server/tests/unit/roommanager.spec.ts
@@ -9,7 +9,7 @@ import { RoomNotFoundException } from "../../exceptions";
 import storage from "../../storage";
 import { ROOM_REQUEST_CHANNEL_PREFIX } from "../../../common/constants";
 import { RoomRequest, RoomRequestType } from "../../../common/models/messages";
-import { VideoQueue } from "server/videoqueue";
+import { VideoQueue } from "../../../server/videoqueue";
 
 describe("Room manager", () => {
 	beforeEach(async () => {
@@ -69,6 +69,8 @@ describe("Room manager", () => {
 			const text = room.serializeState();
 			const options = JSON.parse(text);
 			const loadedRoom = new Room(options);
+			// HACK: room constructor sets the on dirty callback, so we manually remove it here
+			loadedRoom.queue.onDirty(undefined);
 
 			expect(loadedRoom.name).toEqual(room.name);
 			expect(loadedRoom.owner).toEqual(room.owner);

--- a/server/util/dirtyable.ts
+++ b/server/util/dirtyable.ts
@@ -23,7 +23,7 @@ export class Dirtyable {
 	 * Call the given function when the object is marked as dirty. Only one callback can be active at a time.
 	 * @param cb The function to call when the object is marked as dirty.
 	 */
-	onDirty(cb: () => void) {
+	onDirty(cb: (() => void) | undefined) {
 		this.callback = cb;
 	}
 }

--- a/server/util/dirtyable.ts
+++ b/server/util/dirtyable.ts
@@ -1,0 +1,29 @@
+export class Dirtyable {
+	private _dirty = false;
+	private callback: (() => void) | undefined = undefined;
+
+	constructor() {}
+
+	get dirty() {
+		return this._dirty;
+	}
+
+	markDirty() {
+		this._dirty = true;
+		if (this.callback) {
+			this.callback();
+		}
+	}
+
+	clean() {
+		this._dirty = false;
+	}
+
+	/**
+	 * Call the given function when the object is marked as dirty. Only one callback can be active at a time.
+	 * @param cb The function to call when the object is marked as dirty.
+	 */
+	onDirty(cb: () => void) {
+		this.callback = cb;
+	}
+}

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -1,0 +1,1 @@
+export * from "./dirtyable";

--- a/server/videoqueue.ts
+++ b/server/videoqueue.ts
@@ -1,0 +1,139 @@
+import { Mutex } from "@divine/synchronization";
+
+import { Dirtyable } from "./util";
+import { QueueItem, Video, VideoId } from "common/models/video";
+import _ from "lodash";
+import { VideoNotFoundException } from "./exceptions";
+
+/** A concurrently safe orderable queue for videos. */
+export class VideoQueue extends Dirtyable {
+	private _items: QueueItem[] = [];
+	private lock: Mutex;
+
+	constructor(items?: (Video | QueueItem)[]) {
+		super();
+		this.lock = new Mutex();
+
+		if (items) {
+			this._items = items;
+		}
+	}
+
+	get items() {
+		return this._items;
+	}
+
+	get length() {
+		return this._items.length;
+	}
+
+	/** Override all items in the queue */
+	async set(items: (Video | QueueItem)[]) {
+		await this.lock.protect(() => {
+			this._items = items;
+			this.markDirty();
+		});
+	}
+
+	/** Add the given videos to the bottom of the queue. */
+	async enqueue(...video: (Video | QueueItem)[]) {
+		await this.lock.protect(() => {
+			this._items.push(...video);
+			this.markDirty();
+		});
+	}
+
+	/** Dequeue the next video in the queue. */
+	async dequeue(): Promise<QueueItem | undefined> {
+		return this.lock.protect(() => {
+			let item = this._items.shift();
+			this.markDirty();
+			return item;
+		});
+	}
+
+	/** Push the given videos on to the top of the queue. */
+	async pushTop(...video: (Video | QueueItem)[]) {
+		await this.lock.protect(() => {
+			this._items.unshift(...video);
+			this.markDirty();
+		});
+	}
+
+	/** Insert the given video at the given index. */
+	async insert(video: Video | QueueItem, index: number) {
+		await this.lock.protect(() => {
+			const newItems = this._items.splice(0, index);
+			newItems.push(video);
+			newItems.push(...this._items);
+			this._items = newItems;
+			this.markDirty();
+		});
+	}
+
+	/**
+	 * Move the item at index `fromIdx` to index `toIdx`.
+	 */
+	async move(fromIdx: number, toIdx: number) {
+		return this.lock.protect(() => {
+			const item = this._items.splice(fromIdx, 1)[0];
+			this._items.splice(toIdx, 0, item);
+			this.markDirty();
+		});
+	}
+
+	findIndex(video: VideoId) {
+		const matchIdx = _.findIndex(
+			this._items,
+			item => item.service === video.service && item.id === video.id
+		);
+		return matchIdx;
+	}
+
+	contains(video: VideoId) {
+		const matchIdx = this.findIndex(video);
+		return matchIdx >= 0;
+	}
+
+	/** Remove the video from the queue. */
+	async evict(video: VideoId): Promise<[number, QueueItem]> {
+		return this.lock.protect(() => {
+			const matchIdx = this.findIndex(video);
+			if (matchIdx >= 0) {
+				const removed = this._items.splice(matchIdx, 1)[0];
+				this.markDirty();
+				return [matchIdx, removed];
+			} else {
+				throw new VideoNotFoundException();
+			}
+		});
+	}
+
+	/** Reorder the queue based on the given criteria. Takes the same arguments as lodash `_.orderBy()`. */
+	async orderBy(
+		iteratees: _.Many<_.ListIterator<QueueItem, _.NotVoid>>,
+		orders: string | boolean | readonly (boolean | "asc" | "desc")[] | string[]
+	) {
+		await this.lock.protect(() => {
+			const _oldOrder = _.clone(this._items);
+			// @ts-expect-error I'm too lazy to fix the type annotation for iteratees, but it's ok because we dont touch it, and just pass it through.
+			this._items = _.orderBy(this._items, iteratees, orders);
+			if (
+				this._items.length > 0 &&
+				!this._items.every((value, index) => _.isEqual(value, _oldOrder[index]))
+			) {
+				this.markDirty();
+			}
+		});
+	}
+
+	async shuffle() {
+		await this.lock.protect(() => {
+			this._items = _.shuffle(this._items);
+		});
+	}
+
+	toJSON() {
+		return this.items;
+	}
+}


### PR DESCRIPTION
- refactor(server/room): completely refactor how the video queue works
- feat(server/room): respect starts at and ends at metadata, and populate starts at when playback is interrupted with play now
