### PR TITLE
Monolith: add support for balancer clients

### DIFF
--- a/crates/ott-balancer-bin/src/service.rs
+++ b/crates/ott-balancer-bin/src/service.rs
@@ -169,7 +169,9 @@ async fn proxy_request(
     target: &BalancerMonolith,
 ) -> anyhow::Result<Response<Full<Bytes>>> {
     let client = target.http_client();
-    let url: Url = format!("http://{}{}", target.proxy_address(), in_req.uri().path()).parse()?;
+    let mut url: Url =
+        format!("http://{}{}", target.proxy_address(), in_req.uri().path()).parse()?;
+    url.set_query(in_req.uri().query());
     let method = in_req.method().clone();
     let headers = in_req.headers().clone();
     // TODO: update X-Forwarded-For header

--- a/crates/ott-balancer-bin/src/service.rs
+++ b/crates/ott-balancer-bin/src/service.rs
@@ -23,6 +23,7 @@ static NOTFOUND: &[u8] = b"Not Found";
 static ROUTER: Lazy<Router<&'static str>> = Lazy::new(|| {
     let mut router = Router::new();
     router.add("/api/status", "health");
+    router.add("/api/balancing", "status");
     router.add("/api/status/metrics", "metrics");
     router.add("/api/room/:room_name", "room");
     router.add("/monolith", "monolith");

--- a/crates/ott-balancer-bin/src/service.rs
+++ b/crates/ott-balancer-bin/src/service.rs
@@ -12,7 +12,7 @@ use ott_balancer_protocol::RoomName;
 use reqwest::Url;
 use route_recognizer::Router;
 use tokio::sync::RwLock;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::balancer::{BalancerContext, BalancerLink};
 use crate::client::client_entry;
@@ -79,6 +79,7 @@ impl Service<Request<IncomingBody>> for BalancerService {
 
                     let room_name: RoomName = room_name.to_owned().into();
                     if crate::websocket::is_websocket_upgrade(&req) {
+                        debug!("upgrading to websocket");
                         let (response, websocket) = crate::websocket::upgrade(req, None).unwrap();
 
                         // Spawn a task to handle the websocket connection.

--- a/crates/ott-balancer-bin/src/websocket.rs
+++ b/crates/ott-balancer-bin/src/websocket.rs
@@ -107,7 +107,8 @@ pub fn is_websocket_upgrade<B>(req: &hyper::Request<B>) -> bool {
     match (connection, upgrade) {
         (Some(connection), Some(upgrade)) => match (connection.to_str(), upgrade.to_str()) {
             (Ok(connection), Ok(upgrade)) => {
-                connection.trim() == "Upgrade" && upgrade.trim() == "websocket"
+                connection.to_lowercase().contains("upgrade")
+                    && upgrade.trim().to_lowercase() == "websocket"
             }
             _ => false,
         },

--- a/crates/ott-balancer-protocol/src/monolith.rs
+++ b/crates/ott-balancer-protocol/src/monolith.rs
@@ -20,7 +20,9 @@ pub enum MsgB2M {
         client: ClientId,
     },
     ClientMsg {
+        /// The client that sent the message.
         client_id: ClientId,
+        /// The message that was received from the client, verbatim.
         payload: Box<RawValue>,
     },
 }
@@ -38,8 +40,11 @@ pub enum MsgM2B {
         rooms: Vec<RoomName>,
     },
     RoomMsg {
+        /// The room to send the message to.
         room: RoomName,
+        /// The client to send the message to. If `None`, send to all clients in the room.
         client_id: Option<ClientId>,
+        /// The message to send, verbatim.
         payload: Box<RawValue>,
     },
 }

--- a/crates/ott-balancer-protocol/src/monolith.rs
+++ b/crates/ott-balancer-protocol/src/monolith.rs
@@ -47,4 +47,8 @@ pub enum MsgM2B {
         /// The message to send, verbatim.
         payload: Box<RawValue>,
     },
+    Kick {
+        client_id: ClientId,
+        reason: u16,
+    },
 }

--- a/server/balancer.ts
+++ b/server/balancer.ts
@@ -8,6 +8,7 @@ import { BalancerConfig, conf } from "./ott-config";
 import { Result, err, ok, intoResult } from "../common/result";
 import { AuthToken, ClientId } from "../common/models/types";
 import { replacer } from "../common/serialize";
+import { OttWebsocketError } from "ott-common/models/types";
 
 const log = getLogger("balancer");
 
@@ -247,7 +248,12 @@ interface MsgB2MClientMsg<T> {
 	};
 }
 
-export type MsgM2B = MsgM2BLoaded | MsgM2BUnloaded | MsgM2BGossip | MsgM2BRoomMsg<unknown>;
+export type MsgM2B =
+	| MsgM2BLoaded
+	| MsgM2BUnloaded
+	| MsgM2BGossip
+	| MsgM2BRoomMsg<unknown>
+	| MsgM2BKick;
 
 interface MsgM2BLoaded {
 	type: "loaded";
@@ -276,5 +282,13 @@ interface MsgM2BRoomMsg<T> {
 		room: string;
 		client_id?: ClientId;
 		payload: T;
+	};
+}
+
+interface MsgM2BKick {
+	type: "kick";
+	payload: {
+		client_id: ClientId;
+		reason: OttWebsocketError;
 	};
 }

--- a/server/balancer.ts
+++ b/server/balancer.ts
@@ -1,0 +1,201 @@
+import { v4 as uuidv4 } from "uuid";
+import EventEmitter from "events";
+import { URL } from "url";
+import WebSocket from "ws";
+
+import { getLogger } from "./logger";
+import { BalancerConfig, conf } from "./ott-config";
+import { Result, err, ok, intoResult } from "../common/result";
+import { AuthToken, ClientId } from "../common/models/types";
+
+const log = getLogger("balancer");
+export const balancerConnections: BalancerConnection[] = [];
+
+export function initBalancerConnections() {
+	const configs = conf.get("balancers");
+	if (configs.length === 0) {
+		log.warn("No balancers configured");
+		return;
+	}
+	log.info("Initializing balancer connections...");
+	for (const config of configs) {
+		const conn = new BalancerConnection(config);
+		balancerConnections.push(conn);
+		const result = conn.connect();
+		if (result.ok) {
+			log.info(`Connected to balancer ${conn.id}`);
+		} else {
+			log.error(`Error connecting to balancer ${conn.id}: ${result.value}`);
+		}
+	}
+}
+
+type BalancerConnectionEvents = "connect" | "disconnect" | "message" | "error";
+type BalancerConnectionEventHandlers<E> = E extends "connect"
+	? () => void
+	: E extends "disconnect"
+	? () => void
+	: E extends "message"
+	? (message: MsgB2M) => void
+	: E extends "error"
+	? (error: WebSocket.ErrorEvent) => void
+	: never;
+
+/** Manages the websocket connection to a Balancer. */
+class BalancerConnection {
+	/** A local identifier for the balancer. Other monoliths will have different IDs for the same balancer. */
+	id: string;
+	config: BalancerConfig;
+	private socket: WebSocket | null = null;
+	private bus: EventEmitter = new EventEmitter();
+
+	constructor(config: BalancerConfig) {
+		this.id = uuidv4();
+		this.config = config;
+	}
+
+	get socketUrl(): URL {
+		return new URL(`ws://${this.config.host}:${this.config.port}/monolith`);
+	}
+
+	get readyState(): number {
+		if (this.socket === null) {
+			return WebSocket.CLOSED;
+		}
+		return this.socket.readyState;
+	}
+
+	connect(): Result<void, Error> {
+		if (this.socket !== null) {
+			return err(new Error("Already connected"));
+		}
+		this.socket = new WebSocket(this.socketUrl);
+		this.socket.on("open", this.onSocketConnect.bind(this));
+		this.socket.on("close", this.onSocketDisconnect.bind(this));
+		this.socket.on("message", this.onSocketMessage.bind(this));
+		this.socket.on("error", this.onSocketError.bind(this));
+		return ok(undefined);
+	}
+
+	disconnect(): Result<void, Error> {
+		if (this.socket === null) {
+			return err(new Error("Not connected"));
+		}
+		this.socket.close();
+		return ok(undefined);
+	}
+
+	private onSocketConnect(event: WebSocket.OpenEvent) {
+		this.emit("connect");
+	}
+
+	private onSocketDisconnect(event: WebSocket.CloseEvent) {
+		this.socket = null;
+		this.emit("disconnect");
+	}
+
+	private onSocketMessage(event: WebSocket.MessageEvent) {
+		let result = intoResult(() => JSON.parse(event.data.toString()));
+		if (result.ok) {
+			if (!validateB2M(result.value)) {
+				log.error(`Error validating incoming balancer message: ${result.value}`);
+				return;
+			}
+			this.emit("message", result.value);
+		} else {
+			log.error(`Error parsing incoming balancer message: ${result.value}`);
+		}
+	}
+
+	private onSocketError(event: WebSocket.ErrorEvent) {
+		this.emit("error", event);
+	}
+
+	private emit<E extends BalancerConnectionEvents>(
+		event: E,
+		...args: Parameters<BalancerConnectionEventHandlers<E>>
+	) {
+		this.bus.emit(event, ...args);
+	}
+
+	on<E extends BalancerConnectionEvents>(event: E, handler: BalancerConnectionEventHandlers<E>) {
+		this.bus.on(event, handler);
+	}
+
+	send(message: MsgM2B): Result<void, Error> {
+		if (this.socket === null) {
+			return err(new Error("Not connected"));
+		}
+		try {
+			this.socket.send(JSON.stringify(message));
+		} catch (e) {
+			return err(e);
+		}
+		return ok(undefined);
+	}
+}
+
+function validateB2M(message: unknown): message is MsgB2M {
+	if (typeof message !== "object" || message === null) {
+		return false;
+	}
+	const msg = message as MsgB2M;
+	if (typeof msg.type !== "string") {
+		return false;
+	}
+	switch (msg.type) {
+		case "join":
+			return typeof msg.room === "string" && typeof msg.client === "string";
+		case "leave":
+			return typeof msg.client === "string";
+		case "client_msg":
+			return typeof msg.client_id === "string" && typeof msg.payload === "object";
+		default:
+			return false;
+	}
+}
+
+// TODO: use typeshare?
+type MsgB2M = MsgB2MJoin | MsgB2MLeave | MsgB2MClientMsg<unknown>;
+
+interface MsgB2MJoin {
+	type: "join";
+	room: string;
+	client: ClientId;
+	token: AuthToken;
+}
+
+interface MsgB2MLeave {
+	type: "leave";
+	client: ClientId;
+}
+
+interface MsgB2MClientMsg<T> {
+	type: "client_msg";
+	client_id: ClientId;
+	payload: T;
+}
+
+type MsgM2B = MsgM2BLoaded | MsgM2BUnloaded | MsgM2BGossip | MsgM2BRoomMsg<unknown>;
+
+interface MsgM2BLoaded {
+	type: "loaded";
+	room: string;
+}
+
+interface MsgM2BUnloaded {
+	type: "unloaded";
+	room: string;
+}
+
+interface MsgM2BGossip {
+	type: "gossip";
+	rooms: string[];
+}
+
+interface MsgM2BRoomMsg<T> {
+	type: "room_msg";
+	room: string;
+	client_id?: ClientId;
+	payload: T;
+}

--- a/server/client.ts
+++ b/server/client.ts
@@ -181,6 +181,12 @@ export class BalancerClient extends Client {
 	}
 
 	kick(code: OttWebsocketError) {
-		throw new Error("Not implemented");
+		this.conn.send({
+			type: "kick",
+			payload: {
+				client_id: this.id,
+				reason: code,
+			},
+		});
 	}
 }

