### PR TITLE
Convert `VideoQueue`, `VideoQueueItem` to composition api

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,8 +4,8 @@
 
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
-		"octref.vetur",
-		"dbaeumer.vscode-eslint",
+		"Vue.volar",
+		"Vue.vscode-typescript-vue-plugin",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
 		"@mdi/font": "^3.9.97",
 		"@vimeo/player": "^2.10.0",
 		"@vue/cli": "^4.5.13",
-		"@vue/composition-api": "1.4.6",
+		"@vue/composition-api": "1.7.0",
 		"load-script": "^1.0.0",
 		"material-design-icons-iconfont": "^5.0.1",
 		"video.js": "^7.15.4",

--- a/client/src/components/VideoQueue.vue
+++ b/client/src/components/VideoQueue.vue
@@ -21,7 +21,7 @@
 		</div>
 		<draggable
 			v-model="$store.state.room.queue"
-			:move="() => grants.granted('manage-queue.order')"
+			:move="() => granted('manage-queue.order')"
 			@end="onQueueDragDrop"
 			handle=".drag-handle"
 		>
@@ -38,31 +38,33 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import Component from "vue-class-component";
+import { defineComponent } from "@vue/composition-api";
 import draggable from "vuedraggable";
 import VideoQueueItem from "@/components/VideoQueueItem.vue";
 import api from "@/util/api";
-import { GrantChecker } from "@/util/grants";
+import { granted } from "@/util/grants";
 
