### PR TITLE
Make email optional when registering

### DIFF
--- a/client/src/components/LogInForm.vue
+++ b/client/src/components/LogInForm.vue
@@ -192,10 +192,7 @@ const LogInForm = defineComponent({
 		const loginForm = ref<VForm | undefined>(null);
 		const registerForm = ref<VForm | undefined>(null);
 
-		const emailRules = [
-			v => !!v || t("login-form.rules.email-required"),
-			v => (v && isEmail(v)) || t("login-form.rules.valid-email"),
-		];
+		const emailRules = [v => (v && isEmail(v)) || !v || t("login-form.rules.valid-email")];
 		const usernameRules = [
 			v => !!v || t("login-form.rules.username-required"),
 			v =>

--- a/client/src/components/LogInForm.vue
+++ b/client/src/components/LogInForm.vue
@@ -98,6 +98,7 @@
 											v-model="email"
 											:error-messages="registerFieldErrors.email"
 											:rules="emailRules"
+											:hint="$t('login-form.email-optional')"
 										/>
 										<v-text-field
 											:loading="isLoading"

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -274,6 +274,8 @@ export default {
 		"username": "Username",
 		"password": "Password",
 		"retype-password": "Retype Password",
+		"email-optional":
+			"Providing an email is optional, but recommended in case you forget your password.",
 		"rules": {
 			"email-required": "Email is required",
 			"valid-email": "Must be a valid email",

--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -72,9 +72,9 @@ const createModel = (sequelize: Sequelize) => {
 			modelName: "User",
 			validate: {
 				ensureCredentials() {
-					if ((!this.email || !this.hash || !this.salt) && !this.discordId) {
+					if ((!this.username || !this.hash || !this.salt) && !this.discordId) {
 						throw new Error(
-							"Incomplete login credentials. Requires social login or email/password."
+							"Incomplete login credentials. Requires social login or username/password."
 						);
 					}
 				},

--- a/server/tests/unit/api/user.spec.ts
+++ b/server/tests/unit/api/user.spec.ts
@@ -5,7 +5,7 @@ import { User as UserModel } from "../../../models";
 
 describe("User API", () => {
 	let token;
-	beforeAll(async () => {
+	beforeEach(async () => {
 		await UserModel.destroy({ where: {} });
 
 		await usermanager.registerUser({
@@ -24,9 +24,7 @@ describe("User API", () => {
 			username: "social user",
 			discordId: 1234567890,
 		});
-	});
 
-	beforeEach(async () => {
 		let resp = await request(app).get("/api/auth/grant").expect(200);
 		token = resp.body.token;
 	});
@@ -311,6 +309,28 @@ describe("User API", () => {
 							},
 						});
 						expect(onUserLogInSpy).toBeCalled();
+					});
+			});
+
+			it("should register user, but ignore email if it's an empty string ", async () => {
+				await request(app)
+					.post("/api/user/register")
+					.set("Authorization", `Bearer ${token}`)
+					.send({ email: "", username: "registered", password: "test1234" })
+					.expect(200)
+					.expect("Content-Type", /json/)
+					.then(resp => {
+						expect(resp.body.success).toBe(true);
+					});
+
+				await request(app)
+					.post("/api/user/register")
+					.set("Authorization", `Bearer ${token}`)
+					.send({ email: "", username: "registered2", password: "test1234" })
+					.expect(200)
+					.expect("Content-Type", /json/)
+					.then(resp => {
+						expect(resp.body.success).toBe(true);
 					});
 			});
 

--- a/server/usermanager.ts
+++ b/server/usermanager.ts
@@ -519,6 +519,9 @@ async function registerUser({ email, username, password }): Promise<User> {
 	if (username.length > USERNAME_LENGTH_MAX) {
 		throw new LengthOutOfRangeException("Username length", { max: USERNAME_LENGTH_MAX });
 	}
+	if (email === "") {
+		email = null;
+	}
 
 	const salt = crypto.randomBytes(128);
 	// eslint-disable-next-line array-bracket-newline
@@ -528,7 +531,7 @@ async function registerUser({ email, username, password }): Promise<User> {
 	if (await isUsernameTaken(username)) {
 		throw new UsernameTakenError();
 	}
-	if (await isEmailTaken(email)) {
+	if (email && await isEmailTaken(email)) {
 		throw new EmailAlreadyInUseError();
 	}
 

--- a/server/usermanager.ts
+++ b/server/usermanager.ts
@@ -531,7 +531,7 @@ async function registerUser({ email, username, password }): Promise<User> {
 	if (await isUsernameTaken(username)) {
 		throw new UsernameTakenError();
 	}
-	if (email && await isEmailTaken(email)) {
+	if (email && (await isEmailTaken(email))) {
 		throw new EmailAlreadyInUseError();
 	}
 

--- a/tests/e2e/integration/user-login.spec.ts
+++ b/tests/e2e/integration/user-login.spec.ts
@@ -56,6 +56,41 @@ describe("User login/registration", () => {
 		cy.get('[data-cy="user-logged-in"]').should("be.visible").should("contain", username);
 	});
 
+	it("should register a new user without an email", () => {
+		cy.contains("button", "Log In").click();
+		cy.get('[role="tablist"]').contains(".v-tab", "Register").click();
+		cy.wait(500);
+		let username = faker.internet.userName();
+		let password = faker.internet.password(10);
+		cy.get("form")
+			.contains("Register")
+			.parent()
+			.contains("label", "Username")
+			.siblings("input")
+			.click()
+			.wait(250)
+			.type(username);
+		cy.get("form")
+			.contains("Register")
+			.parent()
+			.contains("label", "Password")
+			.siblings("input")
+			.click()
+			.wait(250)
+			.type(password);
+		cy.get("form")
+			.contains("Register")
+			.parent()
+			.contains("label", "Retype Password")
+			.siblings("input")
+			.click()
+			.wait(250)
+			.type(password);
+		cy.get('[data-cy="register-button"]').should("not.be.disabled").click();
+		cy.wait(500);
+		cy.get('[data-cy="user-logged-in"]').should("be.visible").should("contain", username);
+	});
+
 	it("should log in an existing user using email/password", () => {
 		// setup
 		let userCreds = {


### PR DESCRIPTION
- add e2e test for registering without email
- allow LogInForm to submit register form without email
- adjust User model validation
- make email optional when registering
- update unit tests
- add hint for email

closes #905
