### PR TITLE
Allow signed in users to own temporary rooms

### DIFF
--- a/client/src/components/RoomSettingsForm.vue
+++ b/client/src/components/RoomSettingsForm.vue
@@ -72,15 +72,10 @@
 				data-cy="input-auto-skip"
 			/>
 			<PermissionsEditor
-				v-if="
-					!store.state.room.isTemporary && store.state.user && store.state.room.hasOwner
-				"
+				v-if="store.state.user && store.state.room.hasOwner"
 				v-model="inputRoomSettings.grants"
 				:current-role="store.getters['users/self']?.role ?? Role.Owner"
 			/>
-			<div v-else-if="store.state.room.isTemporary">
-				{{ $t("room-settings.permissions-not-available") }}
-			</div>
 			<div v-else-if="!store.state.room.hasOwner">
 				{{ $t("room-settings.room-needs-owner") }}
 				<span v-if="!store.state.user">
@@ -95,13 +90,14 @@
 					size="large"
 					block
 					color="blue"
-					v-if="!store.state.room.isTemporary && !store.state.room.hasOwner"
+					v-if="!store.state.room.hasOwner"
 					:disabled="!store.state.user"
 					role="submit"
 					@click="claimOwnership"
 					data-cy="claim"
-					>Claim Room</v-btn
 				>
+					Claim Room
+				</v-btn>
 				<v-btn
 					size="x-large"
 					block
@@ -109,8 +105,9 @@
 					role="submit"
 					:loading="isLoadingRoomSettings"
 					data-cy="save"
-					>{{ $t("common.save") }}</v-btn
 				>
+					{{ $t("common.save") }}
+				</v-btn>
 			</div>
 		</v-form>
 	</div>

--- a/client/src/components/RoomSettingsForm.vue
+++ b/client/src/components/RoomSettingsForm.vue
@@ -119,12 +119,13 @@ import PermissionsEditor from "@/components/PermissionsEditor.vue";
 import { ToastStyle } from "@/models/toast";
 import { API } from "@/common-http";
 import { Visibility, QueueMode, RoomSettings, Role } from "ott-common/models/types";
-import type { Grants } from "ott-common/permissions";
+import { Grants } from "ott-common/permissions";
 import { granted } from "@/util/grants";
 import toast from "@/util/toast";
 import { defineComponent, onMounted, Ref, ref } from "vue";
 import { useStore } from "@/store";
 import { useI18n } from "vue-i18n";
