### PR TITLE
Automatically save the current queue when the room is unloaded, and have the option to restore it

### DIFF
--- a/client/src/components/RestoreQueue.vue
+++ b/client/src/components/RestoreQueue.vue
@@ -5,7 +5,7 @@
 			color="primary"
 			:text="$t('video-queue.restore')"
 			:stacked="false"
-			v-if="!!store.state.prevQueue"
+			v-if="(store.state.room.prevQueue?.length ?? 0) > 0"
 		>
 			<template v-slot:actions>
 				<v-btn color="primary" @click="restore">{{ $t("common.show") }}</v-btn>

--- a/client/src/components/RestoreQueue.vue
+++ b/client/src/components/RestoreQueue.vue
@@ -1,46 +1,80 @@
 <template>
-	<Transition name="restore">
-		<v-banner
-			class="restore"
-			color="primary"
-			:text="$t('video-queue.restore')"
-			:stacked="false"
-			lines="one"
-			sticky
-			v-if="(store.state.room.prevQueue?.length ?? 0) > 0"
-		>
-			<template v-slot:actions>
-				<v-btn color="primary" @click="restore">{{ $t("common.show") }}</v-btn>
-				<v-btn color="default" @click="discard">{{ $t("common.discard") }}</v-btn>
-			</template>
-		</v-banner>
-	</Transition>
+	<div>
+		<Transition name="restore">
+			<v-banner
+				class="restore"
+				color="primary"
+				:text="$t('video-queue.restore')"
+				:stacked="false"
+				lines="one"
+				sticky
+				v-if="(store.state.room.prevQueue?.length ?? 0) > 0"
+			>
+				<template v-slot:actions>
+					<v-btn color="primary" @click="showDialog">{{ $t("common.show") }}</v-btn>
+					<v-btn color="default" @click="discard">{{ $t("common.discard") }}</v-btn>
+				</template>
+			</v-banner>
+		</Transition>
+		<v-dialog v-model="showRestorePreview" transition="dialog-bottom-transition" width="auto">
+			<v-card>
+				<v-card-title>
+					{{ $t("video-queue.restore-queue") }}
+				</v-card-title>
+				<v-card-text>
+					<div>{{ $t("video-queue.restore-queue-hint") }}</div>
+					<div v-for="video in store.state.room.prevQueue" :key="video.id">
+						<VideoQueueItem :item="video" :hide-all-buttons="true" />
+					</div>
+				</v-card-text>
+				<v-card-actions>
+					<v-btn color="primary" @click="restore">{{ $t("common.restore") }}</v-btn>
+					<v-btn @click="discard">{{ $t("common.discard") }}</v-btn>
+				</v-card-actions>
+			</v-card>
+		</v-dialog>
+	</div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, ref } from "vue";
 import { useStore } from "../store";
 import { useConnection } from "@/plugins/connection";
 import { useRoomApi } from "@/util/roomapi";
