### PR TITLE
Minor refactor to the join process

### DIFF
--- a/common/models/messages.ts
+++ b/common/models/messages.ts
@@ -153,6 +153,7 @@ export interface ClientMessageRoomRequest extends ClientMessageBase {
  */
 export interface RoomRequestAuthorization {
 	token: AuthToken;
+	clientId: ClientId;
 }
 
 /**

--- a/common/models/messages.ts
+++ b/common/models/messages.ts
@@ -153,7 +153,7 @@ export interface ClientMessageRoomRequest extends ClientMessageBase {
  */
 export interface RoomRequestAuthorization {
 	token: AuthToken;
-	clientId: ClientId;
+	clientId?: ClientId;
 }
 
 /**
@@ -164,6 +164,7 @@ export interface RoomRequestContext {
 	role: Role;
 	/** If the user is connected to the room, then we can use it's client id to identify the websocket connection. */
 	clientId?: ClientId;
+	auth?: RoomRequestAuthorization;
 }
 
 export type RoomRequest =
@@ -213,10 +214,6 @@ export interface RoomRequestBase {
 
 export interface JoinRequest extends RoomRequestBase {
 	type: RoomRequestType.JoinRequest;
-	/**
-	 * We need to know the user's token when they join the room in order to authorize their later requests without pinging redis.
-	 */
-	token: AuthToken;
 	info: ClientInfo;
 }
 

--- a/server/api/dev.ts
+++ b/server/api/dev.ts
@@ -53,7 +53,6 @@ router.post("/room/:name/add-fake-user", async (req, res) => {
 		await room.processUnauthorizedRequest(
 			{
 				type: RoomRequestType.JoinRequest,
-				token: token,
 				info: {
 					id: "fake",
 					user_id: user ? user.id : undefined,

--- a/server/clientmanager.ts
+++ b/server/clientmanager.ts
@@ -287,6 +287,7 @@ async function makeRoomRequest(client: Client, request: RoomRequest): Promise<vo
 	const room = result.value;
 	await room.processUnauthorizedRequest(request, {
 		token: client.token,
+		clientId: client.id,
 	});
 }
 

--- a/server/clientmanager.ts
+++ b/server/clientmanager.ts
@@ -108,7 +108,6 @@ async function onClientAuth(client: Client, token: AuthToken, session: SessionIn
 	try {
 		await makeRoomRequest(client, {
 			type: RoomRequestType.JoinRequest,
-			token: token,
 			info: client.getClientInfo(),
 		});
 	} catch (e) {

--- a/server/room.ts
+++ b/server/room.ts
@@ -521,7 +521,7 @@ export class Room implements RoomState {
 		const user = this.getUserInfo(context.clientId);
 		await this.publish({
 			action: "event",
-			request: _.omit(request, "token") as RoomRequest,
+			request,
 			user,
 			additional: additional ?? {},
 		});


### PR DESCRIPTION
- optimize deriveRequestContext
- remove `token` field from `JoinRequest`
- Revert "hotfix to stop leaking auth tokens to other users (#968)"