-@Component({
+function onQueueDragDrop(e: { oldIndex: number; newIndex: number }) {
+	api.queueMove(e.oldIndex, e.newIndex);
+}
+
+const VideoQueue = defineComponent({
 	name: "VideoQueue",
 	components: {
 		draggable,
 		VideoQueueItem,
 	},
-	data() {
+	setup() {
 		return {
+			onQueueDragDrop,
+
 			api,
-			grants: new GrantChecker(),
+			granted,
 		};
 	},
-})
-export default class VideoQueue extends Vue {
-	onQueueDragDrop(e) {
-		api.queueMove(e.oldIndex, e.newIndex);
-	}
-}
+});
+
+export default VideoQueue;
 </script>
 
 <style lang="scss" scoped>

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -144,181 +144,203 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
+import { defineComponent, ref, toRefs, computed, watchEffect } from "@vue/composition-api";
 import { API } from "@/common-http.js";
 import { secondsToTimestamp } from "@/util/timestamp";
 import { ToastStyle } from "@/models/toast";
-import Component from "vue-class-component";
 import { QueueItem, VideoId } from "common/models/video";
 import { QueueMode } from "common/models/types";
 import api from "@/util/api";
 import { useStore } from "@/util/vuex-workaround";
+import { i18n } from "@/i18n";
+import toast from "@/util/toast";
 
-const store = useStore();
+interface VideoQueueItemProps {
+	item: QueueItem;
+	isPreview: boolean;
+	index: number;
+}
 
-@Component({
+const VideoQueueItem = defineComponent({
 	name: "VideoQueueItem",
 	props: {
 		item: { type: Object, required: true },
 		isPreview: { type: Boolean, default: false },
 		index: { type: Number, required: false },
 	},
-})
-export default class VideoQueueItem extends Vue {
-	item: QueueItem;
-	isPreview: boolean;
-	index: number;
+	setup(props: VideoQueueItemProps) {
+		let { item, isPreview, index } = toRefs(props);
+		const store = useStore();
 
-	isLoadingAdd = false;
-	isLoadingVote = false;
-	hasBeenAdded = false;
-	thumbnailHasError = false;
-	hasError = false;
-	voted = false;
-	QueueMode = QueueMode;
-	store = useStore();
+		let isLoadingAdd = ref(false);
+		let isLoadingVote = ref(false);
+		let hasBeenAdded = ref(false);
+		let thumbnailHasError = ref(false);
+		let hasError = ref(false);
+		let voted = ref(false);
 
-	get videoLength(): string {
-		return secondsToTimestamp(this.item?.length ?? 0);
-	}
+		let videoLength = computed(() => secondsToTimestamp(item.value?.length ?? 0));
+		let videoStartAt = computed(() => secondsToTimestamp(item.value?.startAt ?? 0));
+		let thumbnailSource = computed(() => {
+			return !thumbnailHasError.value && item.value.thumbnail
+				? item.value.thumbnail
+				: require("@/assets/placeholder.svg");
+		});
+		let votes = computed(() => {
+			const store = useStore();
+			return store.state.room.voteCounts?.get(item.value.service + item.value.id) ?? 0;
+		});
 
-	get videoStartAt(): string {
-		return secondsToTimestamp(this.item?.startAt ?? 0);
-	}
-
-	get thumbnailSource(): string {
-		return !this.thumbnailHasError && this.item.thumbnail
-			? this.item.thumbnail
-			: require("@/assets/placeholder.svg");
-	}
-
-	get votes() {
-		return store.state.room.voteCounts?.get(this.item.service + this.item.id) ?? 0;
-	}
-
-	created() {
-		if (
-			store.state.room.currentSource &&
-			this.item.id === store.state.room.currentSource.id &&
-			this.item.service === store.state.room.currentSource.service
-		) {
-			this.hasBeenAdded = true;
-			return;
-		}
-		for (let video of store.state.room.queue) {
-			if (this.item.id === video.id && this.item.service === video.service) {
-				this.hasBeenAdded = true;
+		function updateHasBeenAdded() {
+			if (
+				store.state.room.currentSource &&
+				item.value.id === store.state.room.currentSource.id &&
+				item.value.service === store.state.room.currentSource.service
+			) {
+				hasBeenAdded.value = true;
 				return;
 			}
-		}
-	}
-
-	getPostData(): VideoId {
-		let data = {
-			service: this.item.service,
-			id: this.item.id,
-		};
-		return data;
-	}
-
-	async addToQueue() {
-		this.isLoadingAdd = true;
-		try {
-			let resp = await API.post(
-				`/room/${this.$route.params.roomId}/queue`,
-				this.getPostData()
-			);
-			this.hasError = !resp.data.success;
-			this.hasBeenAdded = true;
-			this.$toast.add({
-				style: ToastStyle.Success,
-				content: this.$t("video-queue-item.messages.video-added") as string,
-				duration: 5000,
-			});
-		} catch (e) {
-			this.hasError = true;
-			this.$toast.add({
-				style: ToastStyle.Error,
-				content: e.response.data.error.message,
-				duration: 6000,
-			});
-		}
-		this.isLoadingAdd = false;
-	}
-
-	async removeFromQueue() {
-		this.isLoadingAdd = true;
-		try {
-			let resp = await API.delete(`/room/${this.$route.params.roomId}/queue`, {
-				data: this.getPostData(),
-			});
-			this.hasError = !resp.data.success;
-			this.$toast.add({
-				style: ToastStyle.Success,
-				content: this.$t("video-queue-item.messages.video-removed") as string,
-				duration: 5000,
-			});
-		} catch (e) {
-			this.hasError = true;
-			this.$toast.add({
-				style: ToastStyle.Error,
-				content: e.response.data.error.message,
-				duration: 6000,
-			});
-		}
-		this.isLoadingAdd = false;
-	}
-
-	async vote() {
-		this.isLoadingVote = true;
-		try {
-			let resp;
-			if (!this.voted) {
-				resp = await API.post(
-					`/room/${this.$route.params.roomId}/vote`,
-					this.getPostData()
-				);
-				this.voted = true;
-			} else {
-				resp = await API.delete(`/room/${this.$route.params.roomId}/vote`, {
-					data: this.getPostData(),
-				});
-				this.voted = false;
+			for (let video of store.state.room.queue) {
+				if (item.value.id === video.id && item.value.service === video.service) {
+					hasBeenAdded.value = true;
+					return;
+				}
 			}
-			this.hasError = !resp.data.success;
-		} catch (e) {
-			this.hasError = true;
-			this.$toast.add({
-				style: ToastStyle.Error,
-				content: e.response.data.error.message,
-				duration: 6000,
-			});
+			hasBeenAdded.value = false;
 		}
-		this.isLoadingVote = false;
-	}
 
-	playNow() {
-		api.playNow(this.item);
-	}
+		function getPostData(): VideoId {
+			let data = {
+				service: item.value.service,
+				id: item.value.id,
+			};
+			return data;
+		}
 
-	/**
-	 * Moves the video to the top of the queue.
-	 */
-	moveToTop() {
-		api.queueMove(this.index, 0);
-	}
+		async function addToQueue() {
+			isLoadingAdd.value = true;
+			try {
+				let resp = await API.post(`/room/${store.state.room.name}/queue`, getPostData());
+				hasError.value = !resp.data.success;
+				hasBeenAdded.value = true;
+				toast.add({
+					style: ToastStyle.Success,
+					content: i18n.t("video-queue-item.messages.video-added").toString(),
+					duration: 5000,
+				});
+			} catch (e) {
+				hasError.value = true;
+				toast.add({
+					style: ToastStyle.Error,
+					content: e.response.data.error.message,
+					duration: 6000,
+				});
+			}
+			isLoadingAdd.value = false;
+		}
 
-	/**
-	 * Moves the video to the bottom of the queue.
-	 */
-	moveToBottom() {
-		api.queueMove(this.index, store.state.room.queue.length - 1);
-	}
+		async function removeFromQueue() {
+			isLoadingAdd.value = true;
+			try {
+				let resp = await API.delete(`/room/${store.state.room.name}/queue`, {
+					data: getPostData(),
+				});
+				hasError.value = !resp.data.success;
+				toast.add({
+					style: ToastStyle.Success,
+					content: i18n.t("video-queue-item.messages.video-removed").toString(),
+					duration: 5000,
+				});
+			} catch (e) {
+				hasError.value = true;
+				toast.add({
+					style: ToastStyle.Error,
+					content: e.response.data.error.message,
+					duration: 6000,
+				});
+			}
+			isLoadingAdd.value = false;
+		}
 
-	onThumbnailError() {
-		this.thumbnailHasError = true;
-	}
-}
+		async function vote() {
+			isLoadingVote.value = true;
+			try {
+				let resp;
+				if (!voted.value) {
+					resp = await API.post(`/room/${store.state.room.name}/vote`, getPostData());
+					voted.value = true;
+				} else {
+					resp = await API.delete(`/room/${store.state.room.name}/vote`, {
+						data: getPostData(),
+					});
+					voted.value = false;
+				}
+				hasError.value = !resp.data.success;
+			} catch (e) {
+				hasError.value = true;
+				toast.add({
+					style: ToastStyle.Error,
+					content: e.response.data.error.message,
+					duration: 6000,
+				});
+			}
+			isLoadingVote.value = false;
+		}
+
+		function playNow() {
+			api.playNow(item);
+		}
+
+		/**
+		 * Moves the video to the top of the queue.
+		 */
+		function moveToTop() {
+			api.queueMove(index.value, 0);
+		}
+
+		/**
+		 * Moves the video to the bottom of the queue.
+		 */
+		function moveToBottom() {
+			api.queueMove(index.value, store.state.room.queue.length - 1);
+		}
+
+		function onThumbnailError() {
+			thumbnailHasError.value = true;
+		}
+
+		watchEffect(() => {
+			updateHasBeenAdded();
+		});
+
+		return {
+			isLoadingAdd,
+			isLoadingVote,
+			hasBeenAdded,
+			thumbnailHasError,
+			hasError,
+			voted,
+
+			videoLength,
+			videoStartAt,
+			thumbnailSource,
+			votes,
+
+			addToQueue,
+			removeFromQueue,
+			vote,
+			playNow,
+			moveToTop,
+			moveToBottom,
+			onThumbnailError,
+
+			QueueMode,
+			store,
+		};
+	},
+});
+
+export default VideoQueueItem;
 </script>
 
 <style lang="scss" scoped>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -4,6 +4,8 @@ import Vue from "vue";
 import App from "./App.vue";
 import router from "./router";
 import store from "./store";
+import { setStoreInstance } from "@/util/vuex-workaround";
+setStoreInstance(store);
 
 import VueGtag from "vue-gtag";
 Vue.use(

--- a/client/src/plugins/toast.ts
+++ b/client/src/plugins/toast.ts
@@ -9,9 +9,11 @@ const plugin: PluginObject<ToastPluginOptions> = {
 	install(vue, options: ToastPluginOptions): void {
 		const store = options.store;
 		vue.prototype.$toast = {
+			/** @deprecated */
 			add(toast: Omit<Toast, "id">): void {
 				store.commit("toast/ADD_TOAST", toast);
 			},
+			/** @deprecated */
 			remove(id: symbol): void {
 				store.commit("toast/REMOVE_TOAST", id);
 			},

--- a/client/src/util/grants.ts
+++ b/client/src/util/grants.ts
@@ -3,10 +3,13 @@ import { ref, Ref } from "@vue/composition-api";
 
 export const currentUserGrantMask: Ref<GrantMask> = ref(parseIntoGrantMask(["*"]));
 
-/** A helper for checking grants. */
+/** Checks if the current user is granted the given permission. */
+export function granted(permission: PermissionName) {
+	let permMask = parseIntoGrantMask([permission]);
+	return (currentUserGrantMask.value & permMask) > 0;
+}
+
+/** @deprecated A helper for checking grants. */
 export class GrantChecker {
-	granted(permission: PermissionName) {
-		let permMask = parseIntoGrantMask([permission]);
-		return (currentUserGrantMask.value & permMask) > 0;
-	}
+	granted = granted;
 }

--- a/client/src/util/toast.ts
+++ b/client/src/util/toast.ts
@@ -1,0 +1,16 @@
+import { Toast } from "@/models/toast";
+import { useStore } from "./vuex-workaround";
+
+export function add(toast: Omit<Toast, "id">): void {
+	const store = useStore();
+	store.commit("toast/ADD_TOAST", toast);
+}
+export function remove(id: symbol): void {
+	const store = useStore();
+	store.commit("toast/REMOVE_TOAST", id);
+}
+
+export default {
+	add,
+	remove,
+};

--- a/client/src/util/vuex-workaround.ts
+++ b/client/src/util/vuex-workaround.ts
@@ -1,0 +1,36 @@
+import type { QueueMode } from "common/models/types";
+import type { QueueItem } from "common/models/video";
+import type { Store } from "vuex";
+
+let _store: Store<BaseStoreState>;
+
+// temp state interface that needs to match what's in @/store.js
+interface BaseStoreState {
+	room: {
+		name: string;
+		title: string;
+		description: string;
+		isTemporary: boolean;
+		queueMode: QueueMode;
+		currentSource: QueueItem | null;
+		queue: QueueItem[];
+		isPlaying: boolean;
+		playbackPosition: number;
+		hasOwner: boolean;
+		chatMessages: unknown[];
+		voteCounts?: Map<string, number>;
+	};
+
+	keepAliveInterval: number | null;
+}
+
+export function setStoreInstance(s: Store<unknown>) {
+	_store = s as Store<BaseStoreState>;
+}
+
+/** This is a workaround to make it possible to convert components that
+ * reference the Vuex store to use the composition api. This should be
+ * easily replacable with `useStore()` in vuex 4. */
+export function useStore(): Store<BaseStoreState> {
+	return _store;
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -15,7 +15,8 @@
 			"common/*": [
 				"../common/*"
 			]
-		}
+		},
+		"jsx": "preserve"
 	},
 	"include": [
 		"src/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4184,10 +4184,10 @@
   optionalDependencies:
     prettier "^1.18.2 || ^2.0.0"
 
-"@vue/composition-api@1.4.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.4.6.tgz#886c35221cd7c6f55272543a121240e8d3a1306c"
-  integrity sha512-UP359OJ0G0Zli603/i9fhXFmNtZUSrypSFyqClMxizp8ezlaMK2GCmHgy3qyrRnO/xjcDAx09vvXPwNFtxHPtQ==
+"@vue/composition-api@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.7.0.tgz#26fae79e5023fc6c9dfd99ca5d3d357e1c5b9c60"
+  integrity sha512-hxOgLYR+wjuPX9bkP2pAPlqUs98XxBoa9DSLyp1z6+YR92wC42PZcZKs4d+VRtcv4udOv041Kss+F6ap5nj8YA==
 
 "@vue/eslint-config-typescript@^7.0.0":
   version "7.0.0"


### PR DESCRIPTION
- deprecate GrantChecker, because its slightly more complicated than it needs to be
- convert VideoQueue to composition api
- update vscode extension recommendations
- update client tsconfig
- add somewhat janky workaround for getting the vuex store to make converting to the composition api easier
- convert VideoQueueItem to use vuex store workaround
- convert toast plugin to a couple of utility functions
- update @vue/composition-api
- convert VideoQueueItem to composition api

related: #651
