### PR TITLE
Stream video downloads for direct videos straight into ffprobe

### DIFF
--- a/server/services/direct.ts
+++ b/server/services/direct.ts
@@ -69,10 +69,11 @@ export default class DirectVideoAdapter extends ServiceAdapter {
 		}
 		const fileInfo = await ffprobe.getFileInfo(link);
 		const duration = Math.ceil(this.getDuration(fileInfo));
+		const title = fileInfo.format?.tags?.title ?? fileName;
 		const video: Video = {
 			service: this.serviceId,
 			id: link,
-			title: fileName,
+			title,
 			description: `Full Link: ${link}`,
 			mime,
 			length: duration,


### PR DESCRIPTION
- add ffprobe fetch mode feature flag, add counter for bytes downloaded
- stream video download directly into ffprobe
- direct: grab title from metadata if available

fixes #740
