### PR TITLE
improve queue robustness

### DIFF
--- a/server/roommanager.ts
+++ b/server/roommanager.ts
@@ -40,8 +40,12 @@ export async function start() {
 
 export async function update(): Promise<void> {
 	for (const room of rooms) {
-		await room.update();
-		await room.sync();
+		try {
+			await room.update();
+			await room.sync();
+		} catch (e) {
+			log.error(`Error updating room ${room.name}: ${e}`);
+		}
 
 		if (room.isStale) {
 			await UnloadRoom(room.name);

--- a/server/videoqueue.ts
+++ b/server/videoqueue.ts
@@ -15,7 +15,7 @@ export class VideoQueue extends Dirtyable {
 		this.lock = new Mutex();
 
 		if (items) {
-			this._items = items;
+			this._items = items.filter(v => v !== null && v !== undefined);
 		}
 	}
 


### PR DESCRIPTION
- explicitly disallow null or undefined items to be added to the queue
- ignore null and undefined items in VideoQueue constructor
- wrap room updates in a try catch

follow up for incident #846
