### PR TITLE
finish converting api endpoints to typescript

### DIFF
--- a/client/tests/e2e/component/AddPreview.cy.ts
+++ b/client/tests/e2e/component/AddPreview.cy.ts
@@ -19,15 +19,18 @@ describe("<AddPreview />", () => {
 		cy.intercept(
 			"GET",
 			"/api/data/previewAdd?input=https%3A%2F%2Fyoutube.com%2Fwatch%3Fv%3DLP8GRjv6AIo",
-			[
-				{
-					service: "youtube",
-					id: "1",
-					title: "Foo",
-					description: "Bar",
-					length: 100,
-				},
-			]
+			{
+				success: true,
+				result: [
+					{
+						service: "youtube",
+						id: "1",
+						title: "Foo",
+						description: "Bar",
+						length: 100,
+					},
+				],
+			}
 		).as("previewAdd");
 		cy.mount(page);
 
@@ -41,15 +44,18 @@ describe("<AddPreview />", () => {
 	});
 
 	it("should not make a query if not given a URL until the user explicitly searches", () => {
-		cy.intercept("GET", "/api/data/previewAdd?input=foo", [
-			{
-				service: "youtube",
-				id: "1",
-				title: "Foo",
-				description: "Bar",
-				length: 100,
-			},
-		]).as("previewAdd");
+		cy.intercept("GET", "/api/data/previewAdd?input=foo", {
+			success: true,
+			result: [
+				{
+					service: "youtube",
+					id: "1",
+					title: "Foo",
+					description: "Bar",
+					length: 100,
+				},
+			],
+		}).as("previewAdd");
 		cy.mount(page);
 
 		cy.get('[data-cy="add-preview-input"]').click();

--- a/common/models/rest-api.ts
+++ b/common/models/rest-api.ts
@@ -1,6 +1,6 @@
 import { Grants } from "../permissions";
 import { QueueMode, RoomSettings, RoomUserInfo, Visibility } from "./types";
-import { QueueItem, VideoId } from "./video";
+import { QueueItem, Video, VideoId } from "./video";
 
 export type OttResponseBody<T = unknown, E extends OttApiError = OttApiError> =
 	| OttSuccessResponseBody<T>
@@ -67,3 +67,7 @@ export type OttApiRequestAddToQueue =
 	  };
 
 export type OttApiRequestRemoveFromQueue = VideoId;
+
+export type OttApiResponseAddPreview = {
+	result: Video[];
+};

--- a/common/models/rest-api.ts
+++ b/common/models/rest-api.ts
@@ -2,7 +2,7 @@ import { Grants } from "../permissions";
 import { QueueMode, RoomSettings, RoomUserInfo, Visibility } from "./types";
 import { QueueItem, VideoId } from "./video";
 
-export type OttResponseBody<T = undefined, E extends OttApiError = OttApiError> =
+export type OttResponseBody<T = unknown, E extends OttApiError = OttApiError> =
 	| OttSuccessResponseBody<T>
 	| OttErrorResponseBody<E>;
 

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -371,27 +371,30 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    title:
-                      type: string
-                    thumbnail:
-                      type: string
-                    service:
-                      type: string
-                    length:
-                      type: number
-                    id:
-                      type: string
-                    description:
-                      type: string
-                    mime:
-                      type: string
-                  required:
-                    - service
-                    - id
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                        thumbnail:
+                          type: string
+                        service:
+                          type: string
+                        length:
+                          type: number
+                        id:
+                          type: string
+                        description:
+                          type: string
+                        mime:
+                          type: string
+                      required:
+                        - service
+                        - id
         "400":
           $ref: "#/components/responses/Error"
   /api/user/auth/discord:

--- a/server/api.js
+++ b/server/api.js
@@ -47,24 +47,6 @@ if (conf.get("env") === "development") {
 	})();
 }
 
-router.post("/room/generate", async (req, res) => {
-	let points = 50;
-	if (!(await consumeRateLimitPoints(res, req.ip, points))) {
-		return;
-	}
-	let roomName = uuidv4();
-	log.debug(`Generating room: ${roomName}`);
-	await roommanager.createRoom({
-		name: roomName,
-		isTemporary: true,
-	});
-	log.info(`room generated: ip=${req.ip} user-agent=${req.headers["user-agent"]}`);
-	res.json({
-		success: true,
-		room: roomName,
-	});
-});
-
 router.get("/data/previewAdd", async (req, res) => {
 	let points = 5;
 	if (!InfoExtract.isURL(req.query.input)) {

--- a/server/api.js
+++ b/server/api.js
@@ -3,13 +3,10 @@ import InfoExtract from "./infoextractor";
 const { getLogger } = require("./logger.js");
 import { consumeRateLimitPoints } from "./rate-limit";
 import roomapi from "./api/room";
-import { redisClient } from "./redisclient";
-import { ANNOUNCEMENT_CHANNEL } from "../common/constants";
 import auth from "./auth";
 import usermanager from "./usermanager";
 import passport from "passport";
 import statusapi from "./api/status";
-import { getApiKey } from "./admin";
 import { conf } from "./ott-config";
 import announceapi from "./api/announce";
 
@@ -95,54 +92,6 @@ router.get("/data/previewAdd", async (req, res) => {
 			});
 		}
 	}
-});
-
-router.post("/announce", (req, res) => {
-	if (req.get("apikey")) {
-		if (req.get("apikey") !== getApiKey()) {
-			res.status(400).json({
-				success: false,
-				error: "apikey is invalid",
-			});
-			return;
-		}
-	} else {
-		res.status(400).json({
-			success: false,
-			error: "apikey was not supplied",
-		});
-		return;
-	}
-	if (!req.body.text) {
-		res.status(400).json({
-			success: false,
-			error: "text was not supplied",
-		});
-		return;
-	}
-
-	try {
-		redisClient.publish(
-			ANNOUNCEMENT_CHANNEL,
-			JSON.stringify({
-				action: "announcement",
-				text: req.body.text,
-			})
-		);
-	} catch (error) {
-		log.error(`An unknown error occurred while sending an announcement: ${error}`);
-		res.status(500).json({
-			success: false,
-			error: {
-				name: "Unknown",
-				message: "Unknown, check logs",
-			},
-		});
-		return;
-	}
-	res.json({
-		success: true,
-	});
 });
 
 export default router;