+import VideoQueueItem from "./VideoQueueItem.vue";
 
 export default defineComponent({
 	name: "RestoreQueue",
+	components: {
+		VideoQueueItem,
+	},
 	setup() {
 		const store = useStore();
 		const connection = useConnection();
 		const roomapi = useRoomApi(connection);
 
+		const showRestorePreview = ref(false);
+
+		function showDialog() {
+			showRestorePreview.value = true;
+		}
+
 		function restore() {
 			roomapi.restoreQueue();
+			showRestorePreview.value = false;
 		}
 
 		function discard() {
 			roomapi.restoreQueue({ discard: true });
+			showRestorePreview.value = false;
 		}
 
 		return {
 			store,
 
+			showRestorePreview,
+
+			showDialog,
 			restore,
 			discard,
 		};

--- a/client/src/components/RestoreQueue.vue
+++ b/client/src/components/RestoreQueue.vue
@@ -1,0 +1,60 @@
+<template>
+	<Transition name="restore">
+		<v-banner
+			class="restore"
+			color="primary"
+			:text="$t('video-queue.restore')"
+			:stacked="false"
+			v-if="!!store.state.prevQueue"
+		>
+			<template v-slot:actions>
+				<v-btn color="primary" @click="restore">{{ $t("common.show") }}</v-btn>
+				<v-btn color="default" @click="discard">{{ $t("common.discard") }}</v-btn>
+			</template>
+		</v-banner>
+	</Transition>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { useStore } from "../store";
+import { useConnection } from "@/plugins/connection";
+import { useRoomApi } from "@/util/roomapi";
+
+export default defineComponent({
+	name: "RestoreQueue",
+	setup() {
+		const store = useStore();
+		const connection = useConnection();
+		const roomapi = useRoomApi(connection);
+
+		function restore() {
+			roomapi.restoreQueue();
+		}
+
+		function discard() {
+			roomapi.restoreQueue({ discard: true });
+		}
+
+		return {
+			store,
+
+			restore,
+			discard,
+		};
+	},
+});
+</script>
+
+<style lang="scss">
+.restore-enter-active,
+.restore-leave-active {
+	transition: all 0.5s;
+}
+
+.restore-enter,
+.restore-leave-to {
+	opacity: 0;
+	transform: translateY(100%);
+}
+</style>

--- a/client/src/components/RestoreQueue.vue
+++ b/client/src/components/RestoreQueue.vue
@@ -5,6 +5,8 @@
 			color="primary"
 			:text="$t('video-queue.restore')"
 			:stacked="false"
+			lines="one"
+			sticky
 			v-if="(store.state.room.prevQueue?.length ?? 0) > 0"
 		>
 			<template v-slot:actions>
@@ -55,6 +57,16 @@ export default defineComponent({
 .restore-enter,
 .restore-leave-to {
 	opacity: 0;
-	transform: translateY(100%);
+	transform: scaleY(0);
+}
+
+.restore-enter-to,
+.restore-leave {
+	opacity: 1;
+	transform: scaleY(100%);
+}
+
+.restore {
+	margin-top: 10px;
 }
 </style>

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -29,7 +29,7 @@
 			</div>
 		</div>
 		<div class="d-flex" style="justify-content: center; flex-direction: column">
-			<div class="button-container">
+			<div class="button-container" v-if="!hideAllButtons">
 				<v-btn
 					class="button-with-icon"
 					@click="vote"
@@ -164,6 +164,7 @@ import { useConnection } from "@/plugins/connection";
 interface VideoQueueItemProps {
 	item: QueueItem;
 	isPreview: boolean;
+	hideAllButtons: boolean;
 	index: number;
 }
 
@@ -172,6 +173,7 @@ const VideoQueueItem = defineComponent({
 	props: {
 		item: { type: Object as PropType<QueueItem>, required: true },
 		isPreview: { type: Boolean, default: false },
+		hideAllButtons: { type: Boolean, default: false },
 		index: { type: Number, required: false },
 	},
 	setup(props: VideoQueueItemProps) {

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -22,6 +22,7 @@ export default {
 		"discard": "Discard",
 		"loading": "Loading...",
 		"view": "View",
+		"restore": "Restore",
 	},
 	"landing": {
 		hero: {
@@ -203,6 +204,9 @@ export default {
 		"export-diag-title": "Export Queue",
 		"export-hint": 'Copy and paste this text into the "Add" tab to restore this queue.',
 		"restore": "Would you like to restore the videos from the previous queue?",
+		"restore-queue": "Restore Queue?",
+		"restore-queue-hint":
+			"This is what was in the queue last time this room was active. Would you like to restore it?",
 	},
 	"video-queue-item": {
 		"experimental": "Experimental support for this service! Expect it to break a lot.",

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -17,6 +17,11 @@ export default {
 		"search": "Search",
 		"undo": "Undo",
 		"copy": "Copy",
+		"show": "Show",
+		"hide": "Hide",
+		"discard": "Discard",
+		"loading": "Loading...",
+		"view": "View",
 	},
 	"landing": {
 		hero: {
@@ -197,6 +202,7 @@ export default {
 		"export": "Export",
 		"export-diag-title": "Export Queue",
 		"export-hint": 'Copy and paste this text into the "Add" tab to restore this queue.',
+		"restore": "Would you like to restore the videos from the previous queue?",
 	},
 	"video-queue-item": {
 		"experimental": "Experimental support for this service! Expect it to break a lot.",

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -45,6 +45,7 @@ interface BaseStoreState {
 			category: string;
 		}[];
 		grants: Grants;
+		prevQueue: QueueItem[] | null;
 	};
 
 	keepAliveInterval: number | null;
@@ -94,6 +95,7 @@ export function buildNewStore() {
 					voteCounts: undefined,
 					playbackStartTime: undefined,
 					grants: new Grants(),
+					prevQueue: null,
 				},
 
 				keepAliveInterval: null,

--- a/client/src/util/roomapi.ts
+++ b/client/src/util/roomapi.ts
@@ -131,4 +131,14 @@ class RoomApi {
 			},
 		});
 	}
+
+	restoreQueue(options?: { discard?: boolean }) {
+		this.connection.send({
+			action: "req",
+			request: {
+				type: RoomRequestType.RestoreQueueRequest,
+				discard: options?.discard,
+			},
+		});
+	}
 }

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -32,6 +32,7 @@
 						:style="{ padding: store.state.fullscreen ? 0 : 'inherit' }"
 					>
 						<div class="player-container">
+							<RestoreQueue />
 							<OmniPlayer
 								ref="player"
 								:source="store.state.room.currentSource"
@@ -223,6 +224,7 @@ import { useScreenOrientation, useMouse } from "@vueuse/core";
 import { KeyboardShortcuts, RoomKeyboardShortcutsKey } from "@/util/keyboard-shortcuts";
 import VideoControls from "@/components/controls/VideoControls.vue";
 import { VOLUME_KEY } from "@/components/controls/controlkeys";
+import RestoreQueue from "@/components/RestoreQueue.vue";
 
 const VIDEO_CONTROLS_HIDE_TIMEOUT = 3000;
 
@@ -241,6 +243,7 @@ export default defineComponent({
 		RoomDisconnected,
 		ServerMessageHandler,
 		WorkaroundPlaybackStatusUpdater,
+		RestoreQueue,
 	},
 	setup() {
 		const store = useStore();

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -26,13 +26,13 @@
 				<span id="connectStatus">{{ connectionStatus }}</span>
 			</div>
 			<v-col :style="{ padding: store.state.fullscreen ? 0 : 'inherit' }">
+				<RestoreQueue />
 				<div no-gutters class="video-container">
 					<div
 						class="video-subcontainer"
 						:style="{ padding: store.state.fullscreen ? 0 : 'inherit' }"
 					>
 						<div class="player-container">
-							<RestoreQueue />
 							<OmniPlayer
 								ref="player"
 								:source="store.state.room.currentSource"

--- a/common/models/messages.ts
+++ b/common/models/messages.ts
@@ -180,7 +180,8 @@ export type RoomRequest =
 	| ApplySettingsRequest
 	| PlayNowRequest
 	| ShuffleRequest
-	| PlaybackSpeedRequest;
+	| PlaybackSpeedRequest
+	| RestoreQueueRequest;
 
 export enum RoomRequestType {
 	JoinRequest,
@@ -200,6 +201,7 @@ export enum RoomRequestType {
 	PlayNowRequest,
 	ShuffleRequest,
 	PlaybackSpeedRequest,
+	RestoreQueueRequest,
 }
 
 export interface RoomRequestBase {
@@ -301,4 +303,9 @@ export interface ShuffleRequest extends RoomRequestBase {
 export interface PlaybackSpeedRequest extends RoomRequestBase {
 	type: RoomRequestType.PlaybackSpeedRequest;
 	speed: number;
+}
+
+export interface RestoreQueueRequest extends RoomRequestBase {
+	type: RoomRequestType.RestoreQueueRequest;
+	discard?: boolean;
 }

--- a/common/models/types.ts
+++ b/common/models/types.ts
@@ -1,5 +1,5 @@
 import { Session } from "express-session";
-import { Video } from "./video";
+import { QueueItem, Video } from "./video";
 import { Grants } from "../permissions";
 import type { Segment } from "sponsorblock-api";
 
@@ -61,6 +61,8 @@ export interface RoomOptions extends RoomSettings {
 	isTemporary: boolean
 	owner: UserAccountAttributes | null
 	userRoles: Map<Role, Set<number>>
+	/** The queue as it was when the room was last unloaded. */
+	prevQueue: QueueItem[] | null;
 }
 
 export type RoomUserInfo = {

--- a/server/migrations/20230628203138-add-prev-queue-to-room.js
+++ b/server/migrations/20230628203138-add-prev-queue-to-room.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		await queryInterface.addColumn("rooms", "prevQueue", {
+			type: Sequelize.JSONB,
+			allowNull: true,
+		});
+	},
+
+	async down(queryInterface, Sequelize) {
+		await queryInterface.removeColumn("rooms", "prevQueue");
+	},
+};

--- a/server/models/room.ts
+++ b/server/models/room.ts
@@ -4,6 +4,7 @@ import { QueueMode, Visibility, Role } from "../../common/models/types";
 import { User } from "./user";
 import { ROOM_NAME_REGEX } from "../../common/constants";
 import type { OldRoleGrants, GrantMask } from "../../common/permissions";
+import { QueueItem } from "../../common/models/video";
 
 export interface RoomAttributes {
 	"id": number;
@@ -18,6 +19,7 @@ export interface RoomAttributes {
 	"role-mod": Array<number>;
 	"role-trusted": Array<number>;
 	"autoSkipSegments": boolean;
+	"prevQueue": Array<QueueItem> | null;
 }
 
 type RoomCreationAttributes = Optional<RoomAttributes, "id">;
@@ -38,6 +40,7 @@ export class Room extends Model<RoomAttributes, RoomCreationAttributes> implemen
 	declare "role-mod": Array<number>;
 	declare "role-trusted": Array<number>;
 	declare "autoSkipSegments": boolean;
+	declare "prevQueue": Array<QueueItem> | null;
 }
 
 export const createModel = (sequelize: Sequelize) => {
@@ -95,6 +98,10 @@ export const createModel = (sequelize: Sequelize) => {
 				type: DataTypes.BOOLEAN,
 				allowNull: false,
 				defaultValue: true,
+			},
+			"prevQueue": {
+				type: DataTypes.JSONB,
+				allowNull: true,
 			},
 		},
 		{

--- a/server/room.ts
+++ b/server/room.ts
@@ -172,6 +172,7 @@ export class Room implements RoomState {
 
 	_currentSource: QueueItem | null = null;
 	queue: VideoQueue;
+	prevQueue: QueueItem[] | null = null;
 	_isPlaying = false;
 	_playbackPosition = 0;
 	_playbackSpeed = 1;
@@ -219,7 +220,8 @@ export class Room implements RoomState {
 				"playbackPosition",
 				"isPlaying",
 				"playbackSpeed",
-				"autoSkipSegments"
+				"autoSkipSegments",
+				"prevQueue"
 			)
 		);
 		if (Array.isArray(this.queue)) {
@@ -711,7 +713,8 @@ export class Room implements RoomState {
 			"owner",
 			"_playbackStart",
 			"videoSegments",
-			"autoSkipSegments"
+			"autoSkipSegments",
+			"prevQueue"
 		);
 
 		return JSON.stringify(state, replacer);
@@ -736,7 +739,8 @@ export class Room implements RoomState {
 			"hasOwner",
 			"voteCounts",
 			"videoSegments",
-			"autoSkipSegments"
+			"autoSkipSegments",
+			"prevQueue"
 		);
 
 		return JSON.stringify(state, replacer);
@@ -770,7 +774,8 @@ export class Room implements RoomState {
 			"voteCounts",
 			"hasOwner",
 			"videoSegments",
-			"autoSkipSegments"
+			"autoSkipSegments",
+			"prevQueue"
 		);
 
 		msg = Object.assign(msg, _.pick(state, Array.from(this._dirty)));
@@ -788,7 +793,8 @@ export class Room implements RoomState {
 			"autoSkipSegments",
 			"grants",
 			"userRoles",
-			"owner"
+			"owner",
+			"prevQueue"
 		);
 		if (!_.isEmpty(settings)) {
 			await storage.updateRoom({
@@ -810,7 +816,14 @@ export class Room implements RoomState {
 		});
 	}
 
-	public async onBeforeUnload(): Promise<void> {}
+	public async onBeforeUnload(): Promise<void> {
+		if (!this.isTemporary) {
+			await storage.updateRoom({
+				name: this.name,
+				prevQueue: this.queue.length > 0 ? this.queue.items : null,
+			});
+		}
+	}
 
 	/**
 	 * If true, the room is stale, and should be unloaded.

--- a/server/room.ts
+++ b/server/room.ts
@@ -818,9 +818,17 @@ export class Room implements RoomState {
 
 	public async onBeforeUnload(): Promise<void> {
 		if (!this.isTemporary) {
+			const prevQueue = this.queue.items;
+			if (this.currentSource) {
+				prevQueue.unshift({
+					...this.currentSource,
+					startAt: this.realPlaybackPosition,
+				});
+			}
+
 			await storage.updateRoom({
 				name: this.name,
-				prevQueue: this.queue.length > 0 ? this.queue.items : null,
+				prevQueue: prevQueue.length > 0 ? prevQueue : null,
 			});
 		}
 	}

--- a/server/room.ts
+++ b/server/room.ts
@@ -64,6 +64,7 @@ import { VideoQueue } from "./videoqueue";
 import { Counter } from "prom-client";
 import roommanager from "./roommanager";
 import { calculateCurrentPosition } from "../common/timestamp";
+import { RestoreQueueRequest } from "../common/models/messages";
 
 const set = promisify(redisClient.set).bind(redisClient);
 const ROOM_UNLOAD_AFTER = 240; // seconds
@@ -172,7 +173,7 @@ export class Room implements RoomState {
 
 	_currentSource: QueueItem | null = null;
 	queue: VideoQueue;
-	prevQueue: QueueItem[] | null = null;
+	_prevQueue: QueueItem[] | null = null;
 	_isPlaying = false;
 	_playbackPosition = 0;
 	_playbackSpeed = 1;
@@ -369,6 +370,15 @@ export class Room implements RoomState {
 	public set videoSegments(value: Segment[]) {
 		this._videoSegments = value;
 		this.markDirty("videoSegments");
+	}
+
+	public get prevQueue(): QueueItem[] | null {
+		return this._prevQueue;
+	}
+
+	public set prevQueue(value: QueueItem[] | null) {
+		this._prevQueue = value;
+		this.markDirty("prevQueue");
 	}
 
 	get users(): RoomUserInfo[] {
@@ -980,6 +990,7 @@ export class Room implements RoomState {
 			[RoomRequestType.PlayNowRequest]: "playNow",
 			[RoomRequestType.ShuffleRequest]: "shuffle",
 			[RoomRequestType.PlaybackSpeedRequest]: "setPlaybackSpeed",
+			[RoomRequestType.RestoreQueueRequest]: "restoreQueue",
 		};
 
 		const handler = handlers[request.type];
@@ -1107,6 +1118,7 @@ export class Room implements RoomState {
 			}
 			this.queue.enqueue(video);
 			this.log.info(`Video added: ${JSON.stringify(request.video)}`);
+			this.prevQueue = null;
 			await this.publishRoomEvent(request, context, { video });
 			counterMediaQueued.labels({ service: video.service }).inc();
 		} else if (request.videos) {
@@ -1516,6 +1528,24 @@ export class Room implements RoomState {
 
 		this.flushPlaybackPosition();
 		this.playbackSpeed = request.speed;
+	}
+
+	public async restoreQueue(
+		request: RestoreQueueRequest,
+		_context: RoomRequestContext
+	): Promise<void> {
+		if (this.prevQueue === null) {
+			throw new Error("No previous queue to restore");
+		}
+
+		if (request.discard) {
+			this.log.debug("Discarding previous queue");
+			this.prevQueue = null;
+			return;
+		} else {
+			await this.queue.enqueue(...this.prevQueue);
+			this.prevQueue = null;
+		}
 	}
 }
 

--- a/server/room.ts
+++ b/server/room.ts
@@ -377,6 +377,9 @@ export class Room implements RoomState {
 	}
 
 	public set prevQueue(value: QueueItem[] | null) {
+		if (value === null && this._prevQueue === null) {
+			return;
+		}
 		this._prevQueue = value;
 		this.markDirty("prevQueue");
 	}

--- a/server/storage/room.ts
+++ b/server/storage/room.ts
@@ -105,6 +105,7 @@ function dbToRoomArgs(db: DbRoom): RoomOptions {
 		grants: new permissions.Grants(db.permissions),
 		userRoles: new Map<Role, Set<number>>(),
 		autoSkipSegments: db.autoSkipSegments,
+		prevQueue: db.prevQueue,
 	};
 	for (let i = Role.TrustedUser; i <= 4; i++) {
 		room.userRoles.set(i, new Set(db[`role-${permissions.ROLE_NAMES[i]}`]));
@@ -133,6 +134,7 @@ export function roomToDb(room: RoomStatePersistable): Omit<RoomAttributes, "id">
 		"role-trusted": [],
 		"role-mod": [],
 		"role-admin": [],
+		"prevQueue": room.prevQueue,
 	};
 	if (room.owner) {
 		db.ownerId = room.owner.id;
@@ -160,6 +162,7 @@ export function roomToDbPartial(
 			visibility: room.visibility,
 			queueMode: room.queueMode,
 			autoSkipSegments: room.autoSkipSegments,
+			prevQueue: room.prevQueue,
 		},
 		v => !!v
 	);

--- a/server/tests/unit/room.spec.ts
+++ b/server/tests/unit/room.spec.ts
@@ -297,6 +297,47 @@ describe("Room", () => {
 				expect(room.playbackSpeed).toEqual(1);
 			});
 		});
+
+		describe("RestoreQueueRequest", () => {
+			it("should restore the queue", async () => {
+				const prevQueue = [
+					{ service: "fakeservice", id: "video1" },
+					{ service: "fakeservice", id: "video2" },
+					{ service: "fakeservice", id: "video3" },
+					{ service: "fakeservice", id: "video4" },
+					{ service: "fakeservice", id: "video5" },
+				];
+				room.prevQueue = _.cloneDeep(prevQueue);
+				await room.processRequest(
+					{
+						type: RoomRequestType.RestoreQueueRequest,
+					},
+					{ username: "test", role: Role.Owner, clientId: "1234" }
+				);
+				expect(room.queue.items).toEqual(prevQueue);
+				expect(room.prevQueue).toBeNull();
+			});
+
+			it("should discard the queue", async () => {
+				room.prevQueue = [
+					{ service: "fakeservice", id: "video1" },
+					{ service: "fakeservice", id: "video2" },
+					{ service: "fakeservice", id: "video3" },
+					{ service: "fakeservice", id: "video4" },
+					{ service: "fakeservice", id: "video5" },
+				];
+				await room.processRequest(
+					{
+						type: RoomRequestType.RestoreQueueRequest,
+						discard: true,
+					},
+					{ username: "test", role: Role.Owner, clientId: "1234" }
+				);
+				expect(room.queue.items).not.toEqual(room.prevQueue);
+				expect(room.queue.items).toEqual([]);
+				expect(room.prevQueue).toBeNull();
+			});
+		});
 	});
 
 	describe("auto dequeuing next video", () => {


### PR DESCRIPTION
- add storage for saving previous queue
- have it save the previous queue to storage when the room is unloaded
- include currentSource when saving previous queue
- add room request for restoring the queue
- server side business logic for handling previous queue
- avoid some unnecessary dirtying for prevQueue
- add a couple unit tests
- add some i18n strings
- add prevQueue to store
- add RestoreQueue component
- fix condition
- make restore queue UI work
- add a dialog to preview restoring the queue

closes #927