+import { OttApiResponseGetRoom } from "ott-common/models/rest-api";
 
 const RoomSettingsForm = defineComponent({
 	name: "RoomSettingsForm",
@@ -141,7 +142,7 @@ const RoomSettingsForm = defineComponent({
 			description: "",
 			visibility: Visibility.Public,
 			queueMode: QueueMode.Manual,
-			grants: {} as Grants,
+			grants: new Grants(),
 			autoSkipSegments: true,
 		});
 
@@ -153,9 +154,11 @@ const RoomSettingsForm = defineComponent({
 			// we have to make an API request becuase visibility is not sent in sync messages.
 			isLoadingRoomSettings.value = true;
 			try {
-				let res = await API.get(`/room/${store.state.room.name}`);
+				let res = await API.get<OttApiResponseGetRoom>(`/room/${store.state.room.name}`);
+				let settings = res.data;
+				settings.grants = new Grants(res.data.grants);
 				inputRoomSettings.value = _.pick(
-					res.data,
+					settings,
 					"title",
 					"description",
 					"visibility",

--- a/client/src/components/RoomSettingsForm.vue
+++ b/client/src/components/RoomSettingsForm.vue
@@ -190,9 +190,6 @@ const RoomSettingsForm = defineComponent({
 					blocked.push(prop as keyof typeof propsToGrants);
 				}
 			}
-			if (store.state.room.isTemporary) {
-				blocked.push("grants");
-			}
 			return _.omit(inputRoomSettings.value, blocked);
 		}
 

--- a/client/src/components/RoomSettingsForm.vue
+++ b/client/src/components/RoomSettingsForm.vue
@@ -154,9 +154,6 @@ const RoomSettingsForm = defineComponent({
 			isLoadingRoomSettings.value = true;
 			try {
 				let res = await API.get(`/room/${store.state.room.name}`);
-				if (res.data.permissions && !res.data.grants) {
-					res.data.grants = res.data.permissions;
-				}
 				inputRoomSettings.value = _.pick(
 					res.data,
 					"title",

--- a/client/tests/unit/PermissionsEditor.spec.ts
+++ b/client/tests/unit/PermissionsEditor.spec.ts
@@ -3,6 +3,7 @@ import { mount } from "@vue/test-utils";
 import { createVuetify } from "vuetify";
 import { i18n } from "@/i18n";
 import PermissionsEditor from "@/components/PermissionsEditor.vue";
+import { Grants } from "ott-common/permissions";
 
 const mountOptions = {
 	global: {
@@ -15,7 +16,7 @@ describe("PermissionsEditor Component", () => {
 		let wrapper = mount(PermissionsEditor, {
 			...mountOptions,
 			props: {
-				modelValue: { 0: 1 << 0 },
+				modelValue: new Grants({ 0: 1 << 0 }),
 			},
 		});
 
@@ -35,7 +36,7 @@ describe("PermissionsEditor Component", () => {
 		wrapper = mount(PermissionsEditor, {
 			...mountOptions,
 			props: {
-				modelValue: { 0: 1 << 0, 1: 1 << 1 },
+				modelValue: new Grants({ 0: 1 << 0, 1: 1 << 1 }),
 			},
 		});
 		await wrapper.vm.$nextTick();
@@ -54,7 +55,7 @@ describe("PermissionsEditor Component", () => {
 		let component = mount(PermissionsEditor, {
 			...mountOptions,
 			props: {
-				modelValue: { 0: 1 << 0 },
+				modelValue: new Grants({ 0: 1 << 0 }),
 			},
 		}).vm;
 		expect(
@@ -90,7 +91,7 @@ describe("PermissionsEditor Component", () => {
 		let component = mount(PermissionsEditor, {
 			...mountOptions,
 			props: {
-				modelValue: { 0: 1 << 0 },
+				modelValue: new Grants({ 0: 1 << 0 }),
 			},
 		}).vm;
 		expect(

--- a/server/api/room.ts
+++ b/server/api/room.ts
@@ -94,6 +94,7 @@ const generateRoom: RequestHandler<unknown, OttResponseBody<OttApiResponseRoomGe
 	await roommanager.createRoom({
 		name: roomName,
 		isTemporary: true,
+		owner: req.user,
 	});
 	log.info(`room generated: ip=${req.ip} user-agent=${req.headers["user-agent"]}`);
 	res.json({

--- a/server/api/room.ts
+++ b/server/api/room.ts
@@ -240,6 +240,7 @@ const patchRoom: RequestHandler = async (req, res) => {
 
 	if (req.body.claim && !room.owner) {
 		if (req.user) {
+			log.info(`Room ${room.name} claimed by ${req.user.username} (${req.user.id})`);
 			room.owner = req.user;
 			// HACK: force the room to send the updated user info to the client
 			for (const user of room.realusers) {

--- a/server/room.ts
+++ b/server/room.ts
@@ -473,7 +473,7 @@ export class Room implements RoomState {
 
 	getRoleFromSession(session: SessionInfo): Role {
 		if (session && "user_id" in session) {
-			if (this.owner !== null && this.owner.id === session.user_id) {
+			if (this.owner && this.owner.id === session.user_id) {
 				return Role.Owner;
 			}
 			for (let i = Role.Administrator; i >= Role.TrustedUser; i--) {


### PR DESCRIPTION
- set owner when generating rooms
- allow editing permissions on temporary rooms
- allow claiming temporary rooms
- don't omit grants from room settings form submission
- fix a crash
- remove workaround
- refactor `PermissionsEditor` to use `Grants` class

closes #906 