--- a/server/api.js
+++ b/server/api.js
@@ -1,8 +1,6 @@
 const express = require("express");
-import { v4 as uuidv4 } from "uuid";
 import InfoExtract from "./infoextractor";
 const { getLogger } = require("./logger.js");
-import roommanager from "./roommanager";
 import { consumeRateLimitPoints } from "./rate-limit";
 import roomapi from "./api/room";
 import { redisClient } from "./redisclient";
@@ -13,6 +11,7 @@ import passport from "passport";
 import statusapi from "./api/status";
 import { getApiKey } from "./admin";
 import { conf } from "./ott-config";
+import announceapi from "./api/announce";
 
 const log = getLogger("api");
 
@@ -40,6 +39,7 @@ router.use((req, res, next) => {
 router.use(auth.authTokenMiddleware);
 router.use("/user", usermanager.router);
 router.use("/room", roomapi);
+router.use("/announce", announceapi);
 
 if (conf.get("env") === "development") {
 	(async () => {

--- a/server/api.ts
+++ b/server/api.ts
@@ -1,5 +1,5 @@
-const express = require("express");
-const { getLogger } = require("./logger.js");
+import express from "express";
+import { getLogger } from "./logger.js";
 import roomapi from "./api/room";
 import auth from "./auth";
 import usermanager from "./usermanager";

--- a/server/api/announce.ts
+++ b/server/api/announce.ts
@@ -1,32 +1,46 @@
 import { getLogger } from "../logger.js";
 import { conf } from "../ott-config";
-import express, { RequestHandler, ErrorRequestHandler } from "express";
+import express, { RequestHandler } from "express";
 import { redisClientAsync } from "../redisclient";
 import { ANNOUNCEMENT_CHANNEL } from "../../common/constants";
+import { OttResponseBody } from "common/models/rest-api.js";
 
 const router = express.Router();
 const log = getLogger("api/announce");
 
-const announce: RequestHandler = async (req, res, next) => {
+const announce: RequestHandler<unknown, OttResponseBody, { text: string }> = async (
+	req,
+	res,
+	next
+) => {
 	if (req.get("apikey")) {
 		if (req.get("apikey") !== conf.get("api_key")) {
 			res.status(400).json({
 				success: false,
-				error: "apikey is invalid",
+				error: {
+					name: "InvalidApiKey",
+					message: "apikey is invalid",
+				},
 			});
 			return;
 		}
 	} else {
 		res.status(400).json({
 			success: false,
-			error: "apikey was not supplied",
+			error: {
+				name: "MissingApiKey",
+				message: "apikey was not supplied",
+			},
 		});
 		return;
 	}
 	if (!req.body.text) {
 		res.status(400).json({
 			success: false,
-			error: "text was not supplied",
+			error: {
+				name: "MissingText",
+				message: "text was not supplied",
+			},
 		});
 		return;
 	}

--- a/server/api/announce.ts
+++ b/server/api/announce.ts
@@ -1,0 +1,72 @@
+import { getLogger } from "../logger.js";
+import { conf } from "../ott-config";
+import express, { RequestHandler, ErrorRequestHandler } from "express";
+import { redisClientAsync } from "../redisclient";
+import { ANNOUNCEMENT_CHANNEL } from "../../common/constants";
+
+const router = express.Router();
+const log = getLogger("api/announce");
+
+const announce: RequestHandler = async (req, res, next) => {
+	if (req.get("apikey")) {
+		if (req.get("apikey") !== conf.get("api_key")) {
+			res.status(400).json({
+				success: false,
+				error: "apikey is invalid",
+			});
+			return;
+		}
+	} else {
+		res.status(400).json({
+			success: false,
+			error: "apikey was not supplied",
+		});
+		return;
+	}
+	if (!req.body.text) {
+		res.status(400).json({
+			success: false,
+			error: "text was not supplied",
+		});
+		return;
+	}
+
+	try {
+		await redisClientAsync.publish(
+			ANNOUNCEMENT_CHANNEL,
+			JSON.stringify({
+				action: "announcement",
+				text: req.body.text,
+			})
+		);
+	} catch (error) {
+		log.error(`An unknown error occurred while sending an announcement: ${error}`);
+		res.status(500).json({
+			success: false,
+			error: {
+				name: "Unknown",
+				message: "Unknown, check logs",
+			},
+		});
+		return;
+	}
+	res.json({
+		success: true,
+	});
+};
+
+router.post("/", async (req, res, next) => {
+	try {
+		await announce(req, res, next);
+	} catch (e) {
+		res.status(500).json({
+			success: false,
+			error: {
+				name: "Unknown",
+				message: "Unknown, check logs",
+			},
+		});
+	}
+});
+
+export default router;

--- a/server/api/announce.ts
+++ b/server/api/announce.ts
@@ -3,7 +3,7 @@ import { conf } from "../ott-config";
 import express, { RequestHandler } from "express";
 import { redisClientAsync } from "../redisclient";
 import { ANNOUNCEMENT_CHANNEL } from "../../common/constants";
-import { OttResponseBody } from "common/models/rest-api.js";
+import { OttResponseBody } from "../../common/models/rest-api";
 
 const router = express.Router();
 const log = getLogger("api/announce");

--- a/server/api/data.ts
+++ b/server/api/data.ts
@@ -1,0 +1,114 @@
+import { getLogger } from "../logger.js";
+import { conf } from "../ott-config";
+import express, { RequestHandler, ErrorRequestHandler } from "express";
+import { OttApiResponseAddPreview, OttResponseBody } from "../../common/models/rest-api";
+import { OttException } from "../../common/exceptions";
+import { BadApiArgumentException } from "../exceptions";
+import InfoExtract from "../infoextractor";
+import { consumeRateLimitPoints } from "../rate-limit";
+
+const router = express.Router();
+const log = getLogger("api/data");
+const addPreview: RequestHandler<
+	any,
+	OttResponseBody<OttApiResponseAddPreview>,
+	any,
+	{ input: string }
+> = async (req, res, next) => {
+	let points = 5;
+	if (!InfoExtract.isURL(req.query.input)) {
+		points *= 15;
+	}
+	if (!(await consumeRateLimitPoints(res, req.ip, points))) {
+		return;
+	}
+	try {
+		log.info(`Getting queue add preview for ${req.query.input}`);
+		let result = await InfoExtract.resolveVideoQuery(
+			req.query.input.trim(),
+			conf.get("add_preview.search.provider")
+		);
+		res.json({
+			success: true,
+			result,
+		});
+		log.info(`Sent add preview response with ${result.length} items`);
+	} catch (err) {
+		if (
+			err.name === "UnsupportedServiceException" ||
+			err.name === "InvalidAddPreviewInputException" ||
+			err.name === "OutOfQuotaException" ||
+			err.name === "InvalidVideoIdException" ||
+			err.name === "FeatureDisabledException" ||
+			err.name === "UnsupportedMimeTypeException" ||
+			err.name === "LocalFileException" ||
+			err.name === "MissingMetadataException" ||
+			err.name === "UnsupportedVideoType" ||
+			err.name === "VideoNotFoundException"
+		) {
+			log.error(`Unable to get add preview: ${err.name}`);
+			res.status(400).json({
+				success: false,
+				error: {
+					name: err.name,
+					message: err.message,
+				},
+			});
+		} else {
+			log.error(`Unable to get add preview: ${err} ${err.stack}`);
+			res.status(500).json({
+				success: false,
+				error: {
+					name: "Unknown",
+					message: "Unknown error occurred.",
+				},
+			});
+		}
+	}
+};
+
+router.get("/previewAdd", async (req, res, next) => {
+	try {
+		// @ts-expect-error the type definition for query parameters makes ts angry, but its correct
+		await addPreview(req, res, next);
+	} catch (e) {
+		errorHandler(e, req, res, next);
+	}
+});
+
+const errorHandler: ErrorRequestHandler = (err: Error, req, res) => {
+	if (err instanceof OttException) {
+		log.debug(`OttException: path=${req.path} name=${err.name}`);
+		if (err.name === "BadApiArgumentException") {
+			const e = err as BadApiArgumentException;
+			res.status(400).json({
+				success: false,
+				error: {
+					name: "BadApiArgumentException",
+					message: err.message,
+					arg: e.arg,
+					reason: e.reason,
+				},
+			});
+		} else {
+			res.status(400).json({
+				success: false,
+				error: {
+					name: err.name,
+					message: err.message,
+				},
+			});
+		}
+	} else {
+		log.error(`Unhandled exception: path=${req.path} ${err.name} ${err.message} ${err.stack}`);
+		res.status(500).json({
+			success: false,
+			error: {
+				name: "Unknown",
+				message: "An unknown error occured. Try again later.",
+			},
+		});
+	}
+};
+
+export default router;

--- a/server/api/room.ts
+++ b/server/api/room.ts
@@ -81,7 +81,10 @@ router.get("/list", (req, res) => {
 	res.json(rooms);
 });
 
-const generateRoom: RequestHandler<unknown, OttResponseBody<OttApiResponseRoomGenerate>> = async (req, res) => {
+const generateRoom: RequestHandler<unknown, OttResponseBody<OttApiResponseRoomGenerate>> = async (
+	req,
+	res
+) => {
 	let points = 50;
 	if (!(await consumeRateLimitPoints(res, req.ip, points))) {
 		return;

--- a/server/api/room.ts
+++ b/server/api/room.ts
@@ -18,10 +18,12 @@ import {
 	OttApiRequestRoomCreate,
 	OttApiResponseGetRoom,
 	OttApiResponseRoomCreate,
+	OttApiResponseRoomGenerate,
 	OttResponseBody,
 } from "../../common/models/rest-api";
 import { getApiKey } from "../admin";
 import { AddRequest } from "ott-common/models/messages";
+import { v4 as uuidv4 } from "uuid";
 
 const router = express.Router();
 const log = getLogger("api/room");
@@ -78,6 +80,24 @@ router.get("/list", (req, res) => {
 	rooms = _.orderBy(rooms, ["users", "name"], ["desc", "asc"]);
 	res.json(rooms);
 });
+
+const generateRoom: RequestHandler<unknown, OttResponseBody<OttApiResponseRoomGenerate>> = async (req, res) => {
+	let points = 50;
+	if (!(await consumeRateLimitPoints(res, req.ip, points))) {
+		return;
+	}
+	let roomName = uuidv4();
+	log.debug(`Generating room: ${roomName}`);
+	await roommanager.createRoom({
+		name: roomName,
+		isTemporary: true,
+	});
+	log.info(`room generated: ip=${req.ip} user-agent=${req.headers["user-agent"]}`);
+	res.json({
+		success: true,
+		room: roomName,
+	});
+};
 
 const createRoom: RequestHandler<
 	unknown,
@@ -461,6 +481,14 @@ const errorHandler: ErrorRequestHandler = (err: Error, req, res) => {
 
 // HACK: Ideally, this error handling would be handled with a proper express error handler.
 // I was not able to figure out how to make it work in this context, so this is what we are stuck with.
+router.post("/generate", async (req, res, next) => {
+	try {
+		await generateRoom(req, res, next);
+	} catch (e) {
+		errorHandler(e, req, res, next);
+	}
+});
+
 router.post("/create", async (req, res, next) => {
 	try {
 		await createRoom(req, res, next);

--- a/server/tests/unit/api.spec.js
+++ b/server/tests/unit/api.spec.js
@@ -5,7 +5,7 @@ const InfoExtract = require("../../infoextractor");
 const { User } = require("../../models");
 const usermanager = require("../../usermanager.js");
 import { ANNOUNCEMENT_CHANNEL } from "../../../common/constants";
-import { redisClient, redisClientAsync } from "../../redisclient";
+import { redisClientAsync } from "../../redisclient";
 import tokens from "../../auth/tokens";
 import { setApiKey } from "../../admin";
 

--- a/server/tests/unit/api.spec.js
+++ b/server/tests/unit/api.spec.js
@@ -5,7 +5,7 @@ const InfoExtract = require("../../infoextractor");
 const { User } = require("../../models");
 const usermanager = require("../../usermanager.js");
 import { ANNOUNCEMENT_CHANNEL } from "../../../common/constants";
-import { redisClient } from "../../redisclient";
+import { redisClient, redisClientAsync } from "../../redisclient";
 import tokens from "../../auth/tokens";
 import { setApiKey } from "../../admin";
 
@@ -786,7 +786,8 @@ describe("Data API", () => {
 			.expect("Content-Type", /json/)
 			.expect(200)
 			.then(resp => {
-				expect(resp.body).toHaveLength(0);
+				expect(resp.body.success).toBe(true);
+				expect(resp.body.result).toHaveLength(0);
 				expect(resolveQuerySpy).toBeCalled();
 			});
 
@@ -873,7 +874,7 @@ describe("Announcements API", () => {
 	});
 
 	beforeEach(() => {
-		publishSpy = jest.spyOn(redisClient, "publish").mockImplementation(() => {});
+		publishSpy = jest.spyOn(redisClientAsync, "publish").mockImplementation(() => {});
 	});
 
 	afterEach(() => {
@@ -914,7 +915,10 @@ describe("Announcements API", () => {
 			.then(resp => {
 				expect(resp.body).toEqual({
 					success: false,
-					error: "apikey was not supplied",
+					error: {
+						name: "MissingApiKey",
+						message: "apikey was not supplied",
+					},
 				});
 			});
 		expect(publishSpy).not.toHaveBeenCalled();
@@ -949,7 +953,10 @@ describe("Announcements API", () => {
 			.then(resp => {
 				expect(resp.body).toEqual({
 					success: false,
-					error: "text was not supplied",
+					error: {
+						name: "MissingText",
+						message: "text was not supplied",
+					},
 				});
 			});
 		expect(publishSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
- convert /api/room/generate endpoint to typescript
- convert /api/announce endpoint to typescript
- improve announce endpoint responses and type definitions
- remove old announce endpoint
- convert add preview endpoint to typescript
- rename api.js to api.ts, closes #433
- update api docs
