### PR TITLE
Add automated account recovery via email verification

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -244,6 +244,11 @@ export default App;
 <style lang="scss">
 @import "variables.scss";
 
+.link {
+	text-decoration: underline;
+	cursor: pointer;
+}
+
 .link-invis {
 	text-decoration: none;
 	color: inherit !important;

--- a/client/src/components/ForgotPassword.vue
+++ b/client/src/components/ForgotPassword.vue
@@ -56,6 +56,8 @@ const username = ref("");
 const showForgotPassword = ref(false);
 const isLoading = ref(false);
 
+const emit = defineEmits(["password-reset"]);
+
 async function startPasswordReset() {
 	isLoading.value = true;
 	try {
@@ -72,11 +74,14 @@ async function startPasswordReset() {
 			toast.add({
 				style: ToastStyle.Success,
 				content: i18n.t("login-form.change-password.sent"),
+				duration: 5000,
 			});
+			emit("password-reset");
 		} else {
 			toast.add({
 				style: ToastStyle.Error,
 				content: i18n.t("login-form.change-password.failed"),
+				duration: 5000,
 			});
 		}
 	} catch (e) {

--- a/client/src/components/ForgotPassword.vue
+++ b/client/src/components/ForgotPassword.vue
@@ -1,0 +1,92 @@
+<template>
+	<a @click.prevent class="link text-primary">
+		{{ $t("login-form.change-password.forgot") }}
+
+		<v-dialog activator="parent" v-model="showForgotPassword" width="400">
+			<v-container>
+				<v-card>
+					<v-card-title>
+						{{ $t("login-form.change-password.forgot") }}
+					</v-card-title>
+					<v-form @submit="startPasswordReset">
+						<v-card-text>
+							{{ $t("login-form.change-password.prompt") }}
+							<v-text-field
+								:loading="isLoading"
+								:label="$t('login-form.email')"
+								v-model="email"
+							/>
+							<v-text-field
+								:loading="isLoading"
+								:label="$t('login-form.username')"
+								v-model="username"
+							/>
+						</v-card-text>
+						<v-card-actions>
+							<v-spacer />
+							<v-btn
+								type="submit"
+								color="primary"
+								@click.prevent="startPasswordReset"
+								:loading="isLoading"
+							>
+								{{ $t("login-form.change-password.reset") }}
+							</v-btn>
+						</v-card-actions>
+					</v-form>
+				</v-card>
+			</v-container>
+		</v-dialog>
+	</a>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+import type { OttResponseBody } from "ott-common/models/rest-api";
+import toast from "@/util/toast";
+import { ToastStyle } from "@/models/toast";
+import { API } from "@/common-http";
+import { useI18n } from "vue-i18n";
+
+const i18n = useI18n();
+
+const email = ref("");
+const username = ref("");
+
+const showForgotPassword = ref(false);
+const isLoading = ref(false);
+
+async function startPasswordReset() {
+	isLoading.value = true;
+	try {
+		const resp = await API.post<OttResponseBody>("/user/recover/start", {
+			email: email.value ? email.value : undefined,
+			username: username.value ? username.value : undefined,
+		});
+
+		if (resp.data.success) {
+			showForgotPassword.value = false;
+
+			email.value = "";
+			username.value = "";
+			toast.add({
+				style: ToastStyle.Success,
+				content: i18n.t("login-form.change-password.sent"),
+			});
+		} else {
+			toast.add({
+				style: ToastStyle.Error,
+				content: i18n.t("login-form.change-password.failed"),
+			});
+		}
+	} catch (e) {
+		toast.add({
+			style: ToastStyle.Error,
+			content: i18n.t("login-form.change-password.failed"),
+		});
+		return;
+	} finally {
+		isLoading.value = false;
+	}
+}
+</script>

--- a/client/src/components/LogInForm.vue
+++ b/client/src/components/LogInForm.vue
@@ -53,7 +53,9 @@
 													:error-messages="logInFailureMessage"
 													data-cy="login-password"
 												/>
-												<ForgotPassword />
+												<ForgotPassword
+													@password-reset="$emit('shouldClose')"
+												/>
 											</v-col>
 										</v-row>
 										<v-row v-if="logInFailureMessage">

--- a/client/src/components/LogInForm.vue
+++ b/client/src/components/LogInForm.vue
@@ -53,6 +53,7 @@
 													:error-messages="logInFailureMessage"
 													data-cy="login-password"
 												/>
+												<ForgotPassword />
 											</v-col>
 										</v-row>
 										<v-row v-if="logInFailureMessage">
@@ -144,8 +145,9 @@
 								@click.prevent="register"
 								:disabled="!registerValid"
 								data-cy="register-button"
-								>{{ $t("login-form.register") }}</v-btn
 							>
+								{{ $t("login-form.register") }}
+							</v-btn>
 						</v-card-actions>
 					</v-form>
 				</v-card>
@@ -163,10 +165,14 @@ import { useStore } from "@/store";
 import { useI18n } from "vue-i18n";
 import { VForm } from "vuetify/lib/components/VForm/VForm.mjs";
 import { goLoginDiscord } from "@/util/discord";
+import ForgotPassword from "./ForgotPassword.vue";
 
 const LogInForm = defineComponent({
 	name: "LogInForm",
 	emits: ["shouldClose"],
+	components: {
+		ForgotPassword,
+	},
 	setup(props, { emit }) {
 		const store = useStore();
 		const { t } = useI18n();

--- a/client/src/components/ProcessedText.vue
+++ b/client/src/components/ProcessedText.vue
@@ -101,8 +101,4 @@ export default ProcessedText;
 
 <style lang="scss" scoped>
 @import "../variables.scss";
-
-.link {
-	text-decoration: underline;
-}
 </style>

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -23,6 +23,7 @@ export default {
 		"loading": "Loading...",
 		"view": "View",
 		"restore": "Restore",
+		"success": "Success",
 	},
 	"behavior": {
 		[BehaviorOption.Always]: "Always",
@@ -294,7 +295,7 @@ export default {
 		"password": "Password",
 		"retype-password": "Retype Password",
 		"email-optional":
-			"Providing an email is optional, but recommended in case you forget your password.",
+			"Providing an email is optional, but makes it impossible to recover your account if you forget your password.",
 		"rules": {
 			"email-required": "Email is required",
 			"valid-email": "Must be a valid email",
@@ -316,6 +317,15 @@ export default {
 			"register-failed":
 				"Failed to register, and I don't know why. Check the console and report this as a bug.",
 			"in-use": "Already in use.",
+		},
+		"change-password": {
+			title: "Change Password",
+			success: "Password change successful.",
+			forgot: "Forgot your password?",
+			prompt: "Enter the email address or the username associated with your account.",
+			reset: "Reset",
+			sent: "Password reset email sent.",
+			failed: "Unable to reset password.",
 		},
 	},
 	"permissions-editor": {

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -35,6 +35,10 @@ export const routes: RouteRecordRaw[] = [
 		redirect: "/room/:roomId",
 	},
 	{
+		path: "/passwordreset",
+		component: () => import("./views/PasswordReset.vue"),
+	},
+	{
 		path: "/:catchAll(.*)",
 		name: "not-found",
 		component: () => import("./views/NotFound.vue"),

--- a/client/src/views/PasswordReset.vue
+++ b/client/src/views/PasswordReset.vue
@@ -16,7 +16,7 @@
 				required
 				:rules="passwordConfirmRules"
 			/>
-			<v-btn type="submit" color="primary">
+			<v-btn type="submit" color="primary" @click.prevent="submitPasswordReset">
 				{{ $t("common.save") }}
 			</v-btn>
 		</v-form>

--- a/client/src/views/PasswordReset.vue
+++ b/client/src/views/PasswordReset.vue
@@ -1,0 +1,85 @@
+<template>
+	<v-container>
+		<v-form @submit="submitPasswordReset">
+			<h1>{{ $t("login-form.change-password.title") }}</h1>
+			<v-text-field
+				v-model="password"
+				:label="$t('login-form.password')"
+				type="password"
+				required
+				:rules="passwordRules"
+			/>
+			<v-text-field
+				v-model="passwordConfirm"
+				:label="$t('login-form.retype-password')"
+				type="password"
+				required
+				:rules="passwordConfirmRules"
+			/>
+			<v-btn type="submit" color="primary">
+				{{ $t("common.save") }}
+			</v-btn>
+		</v-form>
+	</v-container>
+</template>
+
+<script lang="ts" setup>
+import { onMounted, ref } from "vue";
+import { API } from "@/common-http";
+import { useRoute, useRouter } from "vue-router";
+import { OttResponseBody } from "ott-common/models/rest-api";
+import { useI18n } from "vue-i18n";
+import { useStore } from "@/store";
+import toast from "@/util/toast";
+import { ToastStyle } from "@/models/toast";
+
+const router = useRouter();
+const route = useRoute();
+const i18n = useI18n();
+const store = useStore();
+
+const verifyKey = ref(route.query.verifyKey);
+const password = ref("");
+const passwordConfirm = ref("");
+
+const passwordRules = [v => !!v || i18n.t("login-form.rules.password-required")];
+
+const passwordConfirmRules = [
+	v => !!v || i18n.t("login-form.rules.password-required"),
+	v => (v && v === password.value) || i18n.t("login-form.rules.passwords-match"),
+];
+
+onMounted(async () => {
+	if (!verifyKey.value) {
+		console.error("No verify key provided");
+		router.push("/");
+	}
+});
+
+async function submitPasswordReset() {
+	if (password.value !== passwordConfirm.value) {
+		console.error("Passwords do not match");
+		return;
+	}
+
+	const resp = await API.post<OttResponseBody>("/user/recovery/verify", {
+		verifyKey: verifyKey.value,
+	});
+
+	if (resp.data.success) {
+		toast.add({
+			style: ToastStyle.Success,
+			content: i18n.t("login-form.change-password.success"),
+		});
+		const resp = await API.get("/user");
+		if (resp.data.loggedIn) {
+			const user = resp.data;
+			delete user.loggedIn;
+			store.commit("LOGIN", user);
+		} else {
+			console.warn("Didn't get logged in user after password reset.");
+		}
+		router.push("/");
+	}
+}
+</script>

--- a/common/exceptions.ts
+++ b/common/exceptions.ts
@@ -1,6 +1,17 @@
 import { Role } from "./models/types";
 
-export class OttException extends Error {}
+export class OttException extends Error {
+	constructor(message?: string) {
+		super(message);
+	}
+
+	toJSON() {
+		return {
+			...this,
+			message: this.message,
+		};
+	}
+}
 
 export class PermissionDeniedException extends OttException {
 	name = "PermissionDeniedException";

--- a/common/models/rest-api.ts
+++ b/common/models/rest-api.ts
@@ -72,3 +72,13 @@ export type OttApiRequestRemoveFromQueue = VideoId;
 export type OttApiResponseAddPreview = {
 	result: Video[];
 };
+
+export type OttApiRequestAccountRecoveryStart = {
+	email?: string;
+	username?: string;
+};
+
+export type OttApiRequestAccountRecoveryVerify = {
+	verifyKey: string;
+	newPassword: string;
+};

--- a/server/exceptions.ts
+++ b/server/exceptions.ts
@@ -201,3 +201,17 @@ export class MissingToken extends OttException {
 		this.name = "MissingToken";
 	}
 }
+
+export class NoEmail extends OttException {
+	constructor() {
+		super("The account does not have an email address.");
+		this.name = "NoEmail";
+	}
+}
+
+export class InvalidVerifyKey extends OttException {
+	constructor() {
+		super("Invalid verify key");
+		this.name = "InvalidVerifyKey";
+	}
+}

--- a/server/exceptions.ts
+++ b/server/exceptions.ts
@@ -215,3 +215,10 @@ export class InvalidVerifyKey extends OttException {
 		this.name = "InvalidVerifyKey";
 	}
 }
+
+export class UserNotFound extends OttException {
+	constructor() {
+		super("User not found");
+		this.name = "UserNotFound";
+	}
+}

--- a/server/mailer.ts
+++ b/server/mailer.ts
@@ -1,0 +1,75 @@
+import { Result, ok, err } from "../common/result";
+import Mailjet, { Client as MailjetClient } from "node-mailjet";
+import { conf } from "./ott-config";
+import { getLogger } from "./logger";
+
+const log = getLogger("mailer");
+
+export abstract class Mailer {
+	abstract send(email: Email): Promise<Result<void, MailerError>>;
+}
+
+export interface Email {
+	to: string;
+	subject: string;
+	body: string;
+}
+
+export class MailjetMailer extends Mailer {
+	client: MailjetClient;
+
+	constructor(api_key: string, api_secret: string) {
+		super();
+		this.client = Mailjet.apiConnect(api_key, api_secret);
+	}
+
+	async send(email: Email): Promise<Result<void, MailerError>> {
+		const resp = await this.client.post("send", { version: "v3.1" }).request({
+			Messages: [
+				{
+					From: {
+						Email: conf.get("mail.sender_email"),
+						Name: conf.get("mail.sender_name"),
+					},
+					To: [
+						{
+							Email: email.to,
+						},
+					],
+					Subject: email.subject,
+					HTMLPart: email.body,
+				},
+			],
+			SandboxMode: conf.get("mail.mailjet_sandbox"),
+		});
+
+		const body = JSON.parse(resp.body.toString());
+
+		if (body.Messages[0].Status !== "success") {
+			log.error(`Failed to send email: ${JSON.stringify(body)}`);
+			return err(new MailerError("Failed to send email"));
+		}
+
+		return ok(undefined);
+	}
+}
+
+export class MockMailer extends Mailer {
+	sentEmails: Email[] = [];
+
+	async send(email: Email): Promise<Result<void, MailerError>> {
+		this.sentEmails.push(email);
+		return ok(undefined);
+	}
+
+	clearSent(): void {
+		this.sentEmails = [];
+	}
+}
+
+export class MailerError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "MailerError";
+	}
+}

--- a/server/mailer.ts
+++ b/server/mailer.ts
@@ -43,7 +43,7 @@ export class MailjetMailer extends Mailer {
 			SandboxMode: conf.get("mail.mailjet_sandbox"),
 		});
 
-		const body = JSON.parse(resp.body.toString());
+		const body = typeof resp.body === "string" ? JSON.parse(resp.body) : resp.body;
 
 		if (body.Messages[0].Status !== "success") {
 			log.error(`Failed to send email: ${JSON.stringify(body)}`);
@@ -67,6 +67,7 @@ export class MockMailer extends Mailer {
 	}
 }
 
+// Intentionally does not extend OttException so it gets logged
 export class MailerError extends Error {
 	constructor(message: string) {
 		super(message);

--- a/server/ott-config.ts
+++ b/server/ott-config.ts
@@ -357,6 +357,45 @@ export const conf = convict({
 			},
 		},
 	},
+	mail: {
+		enabled: {
+			doc: "Whether to enable sending emails.",
+			format: Boolean,
+			default: false,
+		},
+		mailjet_api_key: {
+			doc: "Mailjet API key.",
+			format: String,
+			env: "MAILJET_API_KEY",
+			default: null as string | null,
+			nullable: true,
+			sensitive: true,
+		},
+		mailjet_api_secret: {
+			doc: "Mailjet API secret.",
+			format: String,
+			env: "MAILJET_API_SECRET",
+			default: null as string | null,
+			nullable: true,
+			sensitive: true,
+		},
+		sender_email: {
+			doc: "Email address to send emails from.",
+			format: String,
+			default: null as string | null,
+			nullable: true,
+		},
+		sender_name: {
+			doc: "Display name to send emails as.",
+			format: String,
+			default: "OpenTogetherTube",
+		},
+		mailjet_sandbox: {
+			doc: "Whether to use Mailjet's sandbox mode. This will prevent emails from being sent, but will still validate the request.",
+			format: Boolean,
+			default: false,
+		},
+	},
 });
 
 function getExtraBaseConfig(): string | undefined {
@@ -437,6 +476,11 @@ function postProcessConfig(): void {
 		if (!ALL_VIDEO_SERVICES.includes(service)) {
 			log.warn(`Unknown video service ${service} found in config. Ignoring.`);
 		}
+	}
+
+	const sender = conf.get("mail.sender_email");
+	if (sender && !validator.isEmail(sender)) {
+		log.error(`Invalid email address ${sender} found in config.`);
 	}
 }
 

--- a/server/ott-config.ts
+++ b/server/ott-config.ts
@@ -478,9 +478,28 @@ function postProcessConfig(): void {
 		}
 	}
 
+	if (conf.get("mail.enabled")) {
+		validateMail();
+	}
+}
+
+function validateMail() {
 	const sender = conf.get("mail.sender_email");
 	if (sender && !validator.isEmail(sender)) {
-		log.error(`Invalid email address ${sender} found in config.`);
+		log.error(`Invalid email address ${sender} found in config, disabling mail.`);
+		conf.set("mail.enabled", false);
+		return;
+	}
+
+	if (!conf.get("mail.mailjet_api_key") || !conf.get("mail.mailjet_api_secret")) {
+		log.error("Mailjet API key and secret are required to send mail, disabling mail.");
+		conf.set("mail.enabled", false);
+		return;
+	}
+
+	if (conf.get("env") === "test") {
+		log.warn("Mail is enabled in test mode. Forcing sandbox mode.");
+		conf.set("mail.mailjet_sandbox", true);
 	}
 }
 

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
 		"m3u8-parser": "^6.2.0",
 		"nocache": "^3.0.0",
 		"node-abort-controller": "3.0.1",
+		"node-mailjet": "^6.0.3",
 		"ott-common": "./common",
 		"passport": "0.6.0",
 		"passport-discord": "^0.1.4",

--- a/server/tests/unit/api/accountrecovery.spec.ts
+++ b/server/tests/unit/api/accountrecovery.spec.ts
@@ -1,0 +1,136 @@
+import request from "supertest";
+import { main } from "../../../app";
+import usermanager from "../../../usermanager";
+import { User as UserModel } from "../../../models";
+import { MockMailer } from "server/mailer";
+import { conf } from "../../../ott-config";
+import { redisClient } from "../../../redisclient";
+import { OttApiRequestAccountRecoveryVerify } from "common/models/rest-api";
+
+describe("Account Recovery", () => {
+	let token;
+	let app;
+
+	beforeAll(async () => {
+		app = (await main()).app;
+
+		await usermanager.registerUser({
+			email: "email@localhost",
+			username: "email user",
+			password: "test1234",
+		});
+
+		await usermanager.registerUser({
+			email: null,
+			username: "no email user",
+			password: "test1234",
+		});
+
+		let resp = await request(app).get("/api/auth/grant").expect(200);
+		token = resp.body.token;
+
+		conf.set("mail.enabled", true);
+	});
+
+	beforeEach(async () => {});
+
+	afterEach(() => {
+		const mailer: MockMailer = usermanager.mailer as MockMailer;
+		mailer.clearSent();
+	});
+
+	afterAll(async () => {
+		await UserModel.destroy({ where: {} });
+	});
+
+	it.each([
+		["email", "email@localhost"],
+		["username", "email user"],
+	])(
+		"should send a recovery email when using %s field in request",
+		async (field: string, value: string) => {
+			const resp = await request(app)
+				.post("/api/user/recover/start")
+				.set("Authorization", `Bearer ${token}`)
+				.send({ [field]: value });
+
+			expect(resp.body).toMatchObject({
+				success: true,
+			});
+
+			const mailer: MockMailer = usermanager.mailer as MockMailer;
+			expect(mailer.sentEmails).toHaveLength(1);
+			expect(mailer.sentEmails[0]).toMatchObject({
+				to: "email@localhost",
+			});
+		}
+	);
+
+	it("should not send a recovery email when there is no email", async () => {
+		const resp = await request(app)
+			.post("/api/user/recover/start")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ username: "no email user" })
+			.expect(400);
+
+		expect(resp.body.success).toBe(false);
+		expect(resp.body.error).toMatchObject({
+			name: "NoEmail",
+		});
+
+		const mailer: MockMailer = usermanager.mailer as MockMailer;
+		expect(mailer.sentEmails).toHaveLength(0);
+	});
+
+	it.each([{}, { email: "doesnot@exi.st" }])(
+		"should not send a recovery email when the request is bad: %s",
+		async (body: any) => {
+			const resp = await request(app)
+				.post("/api/user/recover/start")
+				.set("Authorization", `Bearer ${token}`)
+				.send(body)
+				.expect(400);
+
+			expect(resp.body.success).toBe(false);
+
+			const mailer: MockMailer = usermanager.mailer as MockMailer;
+			expect(mailer.sentEmails).toHaveLength(0);
+		}
+	);
+
+	it("should change the password when the verify key is valid", async () => {
+		await redisClient.set("accountrecovery:foo", "email@localhost");
+
+		const body: OttApiRequestAccountRecoveryVerify = {
+			verifyKey: "foo",
+			newPassword: "test5678",
+		};
+
+		const resp = await request(app)
+			.post("/api/user/recover/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send(body);
+
+		expect(resp.body).toMatchObject({
+			success: true,
+		});
+	});
+
+	it.each([
+		{},
+		{ verifyKey: "foo" },
+		{ newPassword: "test5678" },
+		{ verifyKey: "foo", newPassword: "asdf" },
+		{ verifyKey: "bar", newPassword: "asdf1234" },
+	])("should not change the password when the request is bad: %s", async (body: any) => {
+		await redisClient.set("accountrecovery:foo", "email@localhost");
+
+		const resp = await request(app)
+			.post("/api/user/recover/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send(body)
+			.expect(400);
+
+		expect(resp.body.success).toBe(false);
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,6 +2517,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bignumber.js@^9.0.0:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
+  integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -5250,6 +5255,13 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -5875,6 +5887,15 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
+
+node-mailjet@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/node-mailjet/-/node-mailjet-6.0.3.tgz#706e238e1d5aa7fbfcbb3b339bcb894d0278ad16"
+  integrity sha512-dPOrojEtqbg2GDBM1uWV7ExjfsvgHXG65BbicJ/l4nMzHNLdHW05LsbID9wdqK1FuBzRmlzo2tBxQTMpVUBRlA==
+  dependencies:
+    axios "^0.27.2"
+    json-bigint "^1.0.0"
+    url-join "^4.0.0"
 
 node-releases@^2.0.8:
   version "2.0.10"
@@ -7775,6 +7796,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-join@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-parse@^1.5.3:
   version "1.5.10"


### PR DESCRIPTION
closes #847

- add mailjet and the Mailer classes
- do a little more config validation
- add account recovery start and verify endpoints
- add password reset UI stuff
- tweak ui stuff
- add password reset view to router
- tweak UI
- add UserNotFound error
- add unit tests for account recovery endpoints
