### PR TITLE
Fix: Added ffmpeg to Docker distro

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/app
 COPY . .
 
 # Install app dependencies
-RUN apk update -q && apk --no-cache add libc6-compat python make g++ autoconf automake libtool -q
+RUN apk update -q && apk --no-cache add libc6-compat python make g++ autoconf automake libtool ffmpeg -q
 
 # Install app dependencies
 RUN yarn

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     container_name: opentogethertube
     environment:
       - REDIS_HOST=redis_db
+	- FFPROBE_PATH=/usr/bin/ffprobe
       # postgres
       - POSTGRES_DB_USERNAME=opentogethertube
       - POSTGRES_DB_NAME=opentogethertube

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: opentogethertube
     environment:
       - REDIS_HOST=redis_db
-	- FFPROBE_PATH=/usr/bin/ffprobe
+      - FFPROBE_PATH=/usr/bin/ffprobe
       # postgres
       - POSTGRES_DB_USERNAME=opentogethertube
       - POSTGRES_DB_NAME=opentogethertube


### PR DESCRIPTION
Docker builds use Alpine Linux, which does not support DNS resolution with statically-linked ffmpeg, which in turn makes adding .mp4 from URLs impossible. To avoid this issue, ffmpeg/ffprobe is now installed in the image.

This fixes #716.