--- a/server/client.ts
+++ b/server/client.ts
@@ -148,10 +148,17 @@ export class DirectClient extends Client {
  * A client that is connected from a load balancer.
  */
 export class BalancerClient extends Client {
-	constructor(room: string) {
+	constructor(room: string, client_id: ClientId) {
 		super(room);
-		// The balancer takes care of waiting for auth.
-		this.joinStatus = ClientJoinStatus.Joined;
+		this.id = client_id;
+	}
+
+	leave() {
+		this.emit("disconnect", this);
+	}
+
+	receiveMessage(msg: ClientMessage) {
+		this.emit("message", this, msg);
 	}
 
 	sendRaw(msg: string) {

--- a/server/clientmanager.ts
+++ b/server/clientmanager.ts
@@ -185,15 +185,18 @@ function onBalancerDisconnect(conn: BalancerConnection) {
 }
 
 function onBalancerMessage(conn: BalancerConnection, message: MsgB2M) {
+	log.silly("balancer message: " + JSON.stringify(message));
 	if (message.type === "join") {
-		const client = new BalancerClient(message.room, message.client);
+		const msg = message.payload;
+		const client = new BalancerClient(msg.room, msg.client);
 		connections.push(client);
 		client.on("auth", onClientAuth);
 		client.on("message", onClientMessage);
 		client.on("disconnect", onClientDisconnect);
-		client.auth(message.token);
+		client.auth(msg.token);
 	} else if (message.type === "leave") {
-		const client = connections.find(c => c.id === message.client);
+		const msg = message.payload;
+		const client = connections.find(c => c.id === msg.client);
 		if (client instanceof BalancerClient) {
 			client.leave();
 		} else {
@@ -202,9 +205,10 @@ function onBalancerMessage(conn: BalancerConnection, message: MsgB2M) {
 			);
 		}
 	} else if (message.type === "client_msg") {
-		const client = connections.find(c => c.id === message.client_id);
+		const msg = message.payload;
+		const client = connections.find(c => c.id === msg.client_id);
 		if (client instanceof BalancerClient) {
-			client.receiveMessage(message.payload as ClientMessage);
+			client.receiveMessage(msg.payload as ClientMessage);
 		} else {
 			log.error(
 				`Balancer sent message for client that does not exist or is not a balancer client`

--- a/server/clientmanager.ts
+++ b/server/clientmanager.ts
@@ -30,7 +30,8 @@ import tokens, { SessionInfo } from "./auth/tokens";
 import { RoomStateSyncable } from "./room";
 import { Gauge } from "prom-client";
 import { replacer } from "../common/serialize";
-import { Client, ClientJoinStatus, DirectClient } from "./client";
+import { Client, ClientJoinStatus, DirectClient, BalancerClient } from "./client";
+import { initBalancerConnections } from "./balancer";
 
 const log = getLogger("clientmanager");
 const redisSubscriber = createSubscriber();
@@ -55,6 +56,8 @@ export function setup(): void {
 	});
 	roommanager.on("publish", onRoomPublish);
 	roommanager.on("unload", onRoomUnload);
+
+	initBalancerConnections();
 }
 
 /**


### PR DESCRIPTION
- set up BalancerConnection class
- implement adding/removing BalancerClients on join/leave
- fix `is_websocket_upgrade`
- fix type definitions for MsgB2M
- implement monoliths sending messages to balancer clients
- fix proxied requests not including query params
- add and impl kick message and handling

closes #870
closes #879

This makes it possible to use the load balancer in front of the API server, but behind the vite devserver.

