### PR TITLE
Video Control Modes

### DIFF
--- a/client/src/components/controls/VideoControls.vue
+++ b/client/src/components/controls/VideoControls.vue
@@ -11,7 +11,7 @@
 		<v-row no-gutters align="center">
 			<BasicControls :current-position="truePosition" />
 			<!-- eslint-disable-next-line vue/no-v-model-argument -->
-			<VolumeControl v-model:volume="volume" />
+			<VolumeControl />
 			<TimestampDisplay :current-position="truePosition" />
 			<div class="flex-grow-1"><!-- Spacer --></div>
 			<ClosedCaptionsSwitcher
@@ -26,8 +26,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, PropType, onMounted, Ref, toRefs } from "vue";
-import _ from "lodash";
+import { defineComponent, PropType, Ref, toRefs } from "vue";
 
 import BasicControls from "./BasicControls.vue";
 import ClosedCaptionsSwitcher from "./ClosedCaptionsSwitcher.vue";
@@ -39,7 +38,6 @@ import VolumeControl from "./VolumeControl.vue";
 import type OmniPlayer from "../players/OmniPlayer.vue";
 import type { MediaPlayer, MediaPlayerWithCaptions } from "../players/OmniPlayer.vue";
 import { useStore } from "@/store";
-import { useRoomKeyboardShortcuts } from "@/util/keyboard-shortcuts";
 
 export default defineComponent({
 	name: "VideoControls",
@@ -80,38 +78,10 @@ export default defineComponent({
 	emits: [],
 	setup(props) {
 		let store = useStore();
-		let volume = ref(100);
 		let { player } = toRefs(props);
 
 		function isPlayerPresent(p: Ref<typeof OmniPlayer>): p is Ref<typeof OmniPlayer> {
 			return !!p.value;
-		}
-
-		onMounted(() => {
-			volume.value = store.state.settings.volume;
-		});
-
-		function updateVolume() {
-			if (!isPlayerPresent(player)) {
-				return;
-			}
-			player.value.setVolume(volume.value);
-		}
-
-		watch(volume, () => {
-			updateVolume();
-			store.commit("settings/UPDATE", { volume: volume.value });
-		});
-
-		const shortcuts = useRoomKeyboardShortcuts();
-		if (shortcuts) {
-			shortcuts.bind([{ code: "ArrowUp" }, { code: "ArrowDown" }], (e: KeyboardEvent) => {
-				volume.value = _.clamp(
-					volume.value + 5 * (e.code === "ArrowDown" ? -1 : 1),
-					0,
-					100
-				);
-			});
 		}
 
 		function isCaptionsSupported(
@@ -132,7 +102,6 @@ export default defineComponent({
 		return {
 			store,
 
-			volume,
 			getCaptionsTracks,
 		};
 	},

--- a/client/src/components/controls/VideoControls.vue
+++ b/client/src/components/controls/VideoControls.vue
@@ -2,7 +2,8 @@
 	<v-col
 		:class="{
 			'video-controls': true,
-			'outside-video': true,
+			'in-video': mode == 'in-video',
+			'outside-video': mode == 'outside-video',
 			'hide': !controlsVisible,
 		}"
 	>
@@ -70,6 +71,10 @@ export default defineComponent({
 		isCaptionsSupported: {
 			type: Boolean,
 			default: false,
+		},
+		mode: {
+			type: String as PropType<"in-video" | "outside-video">,
+			default: "in-video",
 		},
 	},
 	emits: [],

--- a/client/src/components/controls/VideoControls.vue
+++ b/client/src/components/controls/VideoControls.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, PropType, onMounted, Ref } from "vue";
+import { defineComponent, ref, watch, PropType, onMounted, Ref, toRefs } from "vue";
 import _ from "lodash";
 
 import BasicControls from "./BasicControls.vue";
@@ -81,7 +81,7 @@ export default defineComponent({
 	setup(props) {
 		let store = useStore();
 		let volume = ref(100);
-		let player = ref(props.player);
+		let { player } = toRefs(props);
 
 		function isPlayerPresent(p: Ref<typeof OmniPlayer>): p is Ref<typeof OmniPlayer> {
 			return !!p.value;

--- a/client/src/components/controls/VideoControls.vue
+++ b/client/src/components/controls/VideoControls.vue
@@ -145,10 +145,11 @@ $video-controls-height: 80px;
 .video-controls {
 	height: $video-controls-height;
 	transition: all 0.2s;
+	z-index: 100;
 
 	&.in-video {
-		position: absolute;
-		bottom: 0;
+		position: relative;
+		bottom: $video-controls-height;
 
 		background: linear-gradient(to top, rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0));
 		transition: all 0.2s;
@@ -156,7 +157,7 @@ $video-controls-height: 80px;
 		&.hide {
 			opacity: 0;
 			transition: all 0.5s;
-			bottom: -100%;
+			bottom: 0;
 		}
 	}
 

--- a/client/src/components/controls/VideoControls.vue
+++ b/client/src/components/controls/VideoControls.vue
@@ -163,7 +163,7 @@ $video-controls-height: 80px;
 
 	&.outside-video {
 		position: relative;
-		background: rgb(var(--v-theme-surface));
+		background: #000;
 		border-radius: 0 0 10px 10px;
 
 		&.hide {

--- a/client/src/components/controls/VideoControls.vue
+++ b/client/src/components/controls/VideoControls.vue
@@ -1,0 +1,171 @@
+<template>
+	<v-col
+		:class="{
+			'video-controls': true,
+			'outside-video': true,
+			'hide': !controlsVisible,
+		}"
+	>
+		<VideoProgressSlider :current-position="sliderPosition" />
+		<v-row no-gutters align="center">
+			<BasicControls :current-position="truePosition" />
+			<!-- eslint-disable-next-line vue/no-v-model-argument -->
+			<VolumeControl v-model:volume="volume" />
+			<TimestampDisplay :current-position="truePosition" />
+			<div class="flex-grow-1"><!-- Spacer --></div>
+			<ClosedCaptionsSwitcher
+				:supported="isCaptionsSupported"
+				:tracks="store.state.captions.availableTracks"
+				@enable-cc="value => player.setCaptionsEnabled(value)"
+				@cc-track="value => player.setCaptionsTrack(value)"
+			/>
+			<LayoutSwitcher />
+		</v-row>
+	</v-col>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, watch, PropType, onMounted, Ref } from "vue";
+import _ from "lodash";
+
+import BasicControls from "./BasicControls.vue";
+import ClosedCaptionsSwitcher from "./ClosedCaptionsSwitcher.vue";
+import LayoutSwitcher from "./LayoutSwitcher.vue";
+import TimestampDisplay from "./TimestampDisplay.vue";
+import VideoProgressSlider from "./VideoProgressSlider.vue";
+import VolumeControl from "./VolumeControl.vue";
+
+import type OmniPlayer from "../players/OmniPlayer.vue";
+import type { MediaPlayer, MediaPlayerWithCaptions } from "../players/OmniPlayer.vue";
+import { useStore } from "@/store";
+import { useRoomKeyboardShortcuts } from "@/util/keyboard-shortcuts";
+
+export default defineComponent({
+	name: "VideoControls",
+	components: {
+		BasicControls,
+		ClosedCaptionsSwitcher,
+		LayoutSwitcher,
+		TimestampDisplay,
+		VideoProgressSlider,
+		VolumeControl,
+	},
+	props: {
+		sliderPosition: {
+			type: Number,
+			required: true,
+		},
+		truePosition: {
+			type: Number,
+			required: true,
+		},
+		player: {
+			type: Object as PropType<typeof OmniPlayer | null>,
+			required: true,
+		},
+		controlsVisible: {
+			type: Boolean,
+			default: false,
+		},
+		isCaptionsSupported: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	emits: [],
+	setup(props) {
+		let store = useStore();
+		let volume = ref(100);
+		let player = ref(props.player);
+
+		function isPlayerPresent(p: Ref<typeof OmniPlayer>): p is Ref<typeof OmniPlayer> {
+			return !!p.value;
+		}
+
+		onMounted(() => {
+			volume.value = store.state.settings.volume;
+		});
+
+		function updateVolume() {
+			if (!isPlayerPresent(player)) {
+				return;
+			}
+			player.value.setVolume(volume.value);
+		}
+
+		watch(volume, () => {
+			updateVolume();
+			store.commit("settings/UPDATE", { volume: volume.value });
+		});
+
+		const shortcuts = useRoomKeyboardShortcuts();
+		if (shortcuts) {
+			shortcuts.bind([{ code: "ArrowUp" }, { code: "ArrowDown" }], (e: KeyboardEvent) => {
+				volume.value = _.clamp(
+					volume.value + 5 * (e.code === "ArrowDown" ? -1 : 1),
+					0,
+					100
+				);
+			});
+		}
+
+		function isCaptionsSupported(
+			p: Ref<MediaPlayer | MediaPlayerWithCaptions>
+		): p is Ref<MediaPlayerWithCaptions> {
+			return (player.value as MediaPlayerWithCaptions)?.isCaptionsSupported() ?? false;
+		}
+		function getCaptionsTracks(): string[] {
+			if (!isPlayerPresent(player)) {
+				return [];
+			}
+			if (!isCaptionsSupported(player)) {
+				return [];
+			}
+			return player.value.getCaptionsTracks() ?? [];
+		}
+
+		return {
+			store,
+
+			volume,
+			getCaptionsTracks,
+		};
+	},
+});
+</script>
+
+<style lang="scss">
+$video-controls-height: 80px;
+
+.video-controls {
+	height: $video-controls-height;
+	transition: all 0.2s;
+
+	&.in-video {
+		position: absolute;
+		bottom: 0;
+
+		background: linear-gradient(to top, rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0));
+		transition: all 0.2s;
+
+		&.hide {
+			opacity: 0;
+			transition: all 0.5s;
+			bottom: -100%;
+		}
+	}
+
+	&.outside-video {
+		position: relative;
+		background: rgb(var(--v-theme-surface));
+		border-radius: 0 0 10px 10px;
+
+		&.hide {
+			opacity: 0;
+			transform: scaleY(0) translateY(-50%);
+			transition: all 0.5s;
+			height: 0;
+		}
+	}
+}
+</style>

--- a/client/src/components/controls/VolumeControl.vue
+++ b/client/src/components/controls/VolumeControl.vue
@@ -19,28 +19,27 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, inject, ref } from "vue";
 import VueSlider from "vue-slider-component";
 import "vue-slider-component/theme/default.css";
+import { VOLUME_KEY } from "./controlkeys";
 
 export default defineComponent({
 	name: "VolumeControl",
 	components: {
 		VueSlider,
 	},
-	props: {
-		volume: {
-			type: Number,
-			default: 100,
-		},
-	},
 	emits: ["update:volume"],
 	setup(props, { emit }) {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+		const [volume, updateVolume] = inject(VOLUME_KEY, [ref(100), (_: number) => {}]);
+
 		function changed(value: number) {
 			emit("update:volume", value);
+			updateVolume(value);
 		}
 
-		return { changed };
+		return { volume, changed };
 	},
 });
 </script>

--- a/client/src/components/controls/VolumeControl.vue
+++ b/client/src/components/controls/VolumeControl.vue
@@ -1,0 +1,46 @@
+<template>
+	<vue-slider
+		:model-value="volume"
+		@update:model-value="changed"
+		style="width: 150px; margin-left: 10px; margin-right: 20px"
+		:process="
+			dotsPos => [
+				[
+					0,
+					dotsPos[0],
+					{
+						backgroundColor: 'rgb(var(--v-theme-primary))',
+					},
+				],
+			]
+		"
+		:drag-on-click="true"
+	/>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import VueSlider from "vue-slider-component";
+import "vue-slider-component/theme/default.css";
+
+export default defineComponent({
+	name: "VolumeControl",
+	components: {
+		VueSlider,
+	},
+	props: {
+		volume: {
+			type: Number,
+			default: 100,
+		},
+	},
+	emits: ["update:volume"],
+	setup(props, { emit }) {
+		function changed(value: number) {
+			emit("update:volume", value);
+		}
+
+		return { changed };
+	},
+});
+</script>

--- a/client/src/components/controls/controlkeys.ts
+++ b/client/src/components/controls/controlkeys.ts
@@ -1,0 +1,3 @@
+import type { InjectionKey, Ref } from "vue";
+
+export const VOLUME_KEY: InjectionKey<[Ref<number>, (value: number) => {}]> = Symbol("volume");

--- a/client/src/components/players/DailymotionPlayer.vue
+++ b/client/src/components/players/DailymotionPlayer.vue
@@ -79,6 +79,9 @@ const DailymotionPlayer = defineComponent({
 		function setVolume(value: number) {
 			return player.value.setVolume(value / 100);
 		}
+		function isCaptionsSupported(): boolean {
+			return false;
+		}
 
 		expose({
 			play,
@@ -86,6 +89,7 @@ const DailymotionPlayer = defineComponent({
 			getPosition,
 			setPosition,
 			setVolume,
+			isCaptionsSupported,
 		});
 
 		return {
@@ -94,6 +98,7 @@ const DailymotionPlayer = defineComponent({
 			getPosition,
 			setPosition,
 			setVolume,
+			isCaptionsSupported,
 		};
 	},
 });

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -45,6 +45,9 @@ export default {
 		setPosition(position) {
 			return this.player.currentTime(position);
 		},
+		isCaptionsSupported() {
+			return false;
+		},
 		loadVideoSource() {
 			console.log("DirectPlayer: loading video source:", this.videoUrl, this.videoMime);
 			this.player.src({

--- a/client/src/components/players/GenericHlsPlayer.vue
+++ b/client/src/components/players/GenericHlsPlayer.vue
@@ -48,6 +48,9 @@ export default {
 		setPosition(position) {
 			return this.player.currentTime(position);
 		},
+		isCaptionsSupported() {
+			return false;
+		},
 		async loadVideoSource() {
 			console.log("GenericHlsPlayer: loading video source:", this.hlsUrl);
 

--- a/client/src/components/players/GoogleDrivePlayer.vue
+++ b/client/src/components/players/GoogleDrivePlayer.vue
@@ -68,6 +68,9 @@ export default {
 		setPosition(position) {
 			return this.player.currentTime(position);
 		},
+		isCaptionsSupported() {
+			return false;
+		},
 		loadVideoSource() {
 			this.player.src({
 				src: this.videoSource,

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -117,7 +117,7 @@ import { defineComponent, defineAsyncComponent, PropType, ref, Ref, computed, wa
 
 const services = ["youtube", "vimeo", "dailymotion", "googledrive", "direct", "reddit", "tubi"];
 
-interface MediaPlayer {
+export interface MediaPlayer {
 	play(): void | Promise<void>;
 	pause(): void | Promise<void>;
 	setVolume(volume: number): void | Promise<void>;
@@ -125,7 +125,7 @@ interface MediaPlayer {
 	setPosition(position: number): void | Promise<void>;
 }
 
-interface MediaPlayerWithCaptions extends MediaPlayer {
+export interface MediaPlayerWithCaptions extends MediaPlayer {
 	isCaptionsSupported(): boolean;
 	isCaptionsEnabled(): boolean;
 	setCaptionsEnabled(enabled: boolean): void;

--- a/client/src/components/players/VimeoPlayer.vue
+++ b/client/src/components/players/VimeoPlayer.vue
@@ -87,6 +87,9 @@ const VimeoPlayer = defineComponent({
 			}
 			return player.setVolume(value / 100);
 		}
+		function isCaptionsSupported(): boolean {
+			return false;
+		}
 
 		return {
 			isBuffering,
@@ -96,6 +99,7 @@ const VimeoPlayer = defineComponent({
 			getPosition,
 			setPosition,
 			setVolume,
+			isCaptionsSupported,
 		};
 	},
 });

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -67,7 +67,7 @@
 					:key="currentSource?.id"
 					:player="player"
 					:is-captions-supported="isCaptionsSupported()"
-					mode="outside-video"
+					mode="in-video"
 				/>
 				<v-row no-gutters>
 					<v-col cols="12" md="8" sm="12">

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -227,8 +227,6 @@ import {
 import AddPreview from "@/components/AddPreview.vue";
 import { calculateCurrentPosition } from "@/util/timestamp";
 import _ from "lodash";
-import VueSlider from "vue-slider-component";
-import "vue-slider-component/theme/default.css";
 import OmniPlayer from "@/components/players/OmniPlayer.vue";
 import Chat from "@/components/Chat.vue";
 import UserList from "@/components/UserList.vue";
@@ -254,6 +252,7 @@ import { useRouter, useRoute } from "vue-router";
 import { ServerMessageSync } from "ott-common/models/messages";
 import { useScreenOrientation, useMouse } from "@vueuse/core";
 import { KeyboardShortcuts, RoomKeyboardShortcutsKey } from "@/util/keyboard-shortcuts";
+import VolumeControl from "@/components/controls/VolumeControl.vue";
 
 const VIDEO_CONTROLS_HIDE_TIMEOUT = 3000;
 
@@ -261,11 +260,11 @@ export default defineComponent({
 	name: "room",
 	components: {
 		BasicControls,
+		VolumeControl,
 		VideoProgressSlider,
 		TimestampDisplay,
 		LayoutSwitcher,
 		VideoQueue,
-		VueSlider,
 		OmniPlayer,
 		Chat,
 		AddPreview,

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -26,12 +26,7 @@
 				<span id="connectStatus">{{ connectionStatus }}</span>
 			</div>
 			<v-col :style="{ padding: store.state.fullscreen ? 0 : 'inherit' }">
-				<v-row
-					no-gutters
-					:class="{
-						'video-container': true,
-					}"
-				>
+				<v-row no-gutters class="video-container">
 					<div
 						class="video-subcontainer"
 						:style="{ padding: store.state.fullscreen ? 0 : 'inherit' }"

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -641,6 +641,10 @@ $in-video-chat-width-small: 250px;
 		margin-left: 0;
 		margin-right: 0;
 	}
+
+	@media (min-aspect-ratio: 16 / 9) {
+		aspect-ratio: initial;
+	}
 }
 
 .layout-default {

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -67,6 +67,7 @@
 					:key="currentSource?.id"
 					:player="player"
 					:is-captions-supported="isCaptionsSupported()"
+					mode="outside-video"
 				/>
 				<v-row no-gutters>
 					<v-col cols="12" md="8" sm="12">

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -67,7 +67,7 @@
 					:key="currentSource?.id"
 					:player="player"
 					:is-captions-supported="isCaptionsSupported()"
-					mode="in-video"
+					:mode="currentSource?.service === 'youtube' ? 'outside-video' : 'in-video'"
 				/>
 				<v-row no-gutters>
 					<v-col cols="12" md="8" sm="12">

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -26,7 +26,7 @@
 				<span id="connectStatus">{{ connectionStatus }}</span>
 			</div>
 			<v-col :style="{ padding: store.state.fullscreen ? 0 : 'inherit' }">
-				<v-row no-gutters class="video-container">
+				<div no-gutters class="video-container">
 					<div
 						class="video-subcontainer"
 						:style="{ padding: store.state.fullscreen ? 0 : 'inherit' }"
@@ -54,16 +54,16 @@
 							</div>
 						</v-responsive>
 					</div>
-				</v-row>
-				<VideoControls
-					:slider-position="sliderPosition"
-					:true-position="truePosition"
-					:controls-visible="controlsVisible"
-					:key="currentSource?.id"
-					:player="player"
-					:is-captions-supported="isCaptionsSupported()"
-					:mode="currentSource?.service === 'youtube' ? 'outside-video' : 'in-video'"
-				/>
+					<VideoControls
+						:slider-position="sliderPosition"
+						:true-position="truePosition"
+						:controls-visible="controlsVisible"
+						:key="currentSource?.id"
+						:player="player"
+						:is-captions-supported="isCaptionsSupported()"
+						:mode="currentSource?.service === 'youtube' ? 'outside-video' : 'in-video'"
+					/>
+				</div>
 				<v-row no-gutters>
 					<v-col cols="12" md="8" sm="12">
 						<v-tabs fixed-tabs v-model="queueTab" color="primary">
@@ -624,29 +624,35 @@ $in-video-chat-width-small: 250px;
 .video-container {
 	display: flex;
 	align-items: center;
+	justify-content: center;
+	margin: auto;
 	margin-bottom: 10px;
+	flex-direction: column;
+	aspect-ratio: 16 / 9;
 
 	.video-subcontainer {
 		display: flex;
 		flex-grow: 1;
+		aspect-ratio: 16 / 9;
+		width: 100%;
 	}
 
 	@media (max-width: $md-max) {
-		.video-subcontainer {
-			width: 100%;
-		}
-
-		margin: 0;
+		margin-left: 0;
+		margin-right: 0;
 	}
 }
 
 .layout-default {
 	.video-container {
-		max-height: $video-player-max-height;
+		width: 80vw;
+
+		@media (max-width: $md-max) {
+			width: 100%;
+		}
 	}
 
 	.video-subcontainer {
-		width: 80vw;
 		max-height: $video-player-max-height;
 	}
 }
@@ -655,11 +661,10 @@ $in-video-chat-width-small: 250px;
 	padding: 0;
 
 	.video-container {
-		max-height: $video-player-max-height-theater;
+		width: 100%;
 	}
 
 	.video-subcontainer {
-		width: 100%;
 		max-height: $video-player-max-height-theater;
 	}
 

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -724,17 +724,34 @@ $in-video-chat-width-small: 250px;
 }
 
 .video-controls {
-	position: absolute;
-	bottom: 0;
 	height: $video-controls-height;
-
-	background: linear-gradient(to top, rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0));
 	transition: all 0.2s;
 
-	&.hide {
-		opacity: 0;
-		transition: all 0.5s;
-		bottom: -100%;
+	&.in-video {
+		position: absolute;
+		bottom: 0;
+
+		background: linear-gradient(to top, rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0));
+		transition: all 0.2s;
+
+		&.hide {
+			opacity: 0;
+			transition: all 0.5s;
+			bottom: -100%;
+		}
+	}
+
+	&.outside-video {
+		position: relative;
+		background: rgb(var(--v-theme-surface));
+		border-radius: 0 0 10px 10px;
+
+		&.hide {
+			opacity: 0;
+			transform: scaleY(0) translateY(-50%);
+			transition: all 0.5s;
+			height: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
- add outside-video style for video controls
- move volume control into it's own component
- export types from OmniPlayer
- move video controls into their own component
- add mode prop to video controls
- make it so that the video controls can switch from outside video to inside video
- move video player controls outside of the player for youtube only
- small refactor
- fix video layout I think?
- fix video layout on ultrawide screens maybe?
- fix outside-video controls not being visible in light mode
- fix volume controls not working
- add isCaptionsSupported to all other players
- use provide/inject for volume control

In order to comply with the Youtube API Terms of Service, the video controls need to be moved outside of the bounding box of the video player.

This PR makes it so that video controls are moved outside the player for *only* Youtube videos.

related: #817
closes #652
