### PR TITLE
Fixed ffmpeg being added in build stage rather than in production stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/app
 COPY . .
 
 # Install app dependencies
-RUN apk update -q && apk --no-cache add libc6-compat python make g++ autoconf automake libtool ffmpeg -q
+RUN apk update -q && apk --no-cache add libc6-compat python make g++ autoconf automake libtool -q
 
 # Install app dependencies
 RUN yarn
@@ -39,7 +39,7 @@ RUN rm -rf client/public client/src client/.browserslistrc .eslintrc.js .gitigno
 
 RUN mkdir env && touch env/production.env
 
-RUN apk update -q && apk --no-cache add curl -q
+RUN apk update -q && apk --no-cache add curl ffmpeg -q
 
 # Healthcheck API, WEB, REDIS
 HEALTHCHECK --interval=30s --timeout=3s CMD ( curl -f http://localhost:8080/api/status || exit 1 )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,8 @@ ENV REDIS_PORT 6379
 # Environnement variable nodejs
 ENV NODE_ENV production
 ENV PORT 8080
+# Env variable for external ffprobe
+ENV FFPROBE_PATH /usr/bin/ffprobe
 
 # Copy from build stage
 COPY --from=build-stage /usr/app/ /usr/app/


### PR DESCRIPTION
Fixes (again) #716 after my hastily done fix from yesterday (apologies, it was late) failed to fix the issue.
Additionally added default value for FFPROBE_PATH to hopefully fix existing Docker deployments after image update.