### PR TITLE
batch pluto calls

### DIFF
--- a/server/infoextractor.ts
+++ b/server/infoextractor.ts
@@ -251,7 +251,10 @@ export default {
 		const results = await Promise.all(
 			Object.entries(grouped).map(async ([service, serviceVideos]) => {
 				// Handle each service separately
-				const cachedVideos: Video[] = await storage.getManyVideoInfo(serviceVideos);
+				const adapter = this.getServiceAdapter(service);
+				const cachedVideos: Video[] = adapter.isCacheSafe
+					? await storage.getManyVideoInfo(serviceVideos)
+					: [];
 				const requests = cachedVideos
 					.map(video => ({
 						id: video.id,
@@ -265,7 +268,6 @@ export default {
 					return cachedVideos;
 				}
 
-				const adapter = this.getServiceAdapter(service);
 				const fetchedVideos = await adapter.fetchManyVideoInfo(requests);
 				const finalResults = cachedVideos.map(video => {
 					const fetchedVideo = fetchedVideos.find(v => v.id === video.id);

--- a/server/services/pluto.ts
+++ b/server/services/pluto.ts
@@ -189,13 +189,6 @@ export default class PlutoAdapter extends ServiceAdapter {
 		return params;
 	}
 
-	private ensureStitcherServer(resp: PlutoBootResponse): string {
-		if (!resp.servers.stitcher) {
-			throw new Error("No stitcher server found in boot response");
-		}
-		return resp.servers.stitcher;
-	}
-
 	private parseBootResponseIntoVideo(plutoIds: PlutoParsedIds, resp: PlutoBootResponse): Video {
 		if (!resp.servers.stitcher) {
 			throw new Error("No stitcher server found in boot response");

--- a/server/tests/unit/fixtures/services/pluto/boot-v4_series_judge_judy_stargate_forest_gump_titanic.json
+++ b/server/tests/unit/fixtures/services/pluto/boot-v4_series_judge_judy_stargate_forest_gump_titanic.json
@@ -1,0 +1,22570 @@
+{
+	"servers": {
+		"api": "https://api.pluto.tv",
+		"channels": "https://service-channels.clusters.pluto.tv",
+		"vod": "https://service-vod.clusters.pluto.tv",
+		"stitcher": "https://cfd-v4-service-channel-stitcher-use1-1.prd.pluto.tv",
+		"analytics": "https://sp.pluto.tv",
+		"watchlist": "https://service-watchlist.clusters.pluto.tv",
+		"search": "https://service-media-search.clusters.pluto.tv",
+		"concierge": "https://service-concierge.clusters.pluto.tv",
+		"preferences": "https://service-preferences.clusters.pluto.tv",
+		"campaigns": "https://service-campaigns-ga.prd.pluto.tv",
+		"users": "https://service-users.clusters.pluto.tv",
+		"recommender": "https://service-recommender.clusters.pluto.tv",
+		"catalog": "https://service-media-catalog.clusters.pluto.tv",
+		"stitcherDash": "https://cfd-v4-service-stitcher-dash-use1-1.prd.pluto.tv",
+		"pause": "https://service-ad-image-ga.prd.pluto.tv"
+	},
+	"features": {
+		"activateShow": true,
+		"legacyEventsUse": false,
+		"privacyPolicyVersion": 1,
+		"policymessages": {
+			"moreInfo": false,
+			"prompt": false
+		},
+		"redfast": true,
+		"codeActivationUse": true,
+		"supportPage": "https://support.pluto.tv/s/?language=en_US",
+		"privacyPolicy": "privacy.paramount.com/policy",
+		"pauseAds": {
+			"requestIntervalInMs": 600000
+		},
+		"signUpNamePlaceholder": {
+			"key": "first_name_title_case"
+		},
+		"nowNextLaterTracking": true,
+		"disableKidsContentTracking": true,
+		"kidsModeToggleEnabled": true,
+		"twelveHourExtTimeline": true,
+		"installCheck": true,
+		"resumePointsUpdateFrequencyInMs": 30000,
+		"chromecastEnabled": true,
+		"kidsModeManagePin": {
+			"url": "https://www.pluto.tv/account/kids-mode/manage-pin"
+		},
+		"tmobile": {
+			"allowed": {
+				"method": "get",
+				"origin": "deal.t-mobiletuesdays.com"
+			},
+			"imgHost": "https://pluto-assets.s3.amazonaws.com/optimizely/",
+			"imgHostPluto": "https://pluto-assets.s3.amazonaws.com/optimizely/",
+			"success": {
+				"brandingColor": "#E20074",
+				"btnColor": "#EC0075",
+				"btnText": "Start Watching",
+				"btnTxtColor": "#FFFFFF",
+				"imgLogo": "nr-hero-Full-Tmobile-Logo-New-2021.png",
+				"imgTvIcon": "_Icon/_Icon+and+banner/sync+_icon_black%403x.png",
+				"mobileImg": "Tmobile/nr-hero-Full-Tmobile-Logo-New-2021.png",
+				"msg": "Improve your watching experience by connecting your Pluto.TV account to mobile and CTV platforms.",
+				"msgTv": "Launch the Pluto TV app on your TV device, go to the settings menu to log in and activate your account",
+				"tabletLandImg": "Tmobile/nr-hero-Full-Tmobile-Logo-New-2021.png",
+				"tabletPortImg": "Tmobile/nr-hero-Full-Tmobile-Logo-New-2021.png",
+				"title": "T-Mobile Tuesdays content successfully activated!",
+				"titleTv": "Watch from your TV",
+				"webBtnColor": "#FFDE2B",
+				"webBtnTxtColor": "#000000"
+			},
+			"welcome": {
+				"brandingColor": "#E20074",
+				"btnColor": "#EC0075",
+				"btnText": "Redeem T-Mobile Offer",
+				"btnTxtColor": "#FFFFFF",
+				"imgLogo": "nr-hero-Full-Tmobile-Logo-New-2021.png",
+				"imgWebBanner": "_Icon+and+banner/_desktop/PlutoTV_GenericWelcomeMat_Graphic_1440x470_2x+1%401x.png",
+				"imgWebMobileBanner": "_Icon+and+banner/_phone/PlutoTV_GenericWelcomeMat_Graphic_375x250_2x+1.png",
+				"mobileImg": "Tmobile/nr-hero-Full-Tmobile-Logo-New-2021.png",
+				"msg": "Redeem the offer by Signing Up or Signing In via existing account and start watching interruption free Video on Demand.",
+				"msgTextColor": "#FFFFFF",
+				"tabletLandImg": "Tmobile/nr-hero-Full-Tmobile-Logo-New-2021.png",
+				"tabletPortImg": "Tmobile/nr-hero-Full-Tmobile-Logo-New-2021.png",
+				"title": "T-Mobile Tuesdays Exclusive Interruption Free Offer",
+				"webBtnColor": "#FFDE2B",
+				"webBtnTxtColor": "#000000"
+			}
+		},
+		"vodLabel": "Free Movies \u0026 TV Shows",
+		"UIEventUse": true,
+		"askUserToReview": false,
+		"doNotSellMyInfo": "privacy.paramount.com/app-donotsell",
+		"useGooglePAL": true,
+		"useTCF": true,
+		"useParentChild": true,
+		"liveTVCategoryShow": true,
+		"watchlistSyncSec": 120,
+		"watchlist": true,
+		"phoenix5EventsUse": false,
+		"useTMSID": false,
+		"firstPlayResumeAtOffset": {
+			"subtractedSeconds": 5
+		},
+		"lastWatchedRow": true,
+		"users": true,
+		"idleBehavior": false,
+		"privacyPolicyShow": false,
+		"touNotification": {
+			"acceptanceRequired": true,
+			"disableOnSessionCount": 0,
+			"effectiveDate": "2023-02-16T00:00:00.000Z",
+			"endDate": "2023-03-19T00:00:00.000Z",
+			"isModal": false,
+			"msgOverride": "Our Terms of Use (\"Terms\") have been updated, including changes to the arbitration clause. By clicking \"Accept\", you acknowledge that you have read and agree to the updated Terms.",
+			"startDate": "2023-02-16T00:00:00.000Z",
+			"touUrl": "https://corporate.pluto.tv/terms-of-use/"
+		},
+		"searchNewBadge": true,
+		"kidsModePinUse": true,
+		"hlsEventVodEnabled": true,
+		"removeChannelNumbers": true,
+		"forceUpdate": false,
+		"scrubberUse": true,
+		"peekViewUse": false,
+		"termsOfUse": "corporate.pluto.tv/terms-of-use",
+		"drmDash": {
+			"enableFallback": false,
+			"enableVll": true,
+			"enableVod": true,
+			"supportDashIf": false,
+			"supportEventVod": false
+		},
+		"clickableAds": false,
+		"channelTimelineView": false,
+		"kidsModeSearch": {
+			"recommendations": false
+		},
+		"userAccounts": {
+			"accountDeletion": false,
+			"dateOfBirthField": true,
+			"genderField": true,
+			"marketingOptIn": false,
+			"minAge": 18,
+			"nameField": false
+		},
+		"endCard": {
+			"nextEpisode": {
+				"contentMarkupEnabled": false,
+				"countDownDurationWithCM": 15,
+				"countDownDurationWithoutCM": 25,
+				"isEnabled": true,
+				"offset": 25
+			},
+			"nextMovie": {
+				"contentMarkupEnabled": false,
+				"countDownDurationWithCM": 30,
+				"countDownDurationWithoutCM": 30,
+				"isEnabled": false,
+				"offset": 240
+			},
+			"nextSeries": {
+				"contentMarkupEnabled": false,
+				"countDownDurationWithCM": 30,
+				"countDownDurationWithoutCM": 15,
+				"isEnabled": false,
+				"offset": 15
+			},
+			"prefetchSeconds": 60
+		},
+		"supportedLanguage": "en",
+		"sentry": true,
+		"popularNow": true,
+		"kidsModeToggle": true,
+		"search": {
+			"prompt": {
+				"intervals": [
+					1,
+					3,
+					7,
+					20
+				]
+			},
+			"recommendations": false,
+			"toolTip": false,
+			"voiceEnabled": false
+		},
+		"embedMode": {
+			"disableTimeout": false,
+			"showVOD": false,
+			"webAppLink": true
+		},
+		"NPAWUse": true,
+		"ptb": {
+			"parallax": false,
+			"url": "https://service-recommender.clusters.pluto.tv/v1/personalized"
+		},
+		"watchFromStartWebChanges": true,
+		"extendGuideUse": true,
+		"showCaptions": true,
+		"kidsModePinEnabled": true,
+		"signUpNameFieldRequired": true,
+		"preferences": true,
+		"channeltimelines": true,
+		"useServiceWatchlist": true,
+		"usPrivacyString": true,
+		"kidsMode": true,
+		"searchMenuItemOnL1": true,
+		"heroCarousel": true,
+		"useVPPA": true,
+		"blazeUse": false,
+		"phoenixUse": true,
+		"vodShow": true,
+		"newEPG": true,
+		"rmfEnabled": true,
+		"useChannelsText": false,
+		"userAccount": true,
+		"nowNextGuide": true
+	},
+	"session": {
+		"sessionID": "494501c4-2ba7-11ee-b629-429bafd60572",
+		"clientIP": "104.246.125.141",
+		"countryCode": "US",
+		"activeRegion": "US",
+		"city": "North Bergen",
+		"postalCode": "07047",
+		"preferredLanguage": "en",
+		"deviceType": "web",
+		"deviceMake": "firefox",
+		"deviceModel": "web",
+		"logLevel": "DEFAULT",
+		"clientDeviceType": 0,
+		"marketingRegion": "US",
+		"restartThresholdMS": 1800000
+	},
+	"EPG": [
+		{
+			"name": "Pluto TV Reaction",
+			"id": "617b37b361e0fd0008cfd8c5",
+			"isStitched": true,
+			"slug": "pluto-tv-reaction",
+			"categoryIDs": [
+				"618c3cc54a27070007796ab4"
+			],
+			"stitched": {
+				"paths": [
+					{
+						"type": "mpd",
+						"path": "/stitch/dash/channel/617b37b361e0fd0008cfd8c5/main.mpd"
+					}
+				]
+			},
+			"images": [
+				{
+					"type": "colorLogoPNG",
+					"style": "wide",
+					"ratio": 0.2857142857142857,
+					"defaultWidth": 280,
+					"defaultHeight": 80,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/colorLogoPNG.png"
+				},
+				{
+					"type": "colorLogoSVG",
+					"style": "wide",
+					"ratio": 0.2857142857142857,
+					"defaultWidth": 280,
+					"defaultHeight": 80,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/colorLogoSVG.svg"
+				},
+				{
+					"type": "solidLogoPNG",
+					"style": "wide",
+					"ratio": 0.2857142857142857,
+					"defaultWidth": 280,
+					"defaultHeight": 80,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/solidLogoPNG.png"
+				},
+				{
+					"type": "solidLogoSVG",
+					"style": "wide",
+					"ratio": 0.2857142857142857,
+					"defaultWidth": 280,
+					"defaultHeight": 80,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/solidLogoSVG.svg"
+				},
+				{
+					"type": "logo",
+					"style": "wide",
+					"ratio": 0.2857142857142857,
+					"defaultWidth": 280,
+					"defaultHeight": 80,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/logo.png?fit=fill\u0026fm=png\u0026h=80\u0026w=280"
+				},
+				{
+					"type": "featuredImage",
+					"style": "tall",
+					"ratio": 1.7777777777777777,
+					"defaultWidth": 1560,
+					"defaultHeight": 878,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/featuredImage.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=900\u0026q=75\u0026w=1600"
+				},
+				{
+					"type": "hero",
+					"style": "square",
+					"ratio": 1,
+					"defaultWidth": 660,
+					"defaultHeight": 660,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/thumbnail.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=660\u0026q=75\u0026w=660"
+				},
+				{
+					"type": "tileColor",
+					"style": "wide",
+					"ratio": 0.25,
+					"defaultWidth": 660,
+					"defaultHeight": 150,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/tile.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=150\u0026q=75\u0026w=600"
+				},
+				{
+					"type": "tileGrayscale",
+					"style": "wide",
+					"ratio": 0.25,
+					"defaultWidth": 660,
+					"defaultHeight": 150,
+					"url": "https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/tileGrayscale.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=150\u0026q=75\u0026w=600"
+				}
+			],
+			"number": 61,
+			"timelines": [
+				{
+					"start": "2023-07-26T09:30:00.000Z",
+					"stop": "2023-07-26T12:00:00.000Z",
+					"title": "Criminal",
+					"_id": "64c02a99b0cf5c000822ec2e",
+					"episode": {
+						"_id": "61d72dcaafe81f001a22137a",
+						"name": "Criminal",
+						"rating": "R",
+						"originalContentDuration": 6825000,
+						"genre": "Action \u0026 Adventure",
+						"description": "The memories and skills of a deceased CIA agent are implanted into an unpredictable and dangerous convict in order to complete the agent's final assignment.",
+						"slug": "criminal-2016-1-1",
+						"series": {
+							"_id": "61d72dc7afe81f001a221371",
+							"name": "Criminal",
+							"slug": "criminal-ptv2",
+							"type": "film"
+						},
+						"distributeAs": {
+							"AVOD": true
+						}
+					}
+				},
+				{
+					"start": "2023-07-26T12:00:00.000Z",
+					"stop": "2023-07-26T15:00:00.000Z",
+					"title": "The Island",
+					"_id": "64c02a99b0cf5c000822ec2f",
+					"episode": {
+						"_id": "61e9ea6e6f81a5001bd28640",
+						"name": "The Island",
+						"rating": "PG-13",
+						"originalContentDuration": 8175000,
+						"genre": "Sci-Fi \u0026 Fantasy",
+						"description": "A man goes on the run after he discovers that he is actually a \"harvested being\", and is being kept along with others in a utopian facility.",
+						"slug": "the-island-2005-1-1",
+						"series": {
+							"_id": "61e9ea6c6f81a5001bd28639",
+							"name": "The Island",
+							"slug": "the-island-ptv2",
+							"type": "film"
+						},
+						"distributeAs": {
+							"AVOD": true
+						}
+					}
+				},
+				{
+					"start": "2023-07-26T15:00:00.000Z",
+					"stop": "2023-07-26T17:15:00.000Z",
+					"title": "Tank Girl",
+					"_id": "64c02a99b0cf5c000822ec30",
+					"episode": {
+						"_id": "590141efa1041ca52b5ab14c",
+						"name": "Tank Girl",
+						"rating": "R",
+						"originalContentDuration": 6255000,
+						"genre": "Action \u0026 Adventure",
+						"description": "In this laugh-a-minute, futuristic Thriller, a mega-villain controls the world's water supply, and it's up to Tank Girl and her outrageous cohorts to end his greedy reign.",
+						"slug": "tank-girl-1995-1-1",
+						"series": {
+							"_id": "590141efa1041ca52b5ab112",
+							"name": "Tank Girl",
+							"slug": "tank-girl",
+							"type": "film"
+						},
+						"distributeAs": {
+							"AVOD": true
+						}
+					}
+				}
+			]
+		}
+	],
+	"VOD": [
+		{
+			"id": "603db25de7c979001a88f77a",
+			"name": "Judge Judy",
+			"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+			"duration": 0,
+			"slug": "judge-judy",
+			"rating": "TV-G",
+			"genre": "Reality",
+			"seasons": [
+				{
+					"number": 1,
+					"episodes": [
+						{
+							"_id": "603db2a8e7c979001a890535",
+							"name": "Episode 1",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-1-1995-1-1-ptv4",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a8e7c979001a890535/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a8e7c979001a890535/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a8e7c979001a890535/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a8e7c979001a890535/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a8e7c979001a890535/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a8e7c979001a890520",
+							"name": "Episode 2",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-2-1995-1-2-ptv4",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a8e7c979001a890520/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a8e7c979001a890520/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a8e7c979001a890520/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a8e7c979001a890520/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a8e7c979001a890520/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a6e7c979001a8904ee",
+							"name": "Episode 3",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-3-1995-1-3-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a6e7c979001a8904ee/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a6e7c979001a8904ee/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a6e7c979001a8904ee/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a6e7c979001a8904ee/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a6e7c979001a8904ee/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "606c97a7a224c9001bb92fe8",
+							"name": "Episode 4",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-4-1995-1-4-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/606c97a7a224c9001bb92fe8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/606c97a7a224c9001bb92fe8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/606c97a7a224c9001bb92fe8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/606c97a7a224c9001bb92fe8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/606c97a7a224c9001bb92fe8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a890499",
+							"name": "Episode 5",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-5-1995-1-5-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a890499/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a890499/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890499/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890499/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890499/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "606c97a7a224c9001bb92fd7",
+							"name": "Episode 6",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-6-1995-1-6-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/606c97a7a224c9001bb92fd7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/606c97a7a224c9001bb92fd7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/606c97a7a224c9001bb92fd7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/606c97a7a224c9001bb92fd7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/606c97a7a224c9001bb92fd7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a7e7c979001a890505",
+							"name": "Episode 7",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-7-1995-1-7-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a7e7c979001a890505/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a7e7c979001a890505/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a7e7c979001a890505/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a7e7c979001a890505/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a7e7c979001a890505/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a8903f6",
+							"name": "Episode 8",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-8-1995-1-8-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a8903f6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a8903f6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903f6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903f6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903f6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a2e7c979001a89039c",
+							"name": "Episode 9",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-9-1995-1-9-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a2e7c979001a89039c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a2e7c979001a89039c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a89039c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a89039c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a89039c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "606c97a6a224c9001bb92fc4",
+							"name": "Episode 10",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-10-1995-1-10",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/606c97a6a224c9001bb92fc4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/606c97a6a224c9001bb92fc4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/606c97a6a224c9001bb92fc4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/606c97a6a224c9001bb92fc4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/606c97a6a224c9001bb92fc4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fda1ca306001a360ecc",
+							"name": "Episode 11",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-11-1995-1-11",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fda1ca306001a360ecc/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fda1ca306001a360ecc/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ecc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ecc/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ecc/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a2e7c979001a890387",
+							"name": "Episode 12",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-12-1995-1-12-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a2e7c979001a890387/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a2e7c979001a890387/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a890387/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a890387/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a890387/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a8903cc",
+							"name": "Episode 13",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-13-1995-1-13-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a8903cc/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a8903cc/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903cc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903cc/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903cc/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a1e7c979001a890344",
+							"name": "Episode 14",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-14-1995-1-14-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a1e7c979001a890344/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a1e7c979001a890344/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a1e7c979001a890344/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a1e7c979001a890344/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a1e7c979001a890344/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "606c97aba224c9001bb9300f",
+							"name": "Episode 15",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-15-1995-1-15",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/606c97aba224c9001bb9300f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/606c97aba224c9001bb9300f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/606c97aba224c9001bb9300f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/606c97aba224c9001bb9300f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/606c97aba224c9001bb9300f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a2e7c979001a89035c",
+							"name": "Episode 16",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-16-1995-1-16-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a2e7c979001a89035c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a2e7c979001a89035c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a89035c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a89035c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a89035c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a0e7c979001a890316",
+							"name": "Episode 17",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-17-1995-1-17-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a0e7c979001a890316/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a0e7c979001a890316/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a0e7c979001a890316/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a0e7c979001a890316/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a0e7c979001a890316/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a890475",
+							"name": "Episode 18",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-18-1995-1-18-ptv1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a890475/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a890475/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890475/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890475/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890475/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a89040c",
+							"name": "Episode 19",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-19-1995-1-19",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a89040c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a89040c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a89040c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a89040c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a89040c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a890460",
+							"name": "Episode 20",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-20-1995-1-20",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a890460/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a890460/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890460/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890460/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890460/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a890436",
+							"name": "Episode 21",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-21-1995-1-21",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a890436/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a890436/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890436/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890436/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890436/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db29ee7c979001a8902ca",
+							"name": "Episode 22",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-22-1995-1-22",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db29ee7c979001a8902ca/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db29ee7c979001a8902ca/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a8902ca/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a8902ca/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a8902ca/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a890421",
+							"name": "Episode 23",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-23-1995-1-23",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a890421/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a890421/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890421/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890421/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a890421/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a2e7c979001a8903b1",
+							"name": "Episode 24",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-24-1995-1-24",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a2e7c979001a8903b1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a2e7c979001a8903b1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a8903b1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a8903b1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/F07B8BCE-4098-0146-8315-EFD8FBA383CD_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a1e7c979001a89032d",
+							"name": "Episode 25",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-25-1995-1-25",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a1e7c979001a89032d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a1e7c979001a89032d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a1e7c979001a89032d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a1e7c979001a89032d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a1e7c979001a89032d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a2e7c979001a890371",
+							"name": "Episode 26",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-26-1995-1-26",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a2e7c979001a890371/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a2e7c979001a890371/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a890371/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a890371/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a2e7c979001a890371/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a8903e1",
+							"name": "Episode 27",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-27-1995-1-27",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a8903e1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a8903e1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903e1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903e1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a8903e1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db29ee7c979001a8902b4",
+							"name": "Episode 28",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-28-1995-1-28",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db29ee7c979001a8902b4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db29ee7c979001a8902b4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a8902b4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a8902b4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a8902b4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc9c2",
+							"name": "Episode 29",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-29-1995-1-29",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc9c2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc9c2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9c2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9c2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9c2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc906",
+							"name": "Episode 30",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-30-1995-1-30",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc906/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc906/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc906/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc906/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc906/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db29fe7c979001a8902f3",
+							"name": "Episode 31",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-31-1995-1-31",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db29fe7c979001a8902f3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db29fe7c979001a8902f3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db29fe7c979001a8902f3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db29fe7c979001a8902f3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db29fe7c979001a8902f3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc946",
+							"name": "Episode 32",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-32-1995-1-32",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc946/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc946/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc946/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc946/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc946/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc8cb",
+							"name": "Episode 33",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-33-1995-1-33",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc8cb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc8cb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8cb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8cb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8cb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc997",
+							"name": "Episode 34",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-34-1995-1-34",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc997/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc997/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc997/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc997/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc997/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc91b",
+							"name": "Episode 35",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-35-1995-1-35",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc91b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc91b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc91b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc91b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc91b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc9d7",
+							"name": "Episode 36",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-36-1995-1-36",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc9d7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc9d7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9d7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9d7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9d7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fdd1ca306001a360f11",
+							"name": "Episode 37",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-37-1995-1-37",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fdd1ca306001a360f11/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fdd1ca306001a360f11/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f11/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f11/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f11/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc931",
+							"name": "Episode 38",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-38-1995-1-38",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc931/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc931/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc931/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc931/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc931/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db29ee7c979001a890289",
+							"name": "Episode 39",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-39-1995-1-39",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db29ee7c979001a890289/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db29ee7c979001a890289/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a890289/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a890289/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a890289/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc95b",
+							"name": "Episode 40",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-40-1995-1-40",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc95b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc95b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc95b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc95b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc95b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fda1ca306001a360ea9",
+							"name": "Episode 41",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-41-1995-1-41",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fda1ca306001a360ea9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fda1ca306001a360ea9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ea9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ea9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ea9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc981",
+							"name": "Episode 42",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-42-1995-1-42",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc981/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc981/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc981/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc981/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc981/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc9ac",
+							"name": "Episode 43",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-43-1995-1-43",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc9ac/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc9ac/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9ac/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9ac/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc9ac/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b896d6023001abdc8ae",
+							"name": "Episode 44",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-44-1995-1-44",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b896d6023001abdc8ae/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b896d6023001abdc8ae/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc8ae/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc8ae/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc8ae/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8e6d6023001abdca21",
+							"name": "Episode 45",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-45-1995-1-45",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8e6d6023001abdca21/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8e6d6023001abdca21/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8e6d6023001abdca21/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8e6d6023001abdca21/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8e6d6023001abdca21/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b896d6023001abdc883",
+							"name": "Episode 46",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-46-1995-1-46",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b896d6023001abdc883/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b896d6023001abdc883/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc883/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc883/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc883/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc8e0",
+							"name": "Episode 47",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-47-1995-1-47",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc8e0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc8e0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8e0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8e0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8e0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db29ee7c979001a890274",
+							"name": "Episode 48",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-48-1995-1-48",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db29ee7c979001a890274/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db29ee7c979001a890274/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a890274/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a890274/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a890274/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b896d6023001abdc899",
+							"name": "Episode 49",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-49-1995-1-49",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b896d6023001abdc899/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b896d6023001abdc899/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc899/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc899/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b896d6023001abdc899/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db29ee7c979001a89029e",
+							"name": "Episode 50",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-50-1995-1-50",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db29ee7c979001a89029e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db29ee7c979001a89029e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a89029e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a89029e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a89029e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db29ee7c979001a89025b",
+							"name": "Episode 51",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-51-1995-1-51",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db29ee7c979001a89025b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db29ee7c979001a89025b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a89025b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a89025b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db29ee7c979001a89025b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd72617007f001a81272b",
+							"name": "Episode 52",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-52-1995-1-52",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd72617007f001a81272b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd72617007f001a81272b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd72617007f001a81272b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd72617007f001a81272b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd72617007f001a81272b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db2a3e7c979001a89044b",
+							"name": "Episode 53",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-53-1995-1-53",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db2a3e7c979001a89044b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db2a3e7c979001a89044b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a89044b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a89044b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db2a3e7c979001a89044b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db29ce7c979001a890229",
+							"name": "Episode 54",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-54-1995-1-54",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db29ce7c979001a890229/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db29ce7c979001a890229/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db29ce7c979001a890229/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db29ce7c979001a890229/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db29ce7c979001a890229/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71e17007f001a8126e9",
+							"name": "Episode 55",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-55-1995-1-55",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71e17007f001a8126e9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71e17007f001a8126e9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71e17007f001a8126e9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71e17007f001a8126e9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71e17007f001a8126e9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "616f293f4f409e001a489dd3",
+							"name": "Episode 56",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-56-1995-1-56",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/616f293f4f409e001a489dd3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/616f293f4f409e001a489dd3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489dd3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489dd3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489dd3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "616f293e4f409e001a489da5",
+							"name": "Episode 57",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-57-1995-1-57",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/616f293e4f409e001a489da5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/616f293e4f409e001a489da5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/616f293e4f409e001a489da5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/616f293e4f409e001a489da5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/616f293e4f409e001a489da5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "616f293f4f409e001a489dbc",
+							"name": "Episode 58",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-58-1995-1-58",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/616f293f4f409e001a489dbc/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/616f293f4f409e001a489dbc/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489dbc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489dbc/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489dbc/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a812645",
+							"name": "Episode 59",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-59-1995-1-59",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a812645/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a812645/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812645/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/18A15AB5-80EC-7B43-98A6-9B639841835B_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/18A15AB5-80EC-7B43-98A6-9B639841835B_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "616f293f4f409e001a489de8",
+							"name": "Episode 60",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-60-1995-1-60",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/616f293f4f409e001a489de8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/616f293f4f409e001a489de8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489de8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489de8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/616f293f4f409e001a489de8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db295e7c979001a890109",
+							"name": "Episode 61",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-61-1995-1-61",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db295e7c979001a890109/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db295e7c979001a890109/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db295e7c979001a890109/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db295e7c979001a890109/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db295e7c979001a890109/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db292e7c979001a890060",
+							"name": "Episode 62",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-62-1995-1-62",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db292e7c979001a890060/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db292e7c979001a890060/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db292e7c979001a890060/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db292e7c979001a890060/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db292e7c979001a890060/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71417007f001a812475",
+							"name": "Episode 63",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-63-1995-1-63",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71417007f001a812475/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71417007f001a812475/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812475/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812475/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812475/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc970",
+							"name": "Episode 64",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-64-1995-1-64",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc970/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc970/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc970/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc970/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc970/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60411b8b6d6023001abdc8f5",
+							"name": "Episode 65",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-65-1995-1-65",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60411b8b6d6023001abdc8f5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60411b8b6d6023001abdc8f5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8f5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8f5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60411b8b6d6023001abdc8f5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71417007f001a812460",
+							"name": "Episode 66",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-66-1995-1-66",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71417007f001a812460/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71417007f001a812460/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812460/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812460/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812460/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a81265a",
+							"name": "Episode 67",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-67-1995-1-67",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a81265a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a81265a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81265a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81265a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81265a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fd91ca306001a360e53",
+							"name": "Episode 68",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-68-1995-1-68",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fd91ca306001a360e53/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fd91ca306001a360e53/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fd91ca306001a360e53/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fd91ca306001a360e53/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fd91ca306001a360e53/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a81269e",
+							"name": "Episode 69",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-69-1995-1-69",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a81269e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a81269e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81269e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81269e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81269e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a81262e",
+							"name": "Episode 70",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-70-1995-1-70",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a81262e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a81262e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81262e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81262e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a81262e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a812689",
+							"name": "Episode 71",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-71-1995-1-71",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a812689/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a812689/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812689/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812689/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812689/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a8126b3",
+							"name": "Episode 72",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-72-1995-1-72",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a8126b3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a8126b3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8126b3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/482729BA-83E4-2F4E-A16D-63B1CB6E1543_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/482729BA-83E4-2F4E-A16D-63B1CB6E1543_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71417007f001a812445",
+							"name": "Episode 73",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-73-1995-1-73",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71417007f001a812445/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71417007f001a812445/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812445/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812445/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812445/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a8125c2",
+							"name": "Episode 74",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-74-1995-1-74",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a8125c2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a8125c2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125c2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125c2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125c2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a8125ec",
+							"name": "Episode 75",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-75-1995-1-75",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a8125ec/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a8125ec/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125ec/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125ec/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125ec/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71b17007f001a812583",
+							"name": "Episode 76",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-76-1995-1-76",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71b17007f001a812583/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71b17007f001a812583/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71b17007f001a812583/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71b17007f001a812583/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71b17007f001a812583/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a812601",
+							"name": "Episode 77",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-77-1995-1-77",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a812601/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a812601/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812601/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812601/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812601/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a8125d7",
+							"name": "Episode 78",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-78-1995-1-78",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a8125d7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a8125d7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125d7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125d7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125d7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71b17007f001a812598",
+							"name": "Episode 79",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-79-1995-1-79",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71b17007f001a812598/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71b17007f001a812598/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71b17007f001a812598/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71b17007f001a812598/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71b17007f001a812598/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71817007f001a8124fb",
+							"name": "Episode 80",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-80-1995-1-80",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71817007f001a8124fb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71817007f001a8124fb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a8124fb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a8124fb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a8124fb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a812674",
+							"name": "Episode 81",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-81-1995-1-81",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a812674/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a812674/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812674/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812674/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812674/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71817007f001a812528",
+							"name": "Episode 82",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-82-1995-1-82",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71817007f001a812528/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71817007f001a812528/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812528/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812528/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812528/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71817007f001a812540",
+							"name": "Episode 83",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-83-1995-1-83",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71817007f001a812540/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71817007f001a812540/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812540/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812540/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812540/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71817007f001a812510",
+							"name": "Episode 84",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-84-1995-1-84",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71817007f001a812510/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71817007f001a812510/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812510/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812510/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a812510/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71817007f001a8124e3",
+							"name": "Episode 85",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-85-1995-1-85",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71817007f001a8124e3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71817007f001a8124e3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a8124e3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a8124e3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71817007f001a8124e3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a812616",
+							"name": "Episode 86",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-86-1995-1-86",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a812616/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a812616/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812616/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812616/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a812616/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71c17007f001a8125ad",
+							"name": "Episode 87",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-87-1995-1-87",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71c17007f001a8125ad/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71c17007f001a8125ad/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125ad/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125ad/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71c17007f001a8125ad/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71517007f001a81249f",
+							"name": "Episode 88",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-88-1995-1-88",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71517007f001a81249f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71517007f001a81249f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71517007f001a81249f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71517007f001a81249f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71517007f001a81249f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd71417007f001a812430",
+							"name": "Episode 89",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-89-1995-1-89",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd71417007f001a812430/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd71417007f001a812430/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812430/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812430/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd71417007f001a812430/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd70317007f001a812329",
+							"name": "Episode 90",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-90-1995-1-90",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd70317007f001a812329/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd70317007f001a812329/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd70317007f001a812329/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd70317007f001a812329/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd70317007f001a812329/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fe17007f001a8122e1",
+							"name": "Episode 91",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-91-1995-1-91",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fe17007f001a8122e1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fe17007f001a8122e1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fe17007f001a8122e1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fe17007f001a8122e1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fe17007f001a8122e1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd70217007f001a812313",
+							"name": "Episode 93",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-93-1995-1-93",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd70217007f001a812313/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd70217007f001a812313/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd70217007f001a812313/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd70217007f001a812313/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd70217007f001a812313/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fd17007f001a8122c3",
+							"name": "Episode 94",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-94-1995-1-94",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fd17007f001a8122c3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fd17007f001a8122c3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fd17007f001a8122c3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fd17007f001a8122c3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fd17007f001a8122c3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd70017007f001a8122fd",
+							"name": "Episode 95",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-95-1995-1-95",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd70017007f001a8122fd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd70017007f001a8122fd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd70017007f001a8122fd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/4782B700-AAAA-324C-97E6-9D297BD0755F_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/4782B700-AAAA-324C-97E6-9D297BD0755F_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6f617007f001a811fde",
+							"name": "Episode 96",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-96-1995-1-96",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6f617007f001a811fde/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6f617007f001a811fde/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a811fde/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a811fde/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a811fde/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812110",
+							"name": "Episode 97",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-97-1995-1-97",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812110/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812110/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812110/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812110/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812110/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6f617007f001a811ff3",
+							"name": "Episode 98",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-98-1995-1-98",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6f617007f001a811ff3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6f617007f001a811ff3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a811ff3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a811ff3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a811ff3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812192",
+							"name": "Episode 99",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-99-1995-1-99",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812192/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812192/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812192/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812192/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812192/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812271",
+							"name": "Episode 100",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-100-1995-1-100",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812271/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812271/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812271/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812271/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812271/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fda1ca306001a360ebb",
+							"name": "Episode 101",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-101-1995-1-101",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fda1ca306001a360ebb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fda1ca306001a360ebb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ebb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ebb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360ebb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fdd1ca306001a360f00",
+							"name": "Episode 102",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-102-1995-1-102",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fdd1ca306001a360f00/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fdd1ca306001a360f00/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f00/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f00/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f00/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fdd1ca306001a360f35",
+							"name": "Episode 103",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-103-1995-1-103",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fdd1ca306001a360f35/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fdd1ca306001a360f35/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f35/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f35/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f35/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fda1ca306001a360edd",
+							"name": "Episode 104",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-104-1995-1-104",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fda1ca306001a360edd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fda1ca306001a360edd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360edd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360edd/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360edd/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fdd1ca306001a360f23",
+							"name": "Episode 105",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-105-1995-1-105",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fdd1ca306001a360f23/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fdd1ca306001a360f23/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f23/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f23/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fdd1ca306001a360f23/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a81213e",
+							"name": "Episode 106",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-106-1995-1-106",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a81213e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a81213e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a81213e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/70D4C5E0-231B-A64D-A68A-B27B206CD50C_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/70D4C5E0-231B-A64D-A68A-B27B206CD50C_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6f917007f001a812065",
+							"name": "Episode 107",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-107-1995-1-107",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6f917007f001a812065/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6f917007f001a812065/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a812065/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a812065/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a812065/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a81217d",
+							"name": "Episode 108",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-108-1995-1-108",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a81217d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a81217d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a81217d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a81217d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a81217d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a8121d1",
+							"name": "Episode 109",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-109-1995-1-109",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a8121d1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a8121d1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121d1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121d1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121d1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812168",
+							"name": "Episode 110",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-110-1995-1-110",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812168/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812168/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/assets/images/default/vod.poster-default.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/4F55B17D-7273-BC49-8B68-B9ABDB8913EB_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/4F55B17D-7273-BC49-8B68-B9ABDB8913EB_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812153",
+							"name": "Episode 111",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-111-1995-1-111",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812153/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812153/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812153/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812153/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812153/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a8121fb",
+							"name": "Episode 112",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-112-1995-1-112",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a8121fb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a8121fb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121fb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/D2EFDDC1-E357-4843-87F2-50CF895BD740_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/D2EFDDC1-E357-4843-87F2-50CF895BD740_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812246",
+							"name": "Episode 113",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-113-1995-1-113",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812246/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812246/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812246/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812246/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812246/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a8122a6",
+							"name": "Episode 114",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-114-1995-1-114",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a8122a6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a8122a6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8122a6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8122a6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8122a6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a81228b",
+							"name": "Episode 115",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-115-1995-1-115",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a81228b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a81228b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/assets/images/default/vod.poster-default.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a81228b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/B60438F3-A40C-D244-9F32-0A4B9AC12DE1_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60dcdc30027af500135aa301",
+							"name": "Episode 116",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-116-1995-1-116",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60dcdc30027af500135aa301/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60dcdc30027af500135aa301/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60dcdc30027af500135aa301/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60dcdc30027af500135aa301/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60dcdc30027af500135aa301/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a8121e6",
+							"name": "Episode 117",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-117-1995-1-117",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a8121e6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a8121e6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121e6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121e6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121e6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fa17007f001a8120e0",
+							"name": "Episode 118",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-118-1995-1-118",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fa17007f001a8120e0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fa17007f001a8120e0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fa17007f001a8120e0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/B24E9D7C-6887-F542-8436-B4288EED884B_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/B24E9D7C-6887-F542-8436-B4288EED884B_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a8121a7",
+							"name": "Episode 119",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-119-1995-1-119",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a8121a7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a8121a7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121a7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121a7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121a7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6f617007f001a812008",
+							"name": "Episode 120",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-120-1995-1-120",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6f617007f001a812008/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6f617007f001a812008/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a812008/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a812008/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6f617007f001a812008/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812210",
+							"name": "Episode 121",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-121-1995-1-121",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812210/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812210/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/assets/images/default/vod.poster-default.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/0C6C3D3D-B26E-A041-8E07-9D31473EB518_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/0C6C3D3D-B26E-A041-8E07-9D31473EB518_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6f517007f001a811fc6",
+							"name": "Episode 122",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-122-1995-1-122",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6f517007f001a811fc6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6f517007f001a811fc6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6f517007f001a811fc6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6f517007f001a811fc6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6f517007f001a811fc6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812225",
+							"name": "Episode 123",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-123-1995-1-123",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812225/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812225/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/assets/images/default/vod.poster-default.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/205D1DE6-3B33-E348-8D7D-1CEE28DB60C5_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/205D1DE6-3B33-E348-8D7D-1CEE28DB60C5_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6f917007f001a81204f",
+							"name": "Episode 124",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-124-1995-1-124",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6f917007f001a81204f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6f917007f001a81204f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a81204f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a81204f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a81204f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a8121bc",
+							"name": "Episode 125",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-125-1995-1-125",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a8121bc/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a8121bc/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a8121bc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/F50AC9B1-B04B-464F-A93E-AD2B0FF25CE6_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/F50AC9B1-B04B-464F-A93E-AD2B0FF25CE6_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6f917007f001a812091",
+							"name": "Episode 126",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-126-1995-1-126",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6f917007f001a812091/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6f917007f001a812091/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a812091/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a812091/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a812091/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6f917007f001a81207c",
+							"name": "Episode 127",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-127-1995-1-127",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6f917007f001a81207c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6f917007f001a81207c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a81207c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a81207c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6f917007f001a81207c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a81225c",
+							"name": "Episode 128",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-128-1995-1-128",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a81225c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a81225c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a81225c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a81225c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a81225c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fc17007f001a812129",
+							"name": "Episode 129",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-129-1995-1-129",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fc17007f001a812129/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fc17007f001a812129/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812129/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812129/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fc17007f001a812129/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fa17007f001a8120c9",
+							"name": "Episode 130",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-130-1995-1-130",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fa17007f001a8120c9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fa17007f001a8120c9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fa17007f001a8120c9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fa17007f001a8120c9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/604fd6fa17007f001a8120c9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "604fd6fb17007f001a8120f5",
+							"name": "Episode 131",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-131-1995-1-131",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/604fd6fb17007f001a8120f5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/604fd6fb17007f001a8120f5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/604fd6fb17007f001a8120f5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/604fd6fb17007f001a8120f5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/BE3F111D-1A8B-FA4A-8D35-CA7C79E39269_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db283e7c979001a88fe45",
+							"name": "Episode 133",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-133-1995-1-133",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db283e7c979001a88fe45/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db283e7c979001a88fe45/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db283e7c979001a88fe45/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db283e7c979001a88fe45/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db283e7c979001a88fe45/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db285e7c979001a88ff73",
+							"name": "Episode 134",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-134-1995-1-134",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db285e7c979001a88ff73/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db285e7c979001a88ff73/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db285e7c979001a88ff73/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db285e7c979001a88ff73/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db285e7c979001a88ff73/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db283e7c979001a88fdd8",
+							"name": "Episode 136",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-136-1995-1-136",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db283e7c979001a88fdd8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db283e7c979001a88fdd8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db283e7c979001a88fdd8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db283e7c979001a88fdd8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db283e7c979001a88fdd8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db27fe7c979001a88fd1e",
+							"name": "Episode 137",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-137-1995-1-137",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db27fe7c979001a88fd1e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db27fe7c979001a88fd1e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fd1e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fd1e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fd1e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db27fe7c979001a88fcfb",
+							"name": "Episode 138",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-138-1995-1-138",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db27fe7c979001a88fcfb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db27fe7c979001a88fcfb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fcfb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fcfb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fcfb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db27fe7c979001a88fce6",
+							"name": "Episode 141",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-141-1995-1-141",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db27fe7c979001a88fce6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db27fe7c979001a88fce6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fce6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fce6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db27fe7c979001a88fce6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db27ee7c979001a88fcbf",
+							"name": "Episode 142",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-142-1995-1-142",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db27ee7c979001a88fcbf/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db27ee7c979001a88fcbf/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db27ee7c979001a88fcbf/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db27ee7c979001a88fcbf/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db27ee7c979001a88fcbf/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db27de7c979001a88fca0",
+							"name": "Episode 143",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-143-1995-1-143",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db27de7c979001a88fca0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db27de7c979001a88fca0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db27de7c979001a88fca0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db27de7c979001a88fca0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db27de7c979001a88fca0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db263e7c979001a88f849",
+							"name": "Episode 144",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-144-1995-1-144",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db263e7c979001a88f849/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db263e7c979001a88f849/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f849/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f849/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f849/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db263e7c979001a88f860",
+							"name": "Episode 146",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-146-1995-1-146",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db263e7c979001a88f860/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db263e7c979001a88f860/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f860/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f860/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f860/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f96a",
+							"name": "Episode 147",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-147-1995-1-147",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f96a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f96a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f96a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f96a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f96a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f955",
+							"name": "Episode 148",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-148-1995-1-148",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f955/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f955/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f955/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f955/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f955/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db265e7c979001a88f8c1",
+							"name": "Episode 149",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-149-1995-1-149",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db265e7c979001a88f8c1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db265e7c979001a88f8c1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8c1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8c1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8c1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f9ff",
+							"name": "Episode 151",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-151-1995-1-151",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f9ff/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f9ff/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ff/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ff/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ff/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f940",
+							"name": "Episode 152",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-152-1995-1-152",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f940/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f940/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f940/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f940/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f940/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88fa29",
+							"name": "Episode 153",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-153-1995-1-153",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88fa29/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88fa29/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa29/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa29/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa29/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fda1ca306001a360e93",
+							"name": "Episode 154",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-154-1995-1-154",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fda1ca306001a360e93/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fda1ca306001a360e93/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360e93/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360e93/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360e93/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88fa7e",
+							"name": "Episode 155",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-155-1995-1-155",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88fa7e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88fa7e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/assets/images/default/vod.poster-default.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/C36C5350-0B9D-A044-A3C5-6CB127AF73E2_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/C36C5350-0B9D-A044-A3C5-6CB127AF73E2_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db263e7c979001a88f834",
+							"name": "Episode 156",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-156-1995-1-156",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db263e7c979001a88f834/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db263e7c979001a88f834/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f834/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f834/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f834/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fda1ca306001a360e82",
+							"name": "Episode 157",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-157-1995-1-157",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fda1ca306001a360e82/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fda1ca306001a360e82/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360e82/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360e82/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fda1ca306001a360e82/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f981",
+							"name": "Episode 158",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-158-1995-1-158",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f981/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f981/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f981/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f981/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f981/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db265e7c979001a88f897",
+							"name": "Episode 159",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-159-1995-1-159",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db265e7c979001a88f897/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db265e7c979001a88f897/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f897/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f897/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f897/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88faa8",
+							"name": "Episode 160",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-160-1995-1-160",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88faa8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88faa8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88faa8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/511B838D-B585-9A4B-A7EA-1542AD8D6A34_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/511B838D-B585-9A4B-A7EA-1542AD8D6A34_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88fa54",
+							"name": "Episode 161",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-161-1995-1-161",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88fa54/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88fa54/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa54/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa54/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa54/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "60551fd91ca306001a360e6a",
+							"name": "Episode 162",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-162-1995-1-162",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/60551fd91ca306001a360e6a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/60551fd91ca306001a360e6a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/60551fd91ca306001a360e6a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/60551fd91ca306001a360e6a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/60551fd91ca306001a360e6a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db263e7c979001a88f81c",
+							"name": "Episode 163",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-163-1995-1-163",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db263e7c979001a88f81c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db263e7c979001a88f81c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f81c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f81c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db263e7c979001a88f81c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db265e7c979001a88f901",
+							"name": "Episode 164",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-164-1995-1-164",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db265e7c979001a88f901/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db265e7c979001a88f901/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f901/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f901/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f901/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88fa93",
+							"name": "Episode 165",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-165-1995-1-165",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88fa93/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88fa93/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa93/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa93/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa93/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88fa3f",
+							"name": "Episode 166",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-166-1995-1-166",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88fa3f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88fa3f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/assets/images/default/vod.poster-default.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/B6796A34-66BE-8543-9FA3-3B164AF572CD_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/B6796A34-66BE-8543-9FA3-3B164AF572CD_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f916",
+							"name": "Episode 167",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-167-1995-1-167",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f916/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f916/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f916/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f916/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f916/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88fabd",
+							"name": "Episode 168",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-168-1995-1-168",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88fabd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88fabd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fabd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fabd/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fabd/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f9d5",
+							"name": "Episode 169",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-169-1995-1-169",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f9d5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f9d5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9d5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9d5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9d5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db265e7c979001a88f8d7",
+							"name": "Episode 170",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-170-1995-1-170",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db265e7c979001a88f8d7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db265e7c979001a88f8d7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8d7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8d7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8d7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88fa14",
+							"name": "Episode 171",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-171-1995-1-171",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88fa14/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88fa14/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa14/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa14/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa14/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db265e7c979001a88f8ec",
+							"name": "Episode 172",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-172-1995-1-172",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db265e7c979001a88f8ec/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db265e7c979001a88f8ec/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8ec/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8ec/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8ec/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f996",
+							"name": "Episode 173",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-73-1995-1-173",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f996/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f996/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f996/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f996/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f996/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f92b",
+							"name": "Episode 174",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-174-1995-1-174",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f92b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f92b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f92b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f92b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f92b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88fa69",
+							"name": "Episode 175",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-175-1995-1-175",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88fa69/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88fa69/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88fa69/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/492A454B-36D2-F44B-9BB1-139BE95F6268_int_4x3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://silo.pluto.tv/origin/2gdigital/partners/5efe3f212eac71000725fcd0/492A454B-36D2-F44B-9BB1-139BE95F6268_int_16x9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f9c0",
+							"name": "Episode 176",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-176-1995-1-176",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f9c0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f9c0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9c0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9c0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9c0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db265e7c979001a88f8ac",
+							"name": "Episode 177",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-177-1995-1-177",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db265e7c979001a88f8ac/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db265e7c979001a88f8ac/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8ac/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8ac/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f8ac/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db265e7c979001a88f882",
+							"name": "Episode 178",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-178-1995-1-178",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db265e7c979001a88f882/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db265e7c979001a88f882/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f882/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f882/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db265e7c979001a88f882/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f9ab",
+							"name": "Episode 179",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-179-1995-1-179",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f9ab/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f9ab/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ab/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ab/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ab/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "603db266e7c979001a88f9ea",
+							"name": "Episode 180",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-180-1995-1-180",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/603db266e7c979001a88f9ea/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/603db266e7c979001a88f9ea/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ea/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ea/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/603db266e7c979001a88f9ea/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 2,
+					"episodes": [
+						{
+							"_id": "624dd7fd7936240013192419",
+							"name": "Episode 1",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-1-s2e1-1996-2-1",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624dd7fd7936240013192419/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624dd7fd7936240013192419/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624dd7fd7936240013192419/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624dd7fd7936240013192419/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624dd7fd7936240013192419/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f46fc3f03ed0013c2ffbf",
+							"name": "Episode 2",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-2-1996-2-2-ptv3",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f46fc3f03ed0013c2ffbf/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f46fc3f03ed0013c2ffbf/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f46fc3f03ed0013c2ffbf/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f46fc3f03ed0013c2ffbf/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f46fc3f03ed0013c2ffbf/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624ddac1d0f36a0013e54668",
+							"name": "Episode 3",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-3-s2e3-1996-2-3",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624ddac1d0f36a0013e54668/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624ddac1d0f36a0013e54668/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624ddac1d0f36a0013e54668/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624ddac1d0f36a0013e54668/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624ddac1d0f36a0013e54668/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624ddd9325269a0013aefddb",
+							"name": "Episode 4",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-4-s2e4-1996-2-4",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624ddd9325269a0013aefddb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624ddd9325269a0013aefddb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624ddd9325269a0013aefddb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624ddd9325269a0013aefddb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624ddd9325269a0013aefddb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f6328bacbfb0013bf9a02",
+							"name": "Episode 5",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-5-1996-2-5-ptv3",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f6328bacbfb0013bf9a02/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f6328bacbfb0013bf9a02/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f6328bacbfb0013bf9a02/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f6328bacbfb0013bf9a02/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f6328bacbfb0013bf9a02/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624ddacbd0f36a0013e5483f",
+							"name": "Episode 6",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-6-s2e6-1996-2-6",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624ddacbd0f36a0013e5483f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624ddacbd0f36a0013e5483f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624ddacbd0f36a0013e5483f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624ddacbd0f36a0013e5483f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624ddacbd0f36a0013e5483f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f64a528c6dd00132aed8a",
+							"name": "Episode 7",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-7-1996-2-7-ptv3",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f64a528c6dd00132aed8a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f64a528c6dd00132aed8a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f64a528c6dd00132aed8a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f64a528c6dd00132aed8a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f64a528c6dd00132aed8a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624ddac8d0f36a0013e5477f",
+							"name": "Episode 8",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-8-s2e8-1996-2-8",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624ddac8d0f36a0013e5477f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624ddac8d0f36a0013e5477f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624ddac8d0f36a0013e5477f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624ddac8d0f36a0013e5477f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624ddac8d0f36a0013e5477f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f6fd08f17ad0013f3ea87",
+							"name": "Episode 9",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-9-1996-2-9",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f6fd08f17ad0013f3ea87/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f6fd08f17ad0013f3ea87/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f6fd08f17ad0013f3ea87/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f6fd08f17ad0013f3ea87/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f6fd08f17ad0013f3ea87/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624ddc35ef11000014d7085d",
+							"name": "Episode 10",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-10-s2e10-1996-2-10",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624ddc35ef11000014d7085d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624ddc35ef11000014d7085d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624ddc35ef11000014d7085d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624ddc35ef11000014d7085d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624ddc35ef11000014d7085d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624ddc29ef11000014d7061d",
+							"name": "Episode 11",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-11-s2e11-1996-2-11",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624ddc29ef11000014d7061d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624ddc29ef11000014d7061d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624ddc29ef11000014d7061d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624ddc29ef11000014d7061d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624ddc29ef11000014d7061d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f6fd88f17ad0013f3ebe6",
+							"name": "Episode 12",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-12-1996-2-12",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f6fd88f17ad0013f3ebe6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f6fd88f17ad0013f3ebe6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f6fd88f17ad0013f3ebe6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f6fd88f17ad0013f3ebe6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f6fd88f17ad0013f3ebe6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f6fcb8f17ad0013f3ea30",
+							"name": "Episode 13",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-13-1996-2-13",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f6fcb8f17ad0013f3ea30/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f6fcb8f17ad0013f3ea30/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f6fcb8f17ad0013f3ea30/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f6fcb8f17ad0013f3ea30/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f6fcb8f17ad0013f3ea30/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f6fdb8f17ad0013f3ec3d",
+							"name": "Episode 14",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-14-1996-2-14",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f6fdb8f17ad0013f3ec3d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f6fdb8f17ad0013f3ec3d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f6fdb8f17ad0013f3ec3d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f6fdb8f17ad0013f3ec3d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f6fdb8f17ad0013f3ec3d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624ddc2eef11000014d706dd",
+							"name": "Episode 15",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-15-s2e15-1996-2-15",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624ddc2eef11000014d706dd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624ddc2eef11000014d706dd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624ddc2eef11000014d706dd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624ddc2eef11000014d706dd/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624ddc2eef11000014d706dd/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f71331a74b5001324083c",
+							"name": "Episode 16",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-16-1996-2-16",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f71331a74b5001324083c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f71331a74b5001324083c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f71331a74b5001324083c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f71331a74b5001324083c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f71331a74b5001324083c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624ddc32ef11000014d7079d",
+							"name": "Episode 17",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "judge-judy-episode-17-s2e17-1996-2-17",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624ddc32ef11000014d7079d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624ddc32ef11000014d7079d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624ddc32ef11000014d7079d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624ddc32ef11000014d7079d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624ddc32ef11000014d7079d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f729228c6dd00132aee23",
+							"name": "Episode 18",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-18-1996-2-18",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f729228c6dd00132aee23/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f729228c6dd00132aee23/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f729228c6dd00132aee23/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f729228c6dd00132aee23/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f729228c6dd00132aee23/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f74037b9eaf001376864c",
+							"name": "Episode 19",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-19-1996-2-19",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f74037b9eaf001376864c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f74037b9eaf001376864c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f74037b9eaf001376864c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f74037b9eaf001376864c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f74037b9eaf001376864c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f76d778f6d300136d4fe5",
+							"name": "Episode 20",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-20-1996-2-20",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f76d778f6d300136d4fe5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f76d778f6d300136d4fe5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f76d778f6d300136d4fe5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f76d778f6d300136d4fe5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f76d778f6d300136d4fe5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f76ca78f6d300136d4ebe",
+							"name": "Episode 21",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-21-1996-2-21",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f76ca78f6d300136d4ebe/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f76ca78f6d300136d4ebe/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f76ca78f6d300136d4ebe/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f76ca78f6d300136d4ebe/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f76ca78f6d300136d4ebe/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f76d278f6d300136d4f8e",
+							"name": "Episode 22",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-22-1996-2-22",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f76d278f6d300136d4f8e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f76d278f6d300136d4f8e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f76d278f6d300136d4f8e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f76d278f6d300136d4f8e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f76d278f6d300136d4f8e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f78324a1dfc0013fc5b0d",
+							"name": "Episode 23",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-23-1996-2-23",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f78324a1dfc0013fc5b0d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f78324a1dfc0013fc5b0d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f78324a1dfc0013fc5b0d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f78324a1dfc0013fc5b0d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f78324a1dfc0013fc5b0d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f783c4a1dfc0013fc5c21",
+							"name": "Episode 24",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-24-1996-2-24",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f783c4a1dfc0013fc5c21/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f783c4a1dfc0013fc5c21/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f783c4a1dfc0013fc5c21/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f783c4a1dfc0013fc5c21/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f783c4a1dfc0013fc5c21/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f78384a1dfc0013fc5b97",
+							"name": "Episode 25",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-25-1996-2-25",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f78384a1dfc0013fc5b97/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f78384a1dfc0013fc5b97/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f78384a1dfc0013fc5b97/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f78384a1dfc0013fc5b97/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f78384a1dfc0013fc5b97/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f784b4a1dfc0013fc5c78",
+							"name": "Episode 26",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-26-1996-2-26",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f784b4a1dfc0013fc5c78/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f784b4a1dfc0013fc5c78/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f784b4a1dfc0013fc5c78/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f784b4a1dfc0013fc5c78/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f784b4a1dfc0013fc5c78/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "628fc7454e0353001a42f456",
+							"name": "Episode 27",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-27-1996-2-27",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/628fc7454e0353001a42f456/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/628fc7454e0353001a42f456/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/628fc7454e0353001a42f456/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/628fc7454e0353001a42f456/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/628fc7454e0353001a42f456/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f7b02228ab000133a35cd",
+							"name": "Episode 28",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-28-1996-2-28",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f7b02228ab000133a35cd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f7b02228ab000133a35cd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f7b02228ab000133a35cd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f7b02228ab000133a35cd/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f7b02228ab000133a35cd/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f7b0f228ab000133a3624",
+							"name": "Episode 29",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-29-1996-2-29",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f7b0f228ab000133a3624/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f7b0f228ab000133a3624/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f7b0f228ab000133a3624/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f7b0f228ab000133a3624/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f7b0f228ab000133a3624/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c3dc28c6dd00132bcd1e",
+							"name": "Episode 30",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-30-1996-2-30",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c3dc28c6dd00132bcd1e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c3dc28c6dd00132bcd1e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c3dc28c6dd00132bcd1e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c3dc28c6dd00132bcd1e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c3dc28c6dd00132bcd1e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d0953f03ed0013c3e35d",
+							"name": "Episode 31",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-31-1996-2-31",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d0953f03ed0013c3e35d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d0953f03ed0013c3e35d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d0953f03ed0013c3e35d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d0953f03ed0013c3e35d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d0953f03ed0013c3e35d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "627a9e4a73a0a10014548150",
+							"name": "Episode 32",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-32-1996-2-32",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/627a9e4a73a0a10014548150/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/627a9e4a73a0a10014548150/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/627a9e4a73a0a10014548150/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/627a9e4a73a0a10014548150/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/627a9e4a73a0a10014548150/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d20087cec4001355e826",
+							"name": "Episode 33",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-33-1996-2-33",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d20087cec4001355e826/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d20087cec4001355e826/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d20087cec4001355e826/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d20087cec4001355e826/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d20087cec4001355e826/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250dc044a1dfc0013fccdff",
+							"name": "Episode 34",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-34-1996-2-34",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250dc044a1dfc0013fccdff/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250dc044a1dfc0013fccdff/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250dc044a1dfc0013fccdff/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250dc044a1dfc0013fccdff/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250dc044a1dfc0013fccdff/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250da9d3f03ed0013c39ebb",
+							"name": "Episode 35",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-35-1996-2-35",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250da9d3f03ed0013c39ebb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250da9d3f03ed0013c39ebb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250da9d3f03ed0013c39ebb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250da9d3f03ed0013c39ebb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250da9d3f03ed0013c39ebb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d1f687cec4001355e768",
+							"name": "Episode 36",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-36-1996-2-36",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d1f687cec4001355e768/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d1f687cec4001355e768/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d1f687cec4001355e768/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d1f687cec4001355e768/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d1f687cec4001355e768/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250d92e228ab000133b0330",
+							"name": "Episode 37",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-37-1996-2-37",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250d92e228ab000133b0330/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250d92e228ab000133b0330/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250d92e228ab000133b0330/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250d92e228ab000133b0330/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250d92e228ab000133b0330/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d361baa39e0013dfff64",
+							"name": "Episode 38",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-38-1996-2-38",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d361baa39e0013dfff64/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d361baa39e0013dfff64/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d361baa39e0013dfff64/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d361baa39e0013dfff64/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d361baa39e0013dfff64/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d0913f03ed0013c3e33f",
+							"name": "Episode 39",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-39-1996-2-39",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d0913f03ed0013c3e33f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d0913f03ed0013c3e33f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d0913f03ed0013c3e33f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d0913f03ed0013c3e33f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d0913f03ed0013c3e33f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d08a3f03ed0013c3e2c2",
+							"name": "Episode 40",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-40-1996-2-40",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d08a3f03ed0013c3e2c2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d08a3f03ed0013c3e2c2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d08a3f03ed0013c3e2c2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d08a3f03ed0013c3e2c2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d08a3f03ed0013c3e2c2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d365baa39e0013dfffae",
+							"name": "Episode 41",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-41-1996-2-41",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d365baa39e0013dfffae/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d365baa39e0013dfffae/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d365baa39e0013dfffae/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d365baa39e0013dfffae/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d365baa39e0013dfffae/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d1fb87cec4001355e7c7",
+							"name": "Episode 42",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-42-1996-2-42",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d1fb87cec4001355e7c7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d1fb87cec4001355e7c7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d1fb87cec4001355e7c7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d1fb87cec4001355e7c7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d1fb87cec4001355e7c7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f7c727b9eaf001376879d",
+							"name": "Episode 43",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-43-1996-2-43",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f7c727b9eaf001376879d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f7c727b9eaf001376879d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f7c727b9eaf001376879d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f7c727b9eaf001376879d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f7c727b9eaf001376879d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f7c6f7b9eaf0013768746",
+							"name": "Episode 44",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-44-1996-2-44",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f7c6f7b9eaf0013768746/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f7c6f7b9eaf0013768746/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f7c6f7b9eaf0013768746/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f7c6f7b9eaf0013768746/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f7c6f7b9eaf0013768746/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f7c7a7b9eaf001376886d",
+							"name": "Episode 45",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-45-1996-2-45",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f7c7a7b9eaf001376886d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f7c7a7b9eaf001376886d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f7c7a7b9eaf001376886d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f7c7a7b9eaf001376886d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f7c7a7b9eaf001376886d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f7dd828c6dd00132af03e",
+							"name": "Episode 46",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-46-1996-2-46",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f7dd828c6dd00132af03e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f7dd828c6dd00132af03e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f7dd828c6dd00132af03e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f7dd828c6dd00132af03e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f7dd828c6dd00132af03e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f7dd228c6dd00132aef70",
+							"name": "Episode 47",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-47-1996-2-47",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f7dd228c6dd00132aef70/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f7dd228c6dd00132aef70/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f7dd228c6dd00132aef70/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f7dd228c6dd00132aef70/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f7dd228c6dd00132aef70/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8379228ab000133a679e",
+							"name": "Episode 48",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-48-1996-2-48",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8379228ab000133a679e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8379228ab000133a679e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8379228ab000133a679e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8379228ab000133a679e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8379228ab000133a679e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f837d228ab000133a67f5",
+							"name": "Episode 49",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-49-1996-2-49",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f837d228ab000133a67f5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f837d228ab000133a67f5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f837d228ab000133a67f5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f837d228ab000133a67f5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f837d228ab000133a67f5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f84dd87cec4001354d802",
+							"name": "Episode 50",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-50-1996-2-50",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f84dd87cec4001354d802/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f84dd87cec4001354d802/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f84dd87cec4001354d802/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f84dd87cec4001354d802/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f84dd87cec4001354d802/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f84e887cec4001354d91a",
+							"name": "Episode 51",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-51-1996-2-51",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f84e887cec4001354d91a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f84e887cec4001354d91a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f84e887cec4001354d91a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f84e887cec4001354d91a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f84e887cec4001354d91a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f84da87cec4001354d778",
+							"name": "Episode 52",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-52-1996-2-52",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f84da87cec4001354d778/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f84da87cec4001354d778/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f84da87cec4001354d778/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f84da87cec4001354d778/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f84da87cec4001354d778/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8645025eb50013a06944",
+							"name": "Episode 53",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-53-1996-2-53",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8645025eb50013a06944/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8645025eb50013a06944/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8645025eb50013a06944/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8645025eb50013a06944/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8645025eb50013a06944/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8642025eb50013a068ba",
+							"name": "Episode 54",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-54-1996-2-54",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8642025eb50013a068ba/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8642025eb50013a068ba/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8642025eb50013a068ba/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8642025eb50013a068ba/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8642025eb50013a068ba/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8649025eb50013a069ce",
+							"name": "Episode 55",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-55-1996-2-55",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8649025eb50013a069ce/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8649025eb50013a069ce/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8649025eb50013a069ce/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8649025eb50013a069ce/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8649025eb50013a069ce/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d35abaa39e0013dffe96",
+							"name": "Episode 56",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-56-1996-2-56",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d35abaa39e0013dffe96/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d35abaa39e0013dffe96/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d35abaa39e0013dffe96/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d35abaa39e0013dffe96/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d35abaa39e0013dffe96/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f87aa87cec4001354d938",
+							"name": "Episode 57",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-57-1996-2-57",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f87aa87cec4001354d938/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f87aa87cec4001354d938/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f87aa87cec4001354d938/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f87aa87cec4001354d938/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f87aa87cec4001354d938/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6253d08e3f03ed0013c3e321",
+							"name": "Episode 58",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-58-1996-2-58",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6253d08e3f03ed0013c3e321/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6253d08e3f03ed0013c3e321/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6253d08e3f03ed0013c3e321/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6253d08e3f03ed0013c3e321/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6253d08e3f03ed0013c3e321/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c3d228c6dd00132bcb82",
+							"name": "Episode 60",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-60-1996-2-60",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c3d228c6dd00132bcb82/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c3d228c6dd00132bcb82/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c3d228c6dd00132bcb82/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c3d228c6dd00132bcb82/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c3d228c6dd00132bcb82/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f87bc87cec4001354d9c2",
+							"name": "Episode 61",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-61-1996-2-61",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f87bc87cec4001354d9c2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f87bc87cec4001354d9c2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f87bc87cec4001354d9c2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f87bc87cec4001354d9c2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f87bc87cec4001354d9c2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f89123f03ed0013c30488",
+							"name": "Episode 62",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-62-1996-2-62",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f89123f03ed0013c30488/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f89123f03ed0013c30488/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f89123f03ed0013c30488/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f89123f03ed0013c30488/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f89123f03ed0013c30488/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f89193f03ed0013c304a7",
+							"name": "Episode 63",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-63-1996-2-63",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f89193f03ed0013c304a7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f89193f03ed0013c304a7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f89193f03ed0013c304a7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f89193f03ed0013c304a7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f89193f03ed0013c304a7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f89263f03ed0013c305ae",
+							"name": "Episode 64",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-64-1996-2-64",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f89263f03ed0013c305ae/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f89263f03ed0013c305ae/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f89263f03ed0013c305ae/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f89263f03ed0013c305ae/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f89263f03ed0013c305ae/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8a7abacbfb0013bf9f72",
+							"name": "Episode 65",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-65-1996-2-65",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8a7abacbfb0013bf9f72/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8a7abacbfb0013bf9f72/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8a7abacbfb0013bf9f72/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8a7abacbfb0013bf9f72/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8a7abacbfb0013bf9f72/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "627a9e5273a0a1001454821a",
+							"name": "Episode 66",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-66-1996-2-66",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/627a9e5273a0a1001454821a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/627a9e5273a0a1001454821a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/627a9e5273a0a1001454821a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/627a9e5273a0a1001454821a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/627a9e5273a0a1001454821a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8be1a2111500137e9020",
+							"name": "Episode 67",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-67-1996-2-67",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8be1a2111500137e9020/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8be1a2111500137e9020/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8be1a2111500137e9020/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8be1a2111500137e9020/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8be1a2111500137e9020/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62507de58f17ad0013f43a6e",
+							"name": "Episode 68",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-68-1996-2-68",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62507de58f17ad0013f43a6e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62507de58f17ad0013f43a6e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62507de58f17ad0013f43a6e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62507de58f17ad0013f43a6e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62507de58f17ad0013f43a6e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a5598f17ad0013f45ea9",
+							"name": "Episode 69",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-69-1996-2-69",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a5598f17ad0013f45ea9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a5598f17ad0013f45ea9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a5598f17ad0013f45ea9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a5598f17ad0013f45ea9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a5598f17ad0013f45ea9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a6927b9eaf001376d1ed",
+							"name": "Episode 70",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-70-1996-2-70",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a6927b9eaf001376d1ed/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a6927b9eaf001376d1ed/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a6927b9eaf001376d1ed/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a6927b9eaf001376d1ed/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a6927b9eaf001376d1ed/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c3d828c6dd00132bcc50",
+							"name": "Episode 71",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-71-1996-2-71",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c3d828c6dd00132bcc50/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c3d828c6dd00132bcc50/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c3d828c6dd00132bcc50/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c3d828c6dd00132bcc50/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c3d828c6dd00132bcc50/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a258025eb50013a0d842",
+							"name": "Episode 72",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-72-1996-2-72",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a258025eb50013a0d842/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a258025eb50013a0d842/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a258025eb50013a0d842/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a258025eb50013a0d842/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a258025eb50013a0d842/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625084cf025eb50013a0d212",
+							"name": "Episode 73",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-73-1996-2-73",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625084cf025eb50013a0d212/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625084cf025eb50013a0d212/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625084cf025eb50013a0d212/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625084cf025eb50013a0d212/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625084cf025eb50013a0d212/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c28428c6dd00132bc8cf",
+							"name": "Episode 74",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-74-1996-2-74",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c28428c6dd00132bc8cf/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c28428c6dd00132bc8cf/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c28428c6dd00132bc8cf/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c28428c6dd00132bc8cf/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c28428c6dd00132bc8cf/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c26f28c6dd00132bc7fa",
+							"name": "Episode 75",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-75-1996-2-75",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c26f28c6dd00132bc7fa/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c26f28c6dd00132bc7fa/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c26f28c6dd00132bc7fa/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c26f28c6dd00132bc7fa/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c26f28c6dd00132bc7fa/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8be6a2111500137e903e",
+							"name": "Episode 76",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-76-1996-2-76",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8be6a2111500137e903e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8be6a2111500137e903e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8be6a2111500137e903e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8be6a2111500137e903e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8be6a2111500137e903e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c2bf28c6dd00132bca6e",
+							"name": "Episode 77",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-77-1996-2-77",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c2bf28c6dd00132bca6e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c2bf28c6dd00132bca6e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c2bf28c6dd00132bca6e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c2bf28c6dd00132bca6e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c2bf28c6dd00132bca6e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c542c287f200130059a0",
+							"name": "Episode 78",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-78-1996-2-78",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c542c287f200130059a0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c542c287f200130059a0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c542c287f200130059a0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c542c287f200130059a0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c542c287f200130059a0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a25d025eb50013a0d910",
+							"name": "Episode 79",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-79-1996-2-79",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a25d025eb50013a0d910/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a25d025eb50013a0d910/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a25d025eb50013a0d910/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a25d025eb50013a0d910/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a25d025eb50013a0d910/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c3e028c6dd00132bcda8",
+							"name": "Episode 80",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-80-1996-2-80",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c3e028c6dd00132bcda8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c3e028c6dd00132bcda8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c3e028c6dd00132bcda8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c3e028c6dd00132bcda8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c3e028c6dd00132bcda8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62509cc228c6dd00132b589e",
+							"name": "Episode 81",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-81-1996-2-81",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62509cc228c6dd00132b589e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62509cc228c6dd00132b589e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62509cc228c6dd00132b589e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62509cc228c6dd00132b589e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62509cc228c6dd00132b589e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250dbff4a1dfc0013fccde1",
+							"name": "Episode 82",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-82-1996-2-82",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250dbff4a1dfc0013fccde1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250dbff4a1dfc0013fccde1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250dbff4a1dfc0013fccde1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250dbff4a1dfc0013fccde1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250dbff4a1dfc0013fccde1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250da983f03ed0013c39ded",
+							"name": "Episode 83",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-83-1996-2-83",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250da983f03ed0013c39ded/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250da983f03ed0013c39ded/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250da983f03ed0013c39ded/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250da983f03ed0013c39ded/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250da983f03ed0013c39ded/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250971d28c6dd00132b56b2",
+							"name": "Episode 84",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-84-1996-2-84",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250971d28c6dd00132b56b2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250971d28c6dd00132b56b2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250971d28c6dd00132b56b2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250971d28c6dd00132b56b2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250971d28c6dd00132b56b2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a3c378f6d300136da72b",
+							"name": "Episode 85",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-85-1996-2-85",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a3c378f6d300136da72b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a3c378f6d300136da72b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a3c378f6d300136da72b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a3c378f6d300136da72b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a3c378f6d300136da72b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6254c28928c6dd00132bc9c5",
+							"name": "Episode 86",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-86-1996-2-86",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6254c28928c6dd00132bc9c5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6254c28928c6dd00132bc9c5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6254c28928c6dd00132bc9c5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6254c28928c6dd00132bc9c5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6254c28928c6dd00132bc9c5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62507dc78f17ad0013f43991",
+							"name": "Episode 87",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-87-1996-2-87",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62507dc78f17ad0013f43991/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62507dc78f17ad0013f43991/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62507dc78f17ad0013f43991/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62507dc78f17ad0013f43991/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62507dc78f17ad0013f43991/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a5708f17ad0013f46117",
+							"name": "Episode 88",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-88-1996-2-88",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a5708f17ad0013f46117/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a5708f17ad0013f46117/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a5708f17ad0013f46117/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a5708f17ad0013f46117/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a5708f17ad0013f46117/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a3cc78f6d300136da7f9",
+							"name": "Episode 89",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-89-1996-2-89",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a3cc78f6d300136da7f9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a3cc78f6d300136da7f9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a3cc78f6d300136da7f9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a3cc78f6d300136da7f9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a3cc78f6d300136da7f9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a5638f17ad0013f45fcd",
+							"name": "Episode 90",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-90-1996-2-90",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a5638f17ad0013f45fcd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a5638f17ad0013f45fcd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a5638f17ad0013f45fcd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a5638f17ad0013f45fcd/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a5638f17ad0013f45fcd/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62509f98db330c001408f82f",
+							"name": "Episode 91",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-91-1996-2-91",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62509f98db330c001408f82f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62509f98db330c001408f82f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62509f98db330c001408f82f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62509f98db330c001408f82f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62509f98db330c001408f82f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62509e267b9eaf001376d176",
+							"name": "Episode 92",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-92-1996-2-92",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62509e267b9eaf001376d176/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62509e267b9eaf001376d176/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62509e267b9eaf001376d176/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62509e267b9eaf001376d176/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62509e267b9eaf001376d176/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a6967b9eaf001376d2bb",
+							"name": "Episode 93",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-93-1996-2-93",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a6967b9eaf001376d2bb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a6967b9eaf001376d2bb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a6967b9eaf001376d2bb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a6967b9eaf001376d2bb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a6967b9eaf001376d2bb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625098a187cec4001355787e",
+							"name": "Episode 94",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-94-1996-2-94",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625098a187cec4001355787e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625098a187cec4001355787e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625098a187cec4001355787e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625098a187cec4001355787e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625098a187cec4001355787e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6269aabc5bbb230014b63b43",
+							"name": "Episode 95",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-95-1996-2-95",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6269aabc5bbb230014b63b43/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6269aabc5bbb230014b63b43/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6269aabc5bbb230014b63b43/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6269aabc5bbb230014b63b43/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6269aabc5bbb230014b63b43/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6269aabb5bbb230014b63b29",
+							"name": "Episode 96",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-96-1996-2-96",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6269aabb5bbb230014b63b29/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6269aabb5bbb230014b63b29/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6269aabb5bbb230014b63b29/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6269aabb5bbb230014b63b29/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6269aabb5bbb230014b63b29/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "628e6ea38b143a001ab544aa",
+							"name": "Episode 97",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-97-1996-2-97",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/628e6ea38b143a001ab544aa/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/628e6ea38b143a001ab544aa/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/628e6ea38b143a001ab544aa/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/628e6ea38b143a001ab544aa/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/628e6ea38b143a001ab544aa/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "627aa3f755812e0013ecdee4",
+							"name": "Episode 98",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-98-1996-2-98",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/627aa3f755812e0013ecdee4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/627aa3f755812e0013ecdee4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/627aa3f755812e0013ecdee4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/627aa3f755812e0013ecdee4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/627aa3f755812e0013ecdee4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8d518f17ad0013f3fd06",
+							"name": "Episode 99",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-99-1996-2-99",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8d518f17ad0013f3fd06/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8d518f17ad0013f3fd06/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8d518f17ad0013f3fd06/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8d518f17ad0013f3fd06/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8d518f17ad0013f3fd06/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "627aa552a6d56300130227a0",
+							"name": "Episode 100",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-100-1996-2-100",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/627aa552a6d56300130227a0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/627aa552a6d56300130227a0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/627aa552a6d56300130227a0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/627aa552a6d56300130227a0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/627aa552a6d56300130227a0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250da923f03ed0013c39d8e",
+							"name": "Episode 101",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-101-1996-2-101",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250da923f03ed0013c39d8e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250da923f03ed0013c39d8e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250da923f03ed0013c39d8e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250da923f03ed0013c39d8e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250da923f03ed0013c39d8e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8d4a8f17ad0013f3fbf2",
+							"name": "Episode 102",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-102-1996-2-102",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8d4a8f17ad0013f3fbf2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8d4a8f17ad0013f3fbf2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8d4a8f17ad0013f3fbf2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8d4a8f17ad0013f3fbf2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8d4a8f17ad0013f3fbf2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f8d4d8f17ad0013f3fc7c",
+							"name": "Episode 103",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-103-1996-2-103",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f8d4d8f17ad0013f3fc7c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f8d4d8f17ad0013f3fc7c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f8d4d8f17ad0013f3fc7c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f8d4d8f17ad0013f3fc7c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f8d4d8f17ad0013f3fc7c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f901cdb330c00140847cb",
+							"name": "Episode 104",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-104-1996-2-104",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f901cdb330c00140847cb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f901cdb330c00140847cb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f901cdb330c00140847cb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f901cdb330c00140847cb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f901cdb330c00140847cb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9185db330c00140848af",
+							"name": "Episode 105",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-105-1996-2-105",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9185db330c00140848af/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9185db330c00140848af/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9185db330c00140848af/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9185db330c00140848af/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9185db330c00140848af/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9181db330c0014084858",
+							"name": "Episode 106",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-106-1996-2-106",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9181db330c0014084858/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9181db330c0014084858/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9181db330c0014084858/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9181db330c0014084858/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9181db330c0014084858/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9189db330c0014084939",
+							"name": "Episode 107",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-107-1996-2-107",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9189db330c0014084939/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9189db330c0014084939/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9189db330c0014084939/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9189db330c0014084939/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9189db330c0014084939/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f92f287cec4001354dbc2",
+							"name": "Episode 108",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-108-1996-2-108",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f92f287cec4001354dbc2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f92f287cec4001354dbc2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f92f287cec4001354dbc2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f92f287cec4001354dbc2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f92f287cec4001354dbc2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f92f687cec4001354dc19",
+							"name": "Episode 109",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-109-1996-2-109",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f92f687cec4001354dc19/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f92f687cec4001354dc19/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f92f687cec4001354dc19/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f92f687cec4001354dc19/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f92f687cec4001354dc19/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f92ea87cec4001354daae",
+							"name": "Episode 110",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-110-1996-2-110",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f92ea87cec4001354daae/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f92ea87cec4001354daae/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f92ea87cec4001354daae/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f92ea87cec4001354daae/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f92ea87cec4001354daae/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f92ef87cec4001354db38",
+							"name": "Episode 111",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-111-1996-2-111",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f92ef87cec4001354db38/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f92ef87cec4001354db38/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f92ef87cec4001354db38/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f92ef87cec4001354db38/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f92ef87cec4001354db38/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f945278f6d300136d5226",
+							"name": "Episode 112",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-112-1996-2-112",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f945278f6d300136d5226/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f945278f6d300136d5226/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f945278f6d300136d5226/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f945278f6d300136d5226/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f945278f6d300136d5226/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f945578f6d300136d527d",
+							"name": "Episode 113",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-113-1996-2-113",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f945578f6d300136d527d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f945578f6d300136d527d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f945578f6d300136d527d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f945578f6d300136d527d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f945578f6d300136d527d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f945978f6d300136d5307",
+							"name": "Episode 114",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-114-1996-2-114",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f945978f6d300136d5307/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f945978f6d300136d5307/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f945978f6d300136d5307/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f945978f6d300136d5307/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f945978f6d300136d5307/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f95ba28c6dd00132af4b3",
+							"name": "Episode 115",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-115-1996-2-115",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f95ba28c6dd00132af4b3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f95ba28c6dd00132af4b3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f95ba28c6dd00132af4b3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f95ba28c6dd00132af4b3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f95ba28c6dd00132af4b3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9721baa39e0013df2052",
+							"name": "Episode 116",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-116-1996-2-116",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9721baa39e0013df2052/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9721baa39e0013df2052/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9721baa39e0013df2052/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9721baa39e0013df2052/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9721baa39e0013df2052/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f972abaa39e0013df2126",
+							"name": "Episode 117",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-117-1996-2-117",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f972abaa39e0013df2126/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f972abaa39e0013df2126/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f972abaa39e0013df2126/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f972abaa39e0013df2126/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f972abaa39e0013df2126/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f972dbaa39e0013df21b0",
+							"name": "Episode 118",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-118-1996-2-118",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f972dbaa39e0013df21b0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f972dbaa39e0013df21b0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f972dbaa39e0013df21b0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f972dbaa39e0013df21b0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f972dbaa39e0013df21b0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9726baa39e0013df20dc",
+							"name": "Episode 119",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-119-1996-2-119",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9726baa39e0013df20dc/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9726baa39e0013df20dc/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9726baa39e0013df20dc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9726baa39e0013df20dc/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9726baa39e0013df20dc/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f988b4a1dfc0013fc7c3b",
+							"name": "Episode 120",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-120-1996-2-120",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f988b4a1dfc0013fc7c3b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f988b4a1dfc0013fc7c3b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f988b4a1dfc0013fc7c3b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f988b4a1dfc0013fc7c3b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f988b4a1dfc0013fc7c3b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f98924a1dfc0013fc7d4f",
+							"name": "Episode 121",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-121-1996-2-121",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f98924a1dfc0013fc7d4f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f98924a1dfc0013fc7d4f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f98924a1dfc0013fc7d4f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f98924a1dfc0013fc7d4f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f98924a1dfc0013fc7d4f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f98964a1dfc0013fc7dd9",
+							"name": "Episode 122",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-122-1996-2-122",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f98964a1dfc0013fc7dd9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f98964a1dfc0013fc7dd9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f98964a1dfc0013fc7dd9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f98964a1dfc0013fc7dd9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f98964a1dfc0013fc7dd9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f988e4a1dfc0013fc7cc5",
+							"name": "Episode 123",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-123-1996-2-123",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f988e4a1dfc0013fc7cc5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f988e4a1dfc0013fc7cc5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f988e4a1dfc0013fc7cc5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f988e4a1dfc0013fc7cc5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f988e4a1dfc0013fc7cc5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f99fda2111500137e91df",
+							"name": "Episode 124",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-124-1996-2-124",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f99fda2111500137e91df/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f99fda2111500137e91df/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f99fda2111500137e91df/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f99fda2111500137e91df/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f99fda2111500137e91df/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f99faa2111500137e9155",
+							"name": "Episode 125",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-125-1996-2-125",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f99faa2111500137e9155/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f99faa2111500137e9155/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f99faa2111500137e9155/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f99faa2111500137e9155/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f99faa2111500137e9155/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f99f2a2111500137e9081",
+							"name": "Episode 126",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-126-1996-2-126",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f99f2a2111500137e9081/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f99f2a2111500137e9081/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f99f2a2111500137e9081/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f99f2a2111500137e9081/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f99f2a2111500137e9081/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f99f6a2111500137e90cb",
+							"name": "Episode 127",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-127-1996-2-127",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f99f6a2111500137e90cb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f99f6a2111500137e90cb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f99f6a2111500137e90cb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f99f6a2111500137e90cb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f99f6a2111500137e90cb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9b5c8f17ad0013f401ad",
+							"name": "Episode 128",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-128-1996-2-128",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9b5c8f17ad0013f401ad/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9b5c8f17ad0013f401ad/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9b5c8f17ad0013f401ad/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9b5c8f17ad0013f401ad/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9b5c8f17ad0013f401ad/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9b608f17ad0013f401f7",
+							"name": "Episode 129",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-129-1996-2-129",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9b608f17ad0013f401f7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9b608f17ad0013f401f7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9b608f17ad0013f401f7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9b608f17ad0013f401f7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9b608f17ad0013f401f7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9cc6025eb50013a07cb7",
+							"name": "Episode 130",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-130-1996-2-130",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9cc6025eb50013a07cb7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9cc6025eb50013a07cb7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9cc6025eb50013a07cb7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9cc6025eb50013a07cb7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9cc6025eb50013a07cb7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9ccb025eb50013a07d0e",
+							"name": "Episode 131",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-131-1996-2-131",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9ccb025eb50013a07d0e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9ccb025eb50013a07d0e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9ccb025eb50013a07d0e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9ccb025eb50013a07d0e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9ccb025eb50013a07d0e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9cc2025eb50013a07c60",
+							"name": "Episode 132",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-132-1996-2-132",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9cc2025eb50013a07c60/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9cc2025eb50013a07c60/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9cc2025eb50013a07c60/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9cc2025eb50013a07c60/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9cc2025eb50013a07c60/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9e2a025eb50013a07d58",
+							"name": "Episode 133",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-133-1996-2-133",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9e2a025eb50013a07d58/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9e2a025eb50013a07d58/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9e2a025eb50013a07d58/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9e2a025eb50013a07d58/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9e2a025eb50013a07d58/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9e2e025eb50013a07de2",
+							"name": "Episode 134",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-134-1996-2-134",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9e2e025eb50013a07de2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9e2e025eb50013a07de2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9e2e025eb50013a07de2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9e2e025eb50013a07de2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9e2e025eb50013a07de2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9f93db330c0014084a45",
+							"name": "Episode 135",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-135-1996-2-135",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9f93db330c0014084a45/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9f93db330c0014084a45/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9f93db330c0014084a45/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9f93db330c0014084a45/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9f93db330c0014084a45/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624f9f97db330c0014084acf",
+							"name": "Episode 136",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-136-1996-2-136",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624f9f97db330c0014084acf/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624f9f97db330c0014084acf/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624f9f97db330c0014084acf/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624f9f97db330c0014084acf/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624f9f97db330c0014084acf/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa10c87cec4001354dd46",
+							"name": "Episode 137",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-137-1996-2-137",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa10c87cec4001354dd46/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa10c87cec4001354dd46/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa10c87cec4001354dd46/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa10c87cec4001354dd46/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa10c87cec4001354dd46/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa10287cec4001354dc72",
+							"name": "Episode 138",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-138-1996-2-138",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa10287cec4001354dc72/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa10287cec4001354dc72/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa10287cec4001354dc72/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa10287cec4001354dc72/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa10287cec4001354dc72/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa10687cec4001354dcfc",
+							"name": "Episode 139",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-139-1996-2-139",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa10687cec4001354dcfc/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa10687cec4001354dcfc/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa10687cec4001354dcfc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa10687cec4001354dcfc/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa10687cec4001354dcfc/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa11487cec4001354dd90",
+							"name": "Episode 140",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-140-1996-2-140",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa11487cec4001354dd90/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa11487cec4001354dd90/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa11487cec4001354dd90/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa11487cec4001354dd90/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa11487cec4001354dd90/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa26587cec4001354de71",
+							"name": "Episode 141",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-141-1996-2-141",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa26587cec4001354de71/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa26587cec4001354de71/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa26587cec4001354de71/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa26587cec4001354de71/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa26587cec4001354de71/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa26187cec4001354de1a",
+							"name": "Episode 142",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-142-1996-2-142",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa26187cec4001354de1a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa26187cec4001354de1a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa26187cec4001354de1a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa26187cec4001354de1a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa26187cec4001354de1a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa26887cec4001354defb",
+							"name": "Episode 143",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-143-1996-2-143",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa26887cec4001354defb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa26887cec4001354defb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa26887cec4001354defb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa26887cec4001354defb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa26887cec4001354defb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa3cedb330c0014084ba4",
+							"name": "Episode 144",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-144-1996-2-144",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa3cedb330c0014084ba4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa3cedb330c0014084ba4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa3cedb330c0014084ba4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa3cedb330c0014084ba4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa3cedb330c0014084ba4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa3cadb330c0014084b1a",
+							"name": "Episode 145",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-145-1996-2-145",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa3cadb330c0014084b1a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa3cadb330c0014084b1a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa3cadb330c0014084b1a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa3cadb330c0014084b1a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa3cadb330c0014084b1a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa3dfdb330c0014084c32",
+							"name": "Episode 147",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-147-1996-2-147",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa3dfdb330c0014084c32/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa3dfdb330c0014084c32/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa3dfdb330c0014084c32/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa3dfdb330c0014084c32/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa3dfdb330c0014084c32/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa532baa39e0013df2246",
+							"name": "Episode 148",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-148-1996-2-148",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa532baa39e0013df2246/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa532baa39e0013df2246/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa532baa39e0013df2246/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa532baa39e0013df2246/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa532baa39e0013df2246/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa539baa39e0013df2294",
+							"name": "Episode 149",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-149-1996-2-149",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa539baa39e0013df2294/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa539baa39e0013df2294/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa539baa39e0013df2294/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa539baa39e0013df2294/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa539baa39e0013df2294/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624fa69aa2111500137e922e",
+							"name": "Episode 150",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-150-1996-2-150",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624fa69aa2111500137e922e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624fa69aa2111500137e922e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624fa69aa2111500137e922e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624fa69aa2111500137e922e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624fa69aa2111500137e922e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a80b4a1dfc0013fcc1b1",
+							"name": "Episode 151",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-151-1996-2-151",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a80b4a1dfc0013fcc1b1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a80b4a1dfc0013fcc1b1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a80b4a1dfc0013fcc1b1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a80b4a1dfc0013fcc1b1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a80b4a1dfc0013fcc1b1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62509b52025eb50013a0d726",
+							"name": "Episode 152",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-152-1996-2-152",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62509b52025eb50013a0d726/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62509b52025eb50013a0d726/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62509b52025eb50013a0d726/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62509b52025eb50013a0d726/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62509b52025eb50013a0d726/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625080a287cec4001355710b",
+							"name": "Episode 153",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-153-1996-2-153",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625080a287cec4001355710b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625080a287cec4001355710b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625080a287cec4001355710b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625080a287cec4001355710b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625080a287cec4001355710b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a3be78f6d300136da70d",
+							"name": "Episode 154",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-154-1996-2-154",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a3be78f6d300136da70d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a3be78f6d300136da70d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a3be78f6d300136da70d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a3be78f6d300136da70d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a3be78f6d300136da70d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250809e87cec4001355703d",
+							"name": "Episode 155",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-155-1996-2-155",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250809e87cec4001355703d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250809e87cec4001355703d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250809e87cec4001355703d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250809e87cec4001355703d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250809e87cec4001355703d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250809387cec40013556e7c",
+							"name": "Episode 156",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-156-1996-2-156",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250809387cec40013556e7c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250809387cec40013556e7c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250809387cec40013556e7c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250809387cec40013556e7c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250809387cec40013556e7c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62509e217b9eaf001376d0a8",
+							"name": "Episode 157",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-157-1996-2-157",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62509e217b9eaf001376d0a8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62509e217b9eaf001376d0a8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62509e217b9eaf001376d0a8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62509e217b9eaf001376d0a8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62509e217b9eaf001376d0a8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625080a987cec400135571fa",
+							"name": "Episode 158",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-158-1996-2-158",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625080a987cec400135571fa/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625080a987cec400135571fa/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625080a987cec400135571fa/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625080a987cec400135571fa/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625080a987cec400135571fa/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508207db330c001408efab",
+							"name": "Episode 159",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-159-1996-2-159",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508207db330c001408efab/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508207db330c001408efab/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508207db330c001408efab/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508207db330c001408efab/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508207db330c001408efab/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508646bacbfb0013c00a62",
+							"name": "Episode 160",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-160-1996-2-160",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508646bacbfb0013c00a62/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508646bacbfb0013c00a62/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508646bacbfb0013c00a62/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508646bacbfb0013c00a62/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508646bacbfb0013c00a62/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508203db330c001408ef8d",
+							"name": "Episode 161",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-161-1996-2-161",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508203db330c001408ef8d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508203db330c001408ef8d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508203db330c001408ef8d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508203db330c001408ef8d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508203db330c001408ef8d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a0efc287f20013ff4854",
+							"name": "Episode 162",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-162-1996-2-162",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a0efc287f20013ff4854/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a0efc287f20013ff4854/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a0efc287f20013ff4854/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a0efc287f20013ff4854/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a0efc287f20013ff4854/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508373baa39e0013df8c5a",
+							"name": "Episode 163",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-163-1996-2-163",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508373baa39e0013df8c5a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508373baa39e0013df8c5a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508373baa39e0013df8c5a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508373baa39e0013df8c5a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508373baa39e0013df8c5a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508214db330c001408f141",
+							"name": "Episode 164",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-164-1996-2-164",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508214db330c001408f141/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508214db330c001408f141/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508214db330c001408f141/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508214db330c001408f141/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508214db330c001408f141/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62509e1c7b9eaf001376cfda",
+							"name": "Episode 165",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-165-1996-2-165",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62509e1c7b9eaf001376cfda/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62509e1c7b9eaf001376cfda/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62509e1c7b9eaf001376cfda/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62509e1c7b9eaf001376cfda/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62509e1c7b9eaf001376cfda/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a0eac287f20013ff4786",
+							"name": "Episode 166",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-166-1996-2-166",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a0eac287f20013ff4786/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a0eac287f20013ff4786/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a0eac287f20013ff4786/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a0eac287f20013ff4786/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a0eac287f20013ff4786/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a253025eb50013a0d774",
+							"name": "Episode 167",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-167-1996-2-167",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a253025eb50013a0d774/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a253025eb50013a0d774/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a253025eb50013a0d774/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a253025eb50013a0d774/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a253025eb50013a0d774/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625092da7b9eaf001376ce62",
+							"name": "Episode 168",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-168-1996-2-168",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625092da7b9eaf001376ce62/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625092da7b9eaf001376ce62/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625092da7b9eaf001376ce62/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625092da7b9eaf001376ce62/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625092da7b9eaf001376ce62/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62509f82db330c001408f761",
+							"name": "Episode 169",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-169-1996-2-169",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62509f82db330c001408f761/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62509f82db330c001408f761/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62509f82db330c001408f761/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62509f82db330c001408f761/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62509f82db330c001408f761/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6269a933f7f5cd00136d7729",
+							"name": "Episode 170",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-170-1996-2-170",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6269a933f7f5cd00136d7729/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6269a933f7f5cd00136d7729/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6269a933f7f5cd00136d7729/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6269a933f7f5cd00136d7729/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6269a933f7f5cd00136d7729/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508636bacbfb0013c00796",
+							"name": "Episode 171",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-171-1996-2-171",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508636bacbfb0013c00796/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508636bacbfb0013c00796/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508636bacbfb0013c00796/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508636bacbfb0013c00796/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508636bacbfb0013c00796/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625092de7b9eaf001376cf30",
+							"name": "Episode 172",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-172-1996-2-172",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625092de7b9eaf001376cf30/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625092de7b9eaf001376cf30/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625092de7b9eaf001376cf30/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625092de7b9eaf001376cf30/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625092de7b9eaf001376cf30/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625098a887cec4001355794c",
+							"name": "Episode 173",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-173-1996-2-173",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625098a887cec4001355794c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625098a887cec4001355794c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625098a887cec4001355794c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625098a887cec4001355794c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625098a887cec4001355794c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250988187cec400135577ea",
+							"name": "Episode 174",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-174-1996-2-174",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250988187cec400135577ea/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250988187cec400135577ea/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250988187cec400135577ea/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250988187cec400135577ea/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250988187cec400135577ea/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625099e6a2111500137ecc78",
+							"name": "Episode 175",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-175-1996-2-175",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625099e6a2111500137ecc78/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625099e6a2111500137ecc78/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625099e6a2111500137ecc78/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625099e6a2111500137ecc78/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625099e6a2111500137ecc78/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250a0f5c287f20013ff4872",
+							"name": "Episode 176",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-176-1996-2-176",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250a0f5c287f20013ff4872/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250a0f5c287f20013ff4872/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250a0f5c287f20013ff4872/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250a0f5c287f20013ff4872/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250a0f5c287f20013ff4872/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625099e2a2111500137ecbee",
+							"name": "Episode 177",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-177-1996-2-177",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625099e2a2111500137ecbee/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625099e2a2111500137ecbee/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625099e2a2111500137ecbee/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625099e2a2111500137ecbee/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625099e2a2111500137ecbee/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508d4428c6dd00132b54ff",
+							"name": "Episode 178",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-178-1996-2-178",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508d4428c6dd00132b54ff/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508d4428c6dd00132b54ff/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508d4428c6dd00132b54ff/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508d4428c6dd00132b54ff/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508d4428c6dd00132b54ff/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250971128c6dd00132b561e",
+							"name": "Episode 179",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-179-1996-2-179",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250971128c6dd00132b561e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250971128c6dd00132b561e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250971128c6dd00132b561e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250971128c6dd00132b561e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250971128c6dd00132b561e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625084da025eb50013a0d317",
+							"name": "Episode 180",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-180-1996-2-180",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625084da025eb50013a0d317/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625084da025eb50013a0d317/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625084da025eb50013a0d317/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625084da025eb50013a0d317/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625084da025eb50013a0d317/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625087a1228ab000133af4de",
+							"name": "Episode 181",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-181-1996-2-181",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625087a1228ab000133af4de/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625087a1228ab000133af4de/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625087a1228ab000133af4de/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625087a1228ab000133af4de/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625087a1228ab000133af4de/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625089023f03ed0013c387f2",
+							"name": "Episode 182",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-182-1996-2-182",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625089023f03ed0013c387f2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625089023f03ed0013c387f2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625089023f03ed0013c387f2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625089023f03ed0013c387f2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625089023f03ed0013c387f2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508376baa39e0013df8d28",
+							"name": "Episode 183",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-183-1996-2-183",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508376baa39e0013df8d28/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508376baa39e0013df8d28/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508376baa39e0013df8d28/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508376baa39e0013df8d28/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508376baa39e0013df8d28/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250971928c6dd00132b5668",
+							"name": "Episode 184",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-184-1996-2-184",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250971928c6dd00132b5668/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250971928c6dd00132b5668/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250971928c6dd00132b5668/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250971928c6dd00132b5668/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250971928c6dd00132b5668/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250863bbacbfb0013c008a9",
+							"name": "Episode 185",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-185-1996-2-185",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250863bbacbfb0013c008a9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250863bbacbfb0013c008a9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250863bbacbfb0013c008a9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250863bbacbfb0013c008a9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250863bbacbfb0013c008a9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508d3b28c6dd00132b5471",
+							"name": "Episode 186",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-186-1996-2-186",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508d3b28c6dd00132b5471/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508d3b28c6dd00132b5471/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508d3b28c6dd00132b5471/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508d3b28c6dd00132b5471/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508d3b28c6dd00132b5471/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62508a69228ab000133af519",
+							"name": "Episode 187",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-187-1996-2-187",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62508a69228ab000133af519/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62508a69228ab000133af519/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62508a69228ab000133af519/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62508a69228ab000133af519/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62508a69228ab000133af519/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "625095b93f03ed0013c389af",
+							"name": "Episode 188",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-188-1996-2-188",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/625095b93f03ed0013c389af/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/625095b93f03ed0013c389af/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/625095b93f03ed0013c389af/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/625095b93f03ed0013c389af/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/625095b93f03ed0013c389af/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250989187cec40013557834",
+							"name": "Episode 189",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-189-1996-2-189",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250989187cec40013557834/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250989187cec40013557834/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250989187cec40013557834/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250989187cec40013557834/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250989187cec40013557834/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6250879c228ab000133af494",
+							"name": "Episode 190",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-190-1996-2-190",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6250879c228ab000133af494/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6250879c228ab000133af494/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6250879c228ab000133af494/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6250879c228ab000133af494/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6250879c228ab000133af494/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "627aa5ed225d3900076cf105",
+							"name": "Episode 95",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-95-2-191",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/627aa5ed225d3900076cf105/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/627aa5ed225d3900076cf105/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/627aa5ed225d3900076cf105/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/627aa5ed225d3900076cf105/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/627aa5ed225d3900076cf105/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "627aa6027ccdc400074e2192",
+							"name": "Episode 96",
+							"description": "Judge Judy Sheindlin, a former judge from New York, tackles actual, small claims cases with her no-nonsense attitude.",
+							"duration": 1800000,
+							"slug": "episode-96-2-192",
+							"rating": "TV-G",
+							"genre": "Reality",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/627aa6027ccdc400074e2192/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/627aa6027ccdc400074e2192/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/627aa6027ccdc400074e2192/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/627aa6027ccdc400074e2192/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/627aa6027ccdc400074e2192/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				}
+			],
+			"stitched": {},
+			"covers": [
+				{
+					"aspectRatio": "347:500",
+					"url": "https://images.pluto.tv/series/603db25de7c979001a88f77a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+				},
+				{
+					"aspectRatio": "1:1",
+					"url": "https://images.pluto.tv/series/603db25de7c979001a88f77a/tile.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=660\u0026q=75\u0026w=660"
+				}
+			],
+			"seriesID": "",
+			"categoryID": "",
+			"type": "series"
+		},
+		{
+			"id": "6234b65ffc8de900130ab0d2",
+			"name": "Stargate SG-1",
+			"description": "Stargate SG-1 picks up where the blockbuster film left off as the SG-1 team sets out to explore the mysteries of the Stargate and the worlds beyond it in the pulse-pounding series which became a worldwide phenomenon and a science fiction classic.",
+			"duration": 0,
+			"slug": "stargate-sg-1-ptv1",
+			"rating": "TV-MA",
+			"genre": "Sci-Fi \u0026 Fantasy",
+			"seasons": [
+				{
+					"number": 1,
+					"episodes": [
+						{
+							"_id": "62704a8e73a0a1001450f4c6",
+							"name": "Children Of The Gods (Part 1)",
+							"description": "As Colonel Jack O'Neill and his team journey to Abydos to confront deadly warriors and laser-firing Death Gliders, O'Neill realizes that this new mission seems hauntingly familiar and that an old enemy has returned to take his revenge on Earth.",
+							"duration": 7200000,
+							"slug": "children-of-the-gods-part-1-1997-1-1-ptv1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62704a8e73a0a1001450f4c6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62704a8e73a0a1001450f4c6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62704a8e73a0a1001450f4c6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62704a8e73a0a1001450f4c6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62704a8e73a0a1001450f4c6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234b662fc8de900130ab0da",
+							"name": "The Enemy Within",
+							"description": "In this suspenseful tale of survival of the fittest, O'Neill (Richard Dean Anderson) and the SG-1 team must attempt to remove a Goa'uld larva that has infected Kawalsky's (guest star Jay Acovone) brain … but time is running out!",
+							"duration": 3600000,
+							"slug": "the-enemy-within-1997-1-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234b662fc8de900130ab0da/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234b662fc8de900130ab0da/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234b662fc8de900130ab0da/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234b662fc8de900130ab0da/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234b662fc8de900130ab0da/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cafbca8c65b0007cf9832",
+							"name": "Emancipation",
+							"description": "On the planet Simarka, where the fierce race of Shavadai mistreat females, Capt. Samantha Carter (Amanda Tapping) challenges their ways in a thrilling battle of wits that may bring women equity or forever keep them as second-class citizens.",
+							"duration": 3600000,
+							"slug": "emancipation-1-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cafbca8c65b0007cf9832/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cafbca8c65b0007cf9832/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cafbca8c65b0007cf9832/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cafbca8c65b0007cf9832/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cafbca8c65b0007cf9832/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cafd35b15f40007e64db2",
+							"name": "The Broca Divide",
+							"description": "Returning from a planet with both a civilized and primitive side, all but two of the team become infected and spread a brutal virus. Will Teal'c and Jackson find the cause, or are their colleagues doomed to become Stone Age primitives?",
+							"duration": 3600000,
+							"slug": "the-broca-divide-1-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cafd35b15f40007e64db2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cafd35b15f40007e64db2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cafd35b15f40007e64db2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cafd35b15f40007e64db2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cafd35b15f40007e64db2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caffa73ed310007b1a1f7",
+							"name": "The First Commandment",
+							"description": "The SG-1 team is sent after the SG-9 team that has failed to return. They find that the team's captain (William Russ), having been treated like a god by planetary inhabitants, is drunk with power and is tyrannizing them. Can they overcome him?",
+							"duration": 3600000,
+							"slug": "the-first-commandment-1-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caffa73ed310007b1a1f7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caffa73ed310007b1a1f7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caffa73ed310007b1a1f7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caffa73ed310007b1a1f7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caffa73ed310007b1a1f7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234b7c44f80a80014ec3aa8",
+							"name": "Cold Lazarus",
+							"description": "A strange crystal strikes down O'Neill, replacing him with a double that returns with the team to Earth to find the cause of O'Neill's private grief...his son's death. But the double is dangerously unstable. Can O'Neill return home to save everyone?",
+							"duration": 3600000,
+							"slug": "cold-lazarus-1997-1-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234b7c44f80a80014ec3aa8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234b7c44f80a80014ec3aa8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234b7c44f80a80014ec3aa8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234b7c44f80a80014ec3aa8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234b7c44f80a80014ec3aa8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0072bd9b800072345e4",
+							"name": "The Nox",
+							"description": "When a planned ambush goes disastrously wrong, resulting in fatalities among the SG-1 team, the peace-loving Nox restore them to life. But while these gentle people can bring back the dead, can they resist the deadly technology of the Goa'uld?",
+							"duration": 3600000,
+							"slug": "the-nox-1-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0072bd9b800072345e4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0072bd9b800072345e4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0072bd9b800072345e4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0072bd9b800072345e4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0072bd9b800072345e4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234b7cf4f80a80014ec3bb2",
+							"name": "Brief Candle",
+							"description": "On the mysterious planet Argos, the beautiful Kynthia seduces Colonel Jack O'Neill, which means he's condemned to an Argosian lifespan of only a hundred days. As he turns gray, will his team succeed in their frantic search for a cure?",
+							"duration": 3600000,
+							"slug": "brief-candle-1997-1-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234b7cf4f80a80014ec3bb2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234b7cf4f80a80014ec3bb2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234b7cf4f80a80014ec3bb2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234b7cf4f80a80014ec3bb2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234b7cf4f80a80014ec3bb2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb016effb660008dd2b80",
+							"name": "Thor's Hammer",
+							"description": "Looking for allies against the Goa'uld, the SG-1 team lands on Cimmeria, home of the legendary Norse gods. Teal'c and O'Neill are transported to an underground labyrinth of caves of the vicious creature Unas. Can Carter \u0026 Daniel rescue them?",
+							"duration": 3600000,
+							"slug": "thors-hammer-1-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb016effb660008dd2b80/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb016effb660008dd2b80/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb016effb660008dd2b80/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb016effb660008dd2b80/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb016effb660008dd2b80/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0290730360007aa017a",
+							"name": "The Torment Of Tantalus",
+							"description": "Dr. Daniel Jackson discovers that in 1945, a young professor slipped through the Stargate, never to return. Together with his still living fiancée, the SG-1 team discovers the now aged professor trapped in a decaying fortress.",
+							"duration": 3600000,
+							"slug": "the-torment-of-tantalus-1-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0290730360007aa017a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0290730360007aa017a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0290730360007aa017a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0290730360007aa017a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0290730360007aa017a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb03f1fbed80007376ef7",
+							"name": "Bloodlines",
+							"description": "With the proviso that he bring back a Goa'uld larva for study, Teal'c (Christopher Judge) returns to Chulak to stop the Goa'uld from enslaving his son Rya'c. Trouble is, Rya'c needs a larva to survive - and the only one available is Teal'c's.",
+							"duration": 3600000,
+							"slug": "bloodlines-1-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb03f1fbed80007376ef7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb03f1fbed80007376ef7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb03f1fbed80007376ef7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb03f1fbed80007376ef7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb03f1fbed80007376ef7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb056c69baf00071796eb",
+							"name": "Fire And Water",
+							"description": "The SG-1 team returns from the planet Oannes in a panic and minus Daniel Jackson, who was last seen being consumed by a column of flames. But as his comrades mourn him on Earth, Daniel is the captive of an amphibious humanoid creature known as Nem.",
+							"duration": 3600000,
+							"slug": "fire-and-water-1-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb056c69baf00071796eb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb056c69baf00071796eb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb056c69baf00071796eb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb056c69baf00071796eb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb056c69baf00071796eb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0618717420007386a5c",
+							"name": "Hathor",
+							"description": "The evil Goa'uld Hathor (Suanne Braun) escapes from a Mayan pyramid in Mexico. At the Stargate facility, she uses her charms to seduce the men into helping her take over the world. Can Samantha Carter and her female colleagues defeat her?",
+							"duration": 3600000,
+							"slug": "hathor-1-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0618717420007386a5c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0618717420007386a5c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0618717420007386a5c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0618717420007386a5c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0618717420007386a5c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb06fc0fd530007407d02",
+							"name": "Singularity",
+							"description": "Capt. Carter returns with the sole survivor of a planetary plague - a little girl, Cassandra. As they become attached, Carter discovers the girl's terrible secret - a time bomb implanted by the Goa'uld. Can she save the girl - and the world?",
+							"duration": 3600000,
+							"slug": "singularity-1-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb06fc0fd530007407d02/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb06fc0fd530007407d02/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb06fc0fd530007407d02/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb06fc0fd530007407d02/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb06fc0fd530007407d02/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0863654020007dded76",
+							"name": "Cor-Ai",
+							"description": "Colonel Jack O'Neill and the team travel to Chartago, where Teal'c is recognized as once having been head Jaffa to the sinister Goa'uld Apothis. He's arrested for murder and put on trial for his life. Can his comrades save him?",
+							"duration": 3600000,
+							"slug": "cor-ai-1-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0863654020007dded76/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0863654020007dded76/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0863654020007dded76/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0863654020007dded76/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0863654020007dded76/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0940e017c0007ad15f0",
+							"name": "Enigma",
+							"description": "The SG-1 team rescues a group of highly developed survivors from the cataclysmic planet of Tollan. To stop the legendary knowledge of the Tollan people from falling into the wrong hands, O'Neill and his team stake all on the cross-universal rescue.",
+							"duration": 3600000,
+							"slug": "enigma-1-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0940e017c0007ad15f0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0940e017c0007ad15f0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0940e017c0007ad15f0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0940e017c0007ad15f0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0940e017c0007ad15f0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0a0d458b400075bed61",
+							"name": "Solitudes",
+							"description": "Following a Stargate technical defect, O'Neill and Carter find themselves stranded on an icy wasteland. O'Neill is severely wounded, both are freezing to death, and nobody can find the section of the universe in which they are stranded!",
+							"duration": 3600000,
+							"slug": "solitudes-1-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0a0d458b400075bed61/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0a0d458b400075bed61/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0a0d458b400075bed61/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0a0d458b400075bed61/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0a0d458b400075bed61/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0af58623500074b1337",
+							"name": "Tin Man",
+							"description": "Upon landing on Planet PX3 989, the mysterious alien Harlan renders the SG-1 team unconscious. After waking and returning to Earth, they find that their spirits and minds have been transferred to androids. Can the team regain their bodies and souls?",
+							"duration": 3600000,
+							"slug": "tin-man-1-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0af58623500074b1337/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0af58623500074b1337/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0af58623500074b1337/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0af58623500074b1337/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0af58623500074b1337/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0cff6deff000746f2eb",
+							"name": "There But For The Grace Of God",
+							"description": "A mysterious mirror transports Dr. Daniel Jackson (Michael Shanks) to another dimension. Suddenly he finds himself on an alternate Earth that is under attack from the Goa'uld. Can he return to his dimension and save the world?",
+							"duration": 3600000,
+							"slug": "there-but-for-the-grace-of-god-1-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0cff6deff000746f2eb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0cff6deff000746f2eb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0cff6deff000746f2eb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0cff6deff000746f2eb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0cff6deff000746f2eb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234b7d34f80a80014ec3c3c",
+							"name": "Politics",
+							"description": "Only Daniel Jackson (Michael Shanks) knows of the Goa'uld plans to invade Earth. But no one takes his warnings seriously - in fact, this time the authorities have chosen to terminate the costly Stargate program and close the gate forever.",
+							"duration": 3600000,
+							"slug": "politics-1998-1-21",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234b7d34f80a80014ec3c3c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234b7d34f80a80014ec3c3c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234b7d34f80a80014ec3c3c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234b7d34f80a80014ec3c3c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234b7d34f80a80014ec3c3c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb0e133b8ee0007690fcb",
+							"name": "Within The Serpent's Grasp",
+							"description": "To stop the Goa'uld invasion, the SG-1 team disobeys orders and transports itself to the Goa'uld attack headquarters. Landing amidst preparations for an all-out strike on Earth, the way home is blocked. Can the team avert disaster and save humanity?",
+							"duration": 3600000,
+							"slug": "within-the-serpents-grasp-1-22",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0e133b8ee0007690fcb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0e133b8ee0007690fcb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0e133b8ee0007690fcb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0e133b8ee0007690fcb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0e133b8ee0007690fcb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 2,
+					"episodes": [
+						{
+							"_id": "623cb0ef471258000725394c",
+							"name": "The Serpent's Lair",
+							"description": "When a fleet of Goa'uld warships launches a surprise attack, the SG-1 team uses the Stargate to board an enemy ship with enough explosives to destroy the alien force. But the team's capture suddenly turns their objective into a suicide mission!",
+							"duration": 3600000,
+							"slug": "the-serpents-lair-2-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb0ef471258000725394c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb0ef471258000725394c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb0ef471258000725394c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb0ef471258000725394c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb0ef471258000725394c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb100d32cc600076db6b6",
+							"name": "In The Line Of Duty",
+							"description": "On a daring mission to rescue victims of an interplanetary attack, Carter's body is inhabited by a Goa'uld. And now that Carter has brought the demon back to Earth inside her, the SG-1 team must find a way to destroy it....without destroying Carter!",
+							"duration": 3600000,
+							"slug": "in-the-line-of-duty-2-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb100d32cc600076db6b6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb100d32cc600076db6b6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb100d32cc600076db6b6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb100d32cc600076db6b6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb100d32cc600076db6b6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb10fd5888f0007540c99",
+							"name": "Prisoners",
+							"description": "When the SG-1 team inadvertently helps a desperate criminal, they are charged as accessories to murder and banished to a penal colony. Only one woman there has the power to help them escape....but freedom might not be worth the price she is asking!",
+							"duration": 3600000,
+							"slug": "prisoners-2-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb10fd5888f0007540c99/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb10fd5888f0007540c99/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb10fd5888f0007540c99/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb10fd5888f0007540c99/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb10fd5888f0007540c99/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb1258717420007386a6e",
+							"name": "The Gamekeeper",
+							"description": "Exploring a strange and beautiful garden in a distant world, the team members are trapped, knocked unconscious, and forced to relive their most haunting memories. Now, before they can find their way back home, they must find the way back to reality.",
+							"duration": 3600000,
+							"slug": "the-gamekeeper-2-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb1258717420007386a6e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb1258717420007386a6e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb1258717420007386a6e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb1258717420007386a6e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb1258717420007386a6e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb159c0fd530007407d14",
+							"name": "Need",
+							"description": "On a mysterious planet, Jackson (Michael Shanks) saves the life of a beautiful princess, but his heroics cause the SG-1 team to be taken prisoner. Jackson and the princess fall in love, but his romance could spell doom for the entire SG-1 team!",
+							"duration": 3600000,
+							"slug": "need-2-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb159c0fd530007407d14/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb159c0fd530007407d14/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb159c0fd530007407d14/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb159c0fd530007407d14/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb159c0fd530007407d14/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb16b4309d60007cef553",
+							"name": "Thor's Chariot",
+							"description": "O'Neill and the SG-1 team travel to the planet of Cimmeria to protect it from a massive Goa'uld attack, but they are quickly outnumbered and overpowered. Can they solve an ancient Cimmerian riddle in time to save the planet…and themselves?",
+							"duration": 3600000,
+							"slug": "thors-chariot-2-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb16b4309d60007cef553/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb16b4309d60007cef553/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb16b4309d60007cef553/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb16b4309d60007cef553/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb16b4309d60007cef553/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb17ebd0f9a00070b47aa",
+							"name": "Message In A Bottle",
+							"description": "A seemingly harmless orb from a dead world is brought back to the base through the Stargate, but the strange device infects O'Neill (Richard Dean Anderson) with an alien organism. Now, the only chance to save him is to let the organism control him!",
+							"duration": 3600000,
+							"slug": "message-in-a-bottle-2-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb17ebd0f9a00070b47aa/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb17ebd0f9a00070b47aa/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb17ebd0f9a00070b47aa/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb17ebd0f9a00070b47aa/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb17ebd0f9a00070b47aa/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb1a7097e1d00072e9667",
+							"name": "Family",
+							"description": "SG-1 goes on a mission to rescue Teal'c's son, Rya'c, from the grasp of Apophis. But, when they finally reach Rya'c, he doesn't want to be saved -- he's been brainwashed and has accepted Apophis as his god! Can Teal'c find a way to win back his son?",
+							"duration": 3600000,
+							"slug": "family-2-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb1a7097e1d00072e9667/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb1a7097e1d00072e9667/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb1a7097e1d00072e9667/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb1a7097e1d00072e9667/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb1a7097e1d00072e9667/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb1c9c9735d00076f957c",
+							"name": "Secrets",
+							"description": "The Stargate project is imperiled when a reporter threatens to expose the top-secret portal. O'Neill attempts to stop him while the rest of the team tries to save Jackson's wife who has been impregnated with a Goa'uld. Is this the end of Stargate?",
+							"duration": 3600000,
+							"slug": "secrets-2-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb1c9c9735d00076f957c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb1c9c9735d00076f957c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb1c9c9735d00076f957c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb1c9c9735d00076f957c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb1c9c9735d00076f957c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb1d94fb51700077ef9e9",
+							"name": "Bane",
+							"description": "A giant insect has bitten Teal'c (Christopher Judge) and soon his body will transform into a cocoon and give birth to hundreds of insect aliens. Can the SG-1 team capture one of the bugs, extract the venom and save Teal'c before it's too late?",
+							"duration": 3600000,
+							"slug": "bane-2-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb1d94fb51700077ef9e9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb1d94fb51700077ef9e9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb1d94fb51700077ef9e9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb1d94fb51700077ef9e9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb1d94fb51700077ef9e9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb1e90e017c0007ad1602",
+							"name": "Tok'ra, The - Part 1",
+							"description": "Captain Carter unwillingly becomes the host to a dying Tok'ra, a member of the resistance whose noble goal is to overthrow the evil Goa'uld empire. Now she sees through the Tok'ra's eyes, but can her visions help the SG-1 team save the Tok'ra?",
+							"duration": 3600000,
+							"slug": "tokra-the-part-1-2-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb1e90e017c0007ad1602/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb1e90e017c0007ad1602/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb1e90e017c0007ad1602/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb1e90e017c0007ad1602/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb1e90e017c0007ad1602/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb1f72792150007e15d82",
+							"name": "Tok'ra, The - Part 2",
+							"description": "The Tok'ra are desperate for hosts so they can continue fighting the Goa'uld. Carter's father, who is dying of cancer, has nothing to lose by volunteering his body. But will he die during the transference...or does fate have something else in store?",
+							"duration": 3600000,
+							"slug": "tokra-the-part-2-2-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb1f72792150007e15d82/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb1f72792150007e15d82/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb1f72792150007e15d82/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb1f72792150007e15d82/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb1f72792150007e15d82/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb20718efb500072ef740",
+							"name": "Spirits",
+							"description": "SG-11 vanishes while negotiating the mining rights on a planet inhabited by a tribe known as the Salish. Can the SG-1 team find their lost colleagues without angering the planet's mystical spirits...or will they become their next victims?",
+							"duration": 3600000,
+							"slug": "spirits-2-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb20718efb500072ef740/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb20718efb500072ef740/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb20718efb500072ef740/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb20718efb500072ef740/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb20718efb500072ef740/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb21726da4e0007e25d2b",
+							"name": "Touchstone",
+							"description": "A climate-controlling touchstone is stolen from planet Madrona, causing the weather to rapidly deteriorate. And when the SG-1 team is accused of the theft, O'Neill must pursue the real thief and rescue the missing stone before Madrona perishes.",
+							"duration": 3600000,
+							"slug": "touchstone-2-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb21726da4e0007e25d2b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb21726da4e0007e25d2b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb21726da4e0007e25d2b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb21726da4e0007e25d2b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb21726da4e0007e25d2b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca5de453ba20007453da7",
+							"name": "The Fifth Race",
+							"description": "While studying alien wall inscriptions on another planet, O'Neill peers into a viewer that unleashes ancient knowledge into his mind like computer virus. Can the SG-1 team reverse the process before his mind is completely reconfigured.",
+							"duration": 3600000,
+							"slug": "the-fifth-race-2-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca5de453ba20007453da7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca5de453ba20007453da7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca5de453ba20007453da7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca5de453ba20007453da7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca5de453ba20007453da7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca649e1055700079c90d6",
+							"name": "A Matter Of Time",
+							"description": "A black hole swallows the SG-10 team, and O'Neill is sent on a rescue mission. As the hole's pull grows stronger, it draws the Stargate toward it and soon threatens to destroy Earth. Will O'Neill find a way to stop this super-destructive force?",
+							"duration": 3600000,
+							"slug": "a-matter-of-time-2-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca649e1055700079c90d6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca649e1055700079c90d6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca649e1055700079c90d6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca649e1055700079c90d6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca649e1055700079c90d6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623cb24d22ff070007e5111b",
+							"name": "Holiday",
+							"description": "Jackson's body is swapped with that of an old Goa'uld enemy. As Jackson lies dying in the alien's ancient body, O'Neill and Teal'c accidentally switch forms too, and unless the alien is captured, all will be trapped in their new bodies forever!",
+							"duration": 3600000,
+							"slug": "holiday-2-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623cb24d22ff070007e5111b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623cb24d22ff070007e5111b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623cb24d22ff070007e5111b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623cb24d22ff070007e5111b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623cb24d22ff070007e5111b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca65d06d79800081fa4a6",
+							"name": "Serpent's Song",
+							"description": "SG-1's arch-enemy Apophis is dying and seeks sanctuary with O'Neill. But what he really wants is a new host in exchange for his knowledge of the Goa'uld. Will O'Neill grant his request or send him back to the Goa'uld to face his fate?",
+							"duration": 3600000,
+							"slug": "serpents-song-2-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca65d06d79800081fa4a6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca65d06d79800081fa4a6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca65d06d79800081fa4a6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca65d06d79800081fa4a6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca65d06d79800081fa4a6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234b947ef11000014ce216b",
+							"name": "One False Step",
+							"description": "On a routine recon mission, the SG-1 team discovers a new, friendly life form. But the encounter turns deadly for the new race because of a virus SG-1 inadvertently introduces. Can SG-1 develop a vaccine before this plague eradicates a civilization?",
+							"duration": 3600000,
+							"slug": "one-false-step-1999-2-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234b947ef11000014ce216b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234b947ef11000014ce216b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234b947ef11000014ce216b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234b947ef11000014ce216b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234b947ef11000014ce216b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca671bdf8130007374115",
+							"name": "Show And Tell",
+							"description": "A boy mysteriously appears at SGC and pleas for help, claiming the Goa'uld are chasing him to find a race of invisible beings. But the SG-1 team doesn't know that the invisible aliens plan to destroy humanity…and their invasion has already begun!",
+							"duration": 3600000,
+							"slug": "show-and-tell-2-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca671bdf8130007374115/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca671bdf8130007374115/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca671bdf8130007374115/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca671bdf8130007374115/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca671bdf8130007374115/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca68fa8c65b0007cf97f9",
+							"name": "1969",
+							"description": "A solar flare sends the SG-1 team back to 1969, where the U.S. military suspects the team of espionage. O'Neill and his team escape with two Woodstock-bound kids, desperate to find the Stargate before they're stuck in the psychedelic past forever.",
+							"duration": 3600000,
+							"slug": "1969-2-21",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca68fa8c65b0007cf97f9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca68fa8c65b0007cf97f9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca68fa8c65b0007cf97f9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca68fa8c65b0007cf97f9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca68fa8c65b0007cf97f9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca6a8779a9d00079c4c40",
+							"name": "Out Of Mind",
+							"description": "O'Neill awakens, seemingly from a 79-year cryogenic sleep, to find that his team is long dead. He soon discovers that it's all a setup and he is actually a prisoner of the Goa'uld, who intend to learn all his secrets…and then destroy him!",
+							"duration": 3600000,
+							"slug": "out-of-mind-2-22",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca6a8779a9d00079c4c40/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca6a8779a9d00079c4c40/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca6a8779a9d00079c4c40/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca6a8779a9d00079c4c40/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca6a8779a9d00079c4c40/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 3,
+					"episodes": [
+						{
+							"_id": "623ca6c4968c980007f54012",
+							"name": "Into The Fire",
+							"description": "Hathor captures O'Neill and implants him with a destructive Goa'uld symbiote that could eventually kill him. Meanwhile, O'Neill's rescue party is defeated by Hathor's invincible energy barrier and time is running out. Is there a way to save O'Neill?",
+							"duration": 3600000,
+							"slug": "into-the-fire-3-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca6c4968c980007f54012/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca6c4968c980007f54012/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca6c4968c980007f54012/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca6c4968c980007f54012/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca6c4968c980007f54012/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca6ddc0fd530007407ce2",
+							"name": "Seth",
+							"description": "When SG-1 hunts for a Goa'uld lord living on Earth, they discover this powerful alien in the form of a religious leader with an armed cult following. O'Neill faces off with both government agents and the cult in a clash that may destroy them all.",
+							"duration": 3600000,
+							"slug": "seth-3-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca6ddc0fd530007407ce2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca6ddc0fd530007407ce2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca6ddc0fd530007407ce2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca6ddc0fd530007407ce2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca6ddc0fd530007407ce2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca6f0fe2c55000799a555",
+							"name": "Fair Game",
+							"description": "O'Neill (Richard Dean Anderson) attempts to stop a massive Goa'uld invasion of Earth. But to call off the attack, the Goa'uld lords demand the destruction of the Stargate. O'Neill doesn't fully trust them - but the fate of Earth lies in the balance.",
+							"duration": 3600000,
+							"slug": "fair-game-3-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca6f0fe2c55000799a555/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca6f0fe2c55000799a555/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca6f0fe2c55000799a555/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca6f0fe2c55000799a555/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca6f0fe2c55000799a555/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca7260730360007aa012a",
+							"name": "Legacy",
+							"description": "A mysterious tablet discovered on a distant planet infects anyone who touches it with a hallucinogen. The remarkable stone infects Teal'c and, before long, the entire team except Hammond. Can Hammond (Don S. Davis) stop it and save SG-1 alone?",
+							"duration": 3600000,
+							"slug": "legacy-3-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca7260730360007aa012a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca7260730360007aa012a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca7260730360007aa012a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca7260730360007aa012a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca7260730360007aa012a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca74222d9d40007605c39",
+							"name": "Learning Curve",
+							"description": "As part of an exchange program with the planet Orban, O'Neill travels to Earth with a girl who possesses incredible technical knowledge. But by the time O'Neill discovers the truth behind the child's superior mind…it may be too late for them all.",
+							"duration": 3600000,
+							"slug": "learning-curve-3-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca74222d9d40007605c39/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca74222d9d40007605c39/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca74222d9d40007605c39/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca74222d9d40007605c39/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca74222d9d40007605c39/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca75d004f8000079ad87f",
+							"name": "Point Of View",
+							"description": "Alternate reality versions of Carter (Amanda Tapping) and Kawalsky (Jay Acovone) are found in Area 51. Brought to Stargate Command, they start to deteriorate. However, return to their own reality means death, as their world was invaded by Goa'uld!",
+							"duration": 3600000,
+							"slug": "point-of-view-3-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca75d004f8000079ad87f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca75d004f8000079ad87f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca75d004f8000079ad87f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca75d004f8000079ad87f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca75d004f8000079ad87f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca76a5b722400071235bd",
+							"name": "Deadman Switch",
+							"description": "SG-1 is captured by Aris Boch, a bounty hunter chasing an evil Goa'uld named Kel'tar. He offers them freedom in exchange for their help. They agree, only to find that Kel'tar is, in fact, a Tok'ra, whose capture would endanger countless others.",
+							"duration": 3600000,
+							"slug": "deadman-switch-3-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca76a5b722400071235bd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca76a5b722400071235bd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca76a5b722400071235bd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca76a5b722400071235bd/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca76a5b722400071235bd/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234ffe3cb3fb6001341c797",
+							"name": "Demons",
+							"description": "On another one of their quests, SG-1 encounters a medieval civilization and frees a woman tied to a stake as a sacrifice to a demon. When the woman is freed, the demon vows to destroy the village unless the SG-1 team is offered up in appeasement.",
+							"duration": 3600000,
+							"slug": "demons-1999-3-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234ffe3cb3fb6001341c797/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234ffe3cb3fb6001341c797/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234ffe3cb3fb6001341c797/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234ffe3cb3fb6001341c797/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234ffe3cb3fb6001341c797/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623500ecbfc85300133908d7",
+							"name": "Rules Of Engagement",
+							"description": "SG-1 lands in the middle of a blazing battle between some Stargate soldiers and a Jaffa army. Believing the soldiers to be the missing-in-action SG-11 team, O'Neill and the others provide assistance… until the mystery team turns its weapons on SG-1!",
+							"duration": 3600000,
+							"slug": "rules-of-engagement-1999-3-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623500ecbfc85300133908d7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623500ecbfc85300133908d7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623500ecbfc85300133908d7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623500ecbfc85300133908d7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623500ecbfc85300133908d7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623500e9bfc85300133908b1",
+							"name": "Forever In A Day",
+							"description": "During a rescue of captured Abydonians, Daniel finds his missing wife, Sha're. But instead of greeting him, she attacks him - leading to her death at the hands of Teal'c. Distraught over her death and angry at Teal'c, Daniel quits Stargate Command.",
+							"duration": 3600000,
+							"slug": "forever-in-a-day-1999-3-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623500e9bfc85300133908b1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623500e9bfc85300133908b1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623500e9bfc85300133908b1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623500e9bfc85300133908b1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623500e9bfc85300133908b1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6235010cbfc853001339097b",
+							"name": "Past And Present",
+							"description": "SG-1 encounters an entire planet suffering from amnesia. The planet's leader, a woman named Ke'ra, returns to Earth with SG-1 to find a cure. But as Ke'ra and Daniel develop a mutual attraction, SG-1 suspects she may not be who she appears to be.",
+							"duration": 3600000,
+							"slug": "past-and-present-1999-3-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6235010cbfc853001339097b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6235010cbfc853001339097b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6235010cbfc853001339097b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6235010cbfc853001339097b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6235010cbfc853001339097b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6235024bffa0a9001392fee2",
+							"name": "Jolinar's Memories",
+							"description": "Carter's father has been captured on a moon transformed into hell. No one but Jolinar has ever escaped from hell, so Tok'ra technology is used to access Jolinar's memories from Carter's mind…but not before an old foe shows up to foil the mission!",
+							"duration": 3600000,
+							"slug": "jolinars-memories-1999-3-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6235024bffa0a9001392fee2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6235024bffa0a9001392fee2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6235024bffa0a9001392fee2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6235024bffa0a9001392fee2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6235024bffa0a9001392fee2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234b93cef11000014ce2029",
+							"name": "The Devil You Know",
+							"description": "During a rescue attempt, SG-1 is caught by one of hell's denizens, who is determined to use the information they have to overthrow Goa'uld lord Sokar. Using Tok'ra technology, the team is forced to relive painful memories…but how much can they take?",
+							"duration": 3600000,
+							"slug": "the-devil-you-know-1999-3-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234b93cef11000014ce2029/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234b93cef11000014ce2029/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234b93cef11000014ce2029/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234b93cef11000014ce2029/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234b93cef11000014ce2029/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62350250ffa0a9001392ffad",
+							"name": "Foothold",
+							"description": "During routine medical exams, Dr. Fraiser injects each team member with a sedative. Teal'c awakens and sees General Hammond conspiring with Fraiser and two aliens. What has happened at Stargate Command, and can SG-1 overpower its own allies?",
+							"duration": 3600000,
+							"slug": "foothold-1999-3-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62350250ffa0a9001392ffad/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62350250ffa0a9001392ffad/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62350250ffa0a9001392ffad/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62350250ffa0a9001392ffad/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62350250ffa0a9001392ffad/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62350255ffa0a9001393007a",
+							"name": "Pretense",
+							"description": "When SG-1 is invited to planet Tollan to attend a Triad ceremony, they are shocked to discover it is actually a trial to determine the fate of their friend Skaara. Daniel and O'Neill must argue a case against a mysterious Goa'uld to save Skaara.",
+							"duration": 3600000,
+							"slug": "pretense-2000-3-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62350255ffa0a9001393007a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62350255ffa0a9001393007a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62350255ffa0a9001393007a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62350255ffa0a9001393007a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62350255ffa0a9001393007a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62350261ffa0a9001393010d",
+							"name": "Urgo",
+							"description": "En route to a planet, the SG-1 are implanted with an alien spore that evolves into a being called Urgo. Though Urgo claims to be friendly, the suspicious team members work feverishly to rid themselves of the creature before it destroys their minds.",
+							"duration": 3600000,
+							"slug": "urgo-2000-3-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62350261ffa0a9001393010d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62350261ffa0a9001393010d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62350261ffa0a9001393010d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62350261ffa0a9001393010d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62350261ffa0a9001393010d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623502b0ffa0a9001393021b",
+							"name": "A Hundred Days",
+							"description": "SG-1 visits the friendly planet Edora and gathers to watch the annual meteor shower that lights up the sky like a fiery rain. But suddenly, wayward asteroids bombard the planet, destroying the Stargate. Can O'Neill and the team ever return home?",
+							"duration": 3600000,
+							"slug": "a-hundred-days-2000-3-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623502b0ffa0a9001393021b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623502b0ffa0a9001393021b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623502b0ffa0a9001393021b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623502b0ffa0a9001393021b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623502b0ffa0a9001393021b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623503babfc8530013390b25",
+							"name": "Shades Of Grey",
+							"description": "On a mission to Tollana, O'Neill steals a weapon there and takes it back to Earth. When Hammond discovers the deception, he suspends O'Neill. But O'Neill's misconduct is only the beginning of a deep mystery that could have catastrophic consequences.",
+							"duration": 3600000,
+							"slug": "shades-of-grey-2000-3-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623503babfc8530013390b25/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623503babfc8530013390b25/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623503babfc8530013390b25/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623503babfc8530013390b25/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623503babfc8530013390b25/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623503c4bfc8530013390c73",
+							"name": "New Ground",
+							"description": "SG-1 journeys to a planet where their arrival ignites a war between two cultures. A spy realizes his side could win the war if SG-1 and the Stargate can be neutralized. Will O'Neill and his team make the same realization and save themselves in time?",
+							"duration": 3600000,
+							"slug": "new-ground-2000-3-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623503c4bfc8530013390c73/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623503c4bfc8530013390c73/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623503c4bfc8530013390c73/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623503c4bfc8530013390c73/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623503c4bfc8530013390c73/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234b941ef11000014ce20f1",
+							"name": "Maternal Instinct",
+							"description": "Bra'tac (Tony Amendola) arrives at Stargate Command with a wild story about interplanetary warfare with Apophis (Peter Williams). Daniel deduces that the battle is over Apophis' child, and races to save the child before Apophis can find him first.",
+							"duration": 3600000,
+							"slug": "maternal-instinct-2000-3-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234b941ef11000014ce20f1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234b941ef11000014ce20f1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234b941ef11000014ce20f1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234b941ef11000014ce20f1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234b941ef11000014ce20f1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623503c7bfc8530013390c99",
+							"name": "Crystal Skull",
+							"description": "Daniel finds a crystal skull identical to one first discovered by his grandfather. When Daniel stares into the skull's eyes, a force makes him disappear. Now SG-1 must find his grandfather to unlock the mystery of the skull and bring Daniel home.",
+							"duration": 3600000,
+							"slug": "crystal-skull-2000-3-21",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623503c7bfc8530013390c99/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623503c7bfc8530013390c99/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623503c7bfc8530013390c99/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623503c7bfc8530013390c99/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623503c7bfc8530013390c99/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623503f4bfc8530013390cd1",
+							"name": "Nemesis",
+							"description": "O'Neill is kidnapped by the Asgard and encounters a swarm of vicious metallic bug-like creatures on a mission to destroy Earth. O'Neill plans to blow up the ship and sacrifice himself, but can the team find another way to stop this apocalyptic plan?",
+							"duration": 3600000,
+							"slug": "nemesis-2000-3-22",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623503f4bfc8530013390cd1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623503f4bfc8530013390cd1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623503f4bfc8530013390cd1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623503f4bfc8530013390cd1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623503f4bfc8530013390cd1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 4,
+					"episodes": [
+						{
+							"_id": "623ca777429ff60007aae899",
+							"name": "Small Victories",
+							"description": "SG-1 is called upon to help a race of gentle, highly-intelligent aliens struggling against a swarm of deadly mechanical spiders called Replicators. But the situation becomes much more complicated when a lone Replicator is discovered back on Earth.",
+							"duration": 3600000,
+							"slug": "small-victories-4-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca777429ff60007aae899/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca777429ff60007aae899/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca777429ff60007aae899/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca777429ff60007aae899/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca777429ff60007aae899/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca792e22d020007a54522",
+							"name": "The Other Side",
+							"description": "SG-1 responds to a cry for help from a doomed civilization, which promises to give Earthlings access to advanced technology in exchange for supplies that would help them defeat their enemies. But they soon discover that SG-1 may not be helping.",
+							"duration": 3600000,
+							"slug": "the-other-side-4-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca792e22d020007a54522/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca792e22d020007a54522/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca792e22d020007a54522/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca792e22d020007a54522/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca792e22d020007a54522/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca7a10f6aad0008c85def",
+							"name": "Upgrades",
+							"description": "SG-1 is selected to test the effects of alien-tech wristbands on human wearers, and soon find themselves blessed with spectacular strength and speed. But when they are sent on a mission utilizing these new abilities, they learn a shocking lesson.",
+							"duration": 3600000,
+							"slug": "upgrades-4-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca7a10f6aad0008c85def/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca7a10f6aad0008c85def/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca7a10f6aad0008c85def/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca7a10f6aad0008c85def/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca7a10f6aad0008c85def/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca7b0097e1d00072e90b5",
+							"name": "Crossroads",
+							"description": "When a High Priestess from the planet Chulak claims to have a plan that would cripple the Goa'uld, everyone is skeptical. SG-1 must join forces with the Tok'ra in order to put her plan into effect, but a deadly, hidden secret could jeopardize it.",
+							"duration": 3600000,
+							"slug": "crossroads-4-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca7b0097e1d00072e90b5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca7b0097e1d00072e90b5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca7b0097e1d00072e90b5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca7b0097e1d00072e90b5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca7b0097e1d00072e90b5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca7c19309ef0007e4b777",
+							"name": "Divide And Conquer",
+							"description": "When an SGC soldier under the influence of a Goa'uld mind-control device attempts to assassinate a High Council member, SG-1 must uncover other potential assassins, even amongst themselves, before the president arrives for a crucial Summit meeting!",
+							"duration": 3600000,
+							"slug": "divide-and-conquer-4-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca7c19309ef0007e4b777/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca7c19309ef0007e4b777/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca7c19309ef0007e4b777/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca7c19309ef0007e4b777/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca7c19309ef0007e4b777/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca7dabd0f9a00070b4789",
+							"name": "Window Of Opportunity",
+							"description": "After a visit to a strange planet in the middle of a geomagnetic storm they find themselves repeating the same day over and over again. The team must utilize their accumulated knowledge to stop the time loop before there are disastrous consequences.",
+							"duration": 3600000,
+							"slug": "window-of-opportunity-4-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca7dabd0f9a00070b4789/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca7dabd0f9a00070b4789/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca7dabd0f9a00070b4789/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca7dabd0f9a00070b4789/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca7dabd0f9a00070b4789/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca7e80730360007aa013c",
+							"name": "Watergate",
+							"description": "SG-1 joins forces with a Russian scientist to investigate a rogue Stargate in Siberia, linked to a mysterious water planet. The team must venture via submarine to the water planet, where they encounter an unexpectedly terrifying alien presence.",
+							"duration": 3600000,
+							"slug": "watergate-4-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca7e80730360007aa013c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca7e80730360007aa013c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca7e80730360007aa013c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca7e80730360007aa013c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca7e80730360007aa013c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca805e1977a00079dc2f2",
+							"name": "The First Ones",
+							"description": "During an archaeological survey of fossils on a Goa'uld planet, Daniel is abducted by a fearsome creature, prompting SG-1 to embark on a mission to free him. But Daniel soon learns that the creature's intentions are not what he thought!",
+							"duration": 3600000,
+							"slug": "the-first-ones-4-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca805e1977a00079dc2f2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca805e1977a00079dc2f2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca805e1977a00079dc2f2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca805e1977a00079dc2f2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca805e1977a00079dc2f2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca811746a3500074c81f2",
+							"name": "Scorched Earth",
+							"description": "After relocating an endangered civilization to a safe new planet, the team realizes that another race of aliens is planning to incinerate the planet's surface to make it inhabitable. Will SG-1 be able to reason with the marauding aliens?",
+							"duration": 3600000,
+							"slug": "scorched-earth-4-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca811746a3500074c81f2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca811746a3500074c81f2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca811746a3500074c81f2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca811746a3500074c81f2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca811746a3500074c81f2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca821453ba20007453db9",
+							"name": "Beneath The Surface",
+							"description": "With memories erased and identities changed, SG-1 find themselves trapped below a domed city on a planet of ice, toiling as slave laborers. Can they come to their senses and make a break for the surface, or will they remain enslaved underground?",
+							"duration": 3600000,
+							"slug": "beneath-the-surface-4-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca821453ba20007453db9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca821453ba20007453db9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca821453ba20007453db9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca821453ba20007453db9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca821453ba20007453db9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca8340f6aad0008c85e01",
+							"name": "Point Of No Return",
+							"description": "When a quirky conspiracy theorist contacts SG-1 claiming to know classified information about the Stargate, at first they think he's bluffing. But when they investigate his wild claims, they realize he's a lot closer to the truth than they thought.",
+							"duration": 3600000,
+							"slug": "point-of-no-return-4-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca8340f6aad0008c85e01/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca8340f6aad0008c85e01/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca8340f6aad0008c85e01/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca8340f6aad0008c85e01/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca8340f6aad0008c85e01/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca83e0730360007aa014e",
+							"name": "Tangent",
+							"description": "When O'Neill and Teal'c take an SGC-modified Goa'uld glider out for a test flight, they lose control and are sucked into outer space by a Goa'uld tracking device. It's up to the team to rescue them, before they run out oxygen and life support.",
+							"duration": 3600000,
+							"slug": "tangent-4-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca83e0730360007aa014e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca83e0730360007aa014e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca83e0730360007aa014e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca83e0730360007aa014e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca83e0730360007aa014e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca852b8a83e000771db15",
+							"name": "The Curse",
+							"description": "When Daniel Jackson returns to Chicago to attend the funeral of his mentor, a celebrated archaeologist, he soon realizes that the death is mysteriously connected to the recent discovery of a 10,000-year-old Egyptian artifact that might be cursed.",
+							"duration": 3600000,
+							"slug": "the-curse-4-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca852b8a83e000771db15/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca852b8a83e000771db15/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca852b8a83e000771db15/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca852b8a83e000771db15/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca852b8a83e000771db15/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c318ff21e500131c373b",
+							"name": "The Serpent's Venom",
+							"description": "SG-1 travels to a remote interplanetary minefield to sabotage a hazardous alliance between two powerful Goa'uld System Lords. But their mission becomes far more dangerous when they realize Teal'c has been captured by one of the Lords.",
+							"duration": 3600000,
+							"slug": "the-serpents-venom-2000-4-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c318ff21e500131c373b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c318ff21e500131c373b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c318ff21e500131c373b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c318ff21e500131c373b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c318ff21e500131c373b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c31dff21e500131c37c5",
+							"name": "Chain Reaction",
+							"description": "When SGC commander Gen. Hammond steps down saying he's too old for the job, SG-1 suspects foul play. When a hard-nosed new general steps in to replace him and splits up SG-1, they vow to solve the mystery and get their beloved General back.",
+							"duration": 3600000,
+							"slug": "chain-reaction-2001-4-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c31dff21e500131c37c5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c31dff21e500131c37c5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c31dff21e500131c37c5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c31dff21e500131c37c5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c31dff21e500131c37c5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c32eff21e500131c3b7b",
+							"name": "2010",
+							"description": "A decade in the future, Earth's alliance with a highly intelligent race of aliens has rendered SGC obsolete. But when Carter, now married to an ambassador, uncovers a terrifying secret, she must reassemble SG-1 to send an urgent message to the past.",
+							"duration": 3600000,
+							"slug": "2010-2001-4-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c32eff21e500131c3b7b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c32eff21e500131c3b7b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c32eff21e500131c3b7b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c32eff21e500131c3b7b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c32eff21e500131c3b7b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c327ff21e500131c3a25",
+							"name": "Absolute Power",
+							"description": "When a chosen boy is brought to SGC, he sends a telepathic message, causing Daniel's personality to undergo disturbing changes. Will the rest of SG-1 be able to solve the mystery of the boy's origin before he becomes a power-hungry warmonger?",
+							"duration": 3600000,
+							"slug": "absolute-power-2001-4-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c327ff21e500131c3a25/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c327ff21e500131c3a25/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c327ff21e500131c3a25/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c327ff21e500131c3a25/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c327ff21e500131c3a25/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c46bffa0a9001392ecae",
+							"name": "The Light",
+							"description": "SG-1 travels to a planet to investigate a machine that induces narcotic pleasure. But when they try to leave the planet, they are overcome with debilitating withdrawal symptoms, forcing them to stay. Can they free themselves from this addiction?",
+							"duration": 3600000,
+							"slug": "the-light-2001-4-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c46bffa0a9001392ecae/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c46bffa0a9001392ecae/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c46bffa0a9001392ecae/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c46bffa0a9001392ecae/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c46bffa0a9001392ecae/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c46fffa0a9001392ecd4",
+							"name": "Prodigy",
+							"description": "Carter takes a young cadet under her wing on a mission to a remote planet inhabited by unique electronic beings. But when the creatures suddenly turn aggressive, SG-1 will need the cadet's brainpower to help them escape with their lives!",
+							"duration": 3600000,
+							"slug": "prodigy-2001-4-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c46fffa0a9001392ecd4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c46fffa0a9001392ecd4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c46fffa0a9001392ecd4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c46fffa0a9001392ecd4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c46fffa0a9001392ecd4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c5e1d16300001390d010",
+							"name": "Entity",
+							"description": "When SG-1 sends a probe through the Stargate, a powerful electronic impulse comes back through and hides inside SGC's computer. But when the entity suddenly jumps inside Carter's mind, SG-1 must choose between saving SGC and saving Carter's life!",
+							"duration": 3600000,
+							"slug": "entity-2001-4-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c5e1d16300001390d010/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c5e1d16300001390d010/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c5e1d16300001390d010/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c5e1d16300001390d010/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c5e1d16300001390d010/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c5d5d16300001390cefb",
+							"name": "Double Jeopardy",
+							"description": "SG-1 encounters a tricky situation when they join forces with androids designed to look like them in a battle against an evil Goa'uld System Lord. Can they fight alongside robotic doppelgangers, or will confusion and contradiction blur the line?",
+							"duration": 3600000,
+							"slug": "double-jeopardy-2001-4-21",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c5d5d16300001390cefb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c5d5d16300001390cefb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c5d5d16300001390cefb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c5d5d16300001390cefb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c5d5d16300001390cefb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c5dcd16300001390cf48",
+							"name": "Exodus",
+							"description": "SG-1 joins forces with the Tok'ra in a final attempt to rid the universe of their mutual Goa'uld nemesis, Apophis. But their plan goes awry when a member of the team is captured and they find themselves at the mercy of their most feared enemy!",
+							"duration": 3600000,
+							"slug": "exodus-2001-4-22",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c5dcd16300001390cf48/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c5dcd16300001390cf48/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c5dcd16300001390cf48/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c5dcd16300001390cf48/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c5dcd16300001390cf48/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 5,
+					"episodes": [
+						{
+							"_id": "623ca85fb8c0e3000709f0ea",
+							"name": "Enemies",
+							"description": "Presumed dead, Teal'c (Christopher Judge) is discovered very much alive…but still under the control of the evil Apophis (Peter Williams). Will the SG-1 team be able to rescue their friend from the clutches of Apophis or will they die trying?",
+							"duration": 3600000,
+							"slug": "enemies-5-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca85fb8c0e3000709f0ea/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca85fb8c0e3000709f0ea/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca85fb8c0e3000709f0ea/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca85fb8c0e3000709f0ea/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca85fb8c0e3000709f0ea/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c5d8d16300001390cf22",
+							"name": "Threshold",
+							"description": "While Teal’c’s body has been saved from death on Apophis’ ship, his mind is still loyal to his Goa’uld lord. Jaffa Master Bra’tac suggests an ancient ritual to restore Teal'c's mind...a ritual fraught with danger and one which no one has survived.",
+							"duration": 3600000,
+							"slug": "threshold-2001-5-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c5d8d16300001390cf22/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c5d8d16300001390cf22/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c5d8d16300001390cf22/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c5d8d16300001390cf22/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c5d8d16300001390cf22/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca86c746a3500074c8204",
+							"name": "Ascension",
+							"description": "While investigating an alien device Carter is found unconscious. Resting from suspected exhaustion, she is visited by an invisible being who holds vital secrets to the device and more. But how does she convince SG-1 that she is not delusional?",
+							"duration": 3600000,
+							"slug": "ascension-5-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca86c746a3500074c8204/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca86c746a3500074c8204/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca86c746a3500074c8204/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca86c746a3500074c8204/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca86c746a3500074c8204/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c8b7bfc853001338ff4e",
+							"name": "The Fifth Man",
+							"description": "When the SG-1 team reports in from a brutal mission, they discover that their fifth team member -- Lt. Tyler -- may not actually have been real. Does this mean the end of the Stargate Program? If the Pentagon's Col. Simmons has his way, it will.",
+							"duration": 3600000,
+							"slug": "the-fifth-man-2001-5-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c8b7bfc853001338ff4e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c8b7bfc853001338ff4e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c8b7bfc853001338ff4e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c8b7bfc853001338ff4e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c8b7bfc853001338ff4e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c8bbbfc853001338ffad",
+							"name": "Red Sky",
+							"description": "The SG-1 team is welcomed on K'Tau by the planet's religious leader, who takes the reddening sky concurrent with their arrival as a sign from their gods. What he doesn't know is that the reddish color is signaling the planet's impending doom!",
+							"duration": 3600000,
+							"slug": "red-sky-2001-5-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c8bbbfc853001338ffad/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c8bbbfc853001338ffad/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c8bbbfc853001338ffad/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c8bbbfc853001338ffad/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c8bbbfc853001338ffad/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234c8b0bfc853001338ff28",
+							"name": "Rite Of Passage",
+							"description": "On the eve of her birthday, Cassandra is showing signs of mind fire, a powerful electromagnetic field triggered at puberty. Now SG-1 must find a cure to stop the life-threatening changes before she destroys herself…and the command center!",
+							"duration": 3600000,
+							"slug": "rite-of-passage-2001-5-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234c8b0bfc853001338ff28/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234c8b0bfc853001338ff28/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234c8b0bfc853001338ff28/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234c8b0bfc853001338ff28/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234c8b0bfc853001338ff28/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca87d30008400074faf46",
+							"name": "Beast Of Burden",
+							"description": "Daniel's Unas friend, Chaka (Dion Johnstone), is captured by a pre-industrial civilization that uses Unas as slaves. While attempting to free Chaka from this cruel regime, Daniel risks the safety of SG-1, and possibly the life of his friend.",
+							"duration": 3600000,
+							"slug": "beast-of-burden-5-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca87d30008400074faf46/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca87d30008400074faf46/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca87d30008400074faf46/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca87d30008400074faf46/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca87d30008400074faf46/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234ca1acb3fb6001341b8d4",
+							"name": "The Tomb",
+							"description": "On a rescue mission to recover Russian soldiers believed missing in action on a previously undisclosed trip, the SG-1 team gets trapped in a Goa'uld tomb with a number of decomposed bodies…and a deadly alien monster with an appetite for human flesh!",
+							"duration": 3600000,
+							"slug": "the-tomb-2001-5-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234ca1acb3fb6001341b8d4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234ca1acb3fb6001341b8d4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234ca1acb3fb6001341b8d4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234ca1acb3fb6001341b8d4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234ca1acb3fb6001341b8d4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca88b9c333900071bf2f8",
+							"name": "Between Two Fires",
+							"description": "The SG-1 team returns to Tollana for the funeral of Chancellor Omoc, only to discover the rulers have reversed their policy on technology sharing and will now trade advanced weaponry with Earth. But is there a secret agenda behind the gesture?",
+							"duration": 3600000,
+							"slug": "between-two-fires-5-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca88b9c333900071bf2f8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca88b9c333900071bf2f8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca88b9c333900071bf2f8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca88b9c333900071bf2f8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca88b9c333900071bf2f8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca8cabd0f9a00070b479b",
+							"name": "2001",
+							"description": "SG-1 discover an opportunity to form an alliance with an advanced race who are willing to share their technology. They are the Aschen, the danger of whom the future SG-1 team warned about. Will the truth be revealed before it is too late?",
+							"duration": 3600000,
+							"slug": "2001-5-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca8cabd0f9a00070b479b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca8cabd0f9a00070b479b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca8cabd0f9a00070b479b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca8cabd0f9a00070b479b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca8cabd0f9a00070b479b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca8da097e1d00072e90c7",
+							"name": "Desperate Measures",
+							"description": "When Major Carter is abducted by a reclusive billionaire with nefarious plans that threaten her life, O'Neill and the rest of the SG-1 team must work with an old adversary to solve the mystery of her disappearance and bring her back alive!",
+							"duration": 3600000,
+							"slug": "desperate-measures-5-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca8da097e1d00072e90c7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca8da097e1d00072e90c7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca8da097e1d00072e90c7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca8da097e1d00072e90c7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca8da097e1d00072e90c7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234ca11cb3fb6001341b806",
+							"name": "Wormhole X-Treme!",
+							"description": "A ship headed for Earth is linked to the pod found through the alien Martin. Investigating what he knows, SG-1 finds Martin has become a consultant on a sci-fi series called Wormhole X-treme!, with a plot uncannily like the Stargate program!",
+							"duration": 3600000,
+							"slug": "wormhole-x-treme-2001-5-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234ca11cb3fb6001341b806/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234ca11cb3fb6001341b806/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234ca11cb3fb6001341b806/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234ca11cb3fb6001341b806/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234ca11cb3fb6001341b806/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234ca0ccb3fb6001341b7e0",
+							"name": "Proving Ground",
+							"description": "Col. Jack O'Neill (Richard Dean Anderson) and his new SG recruits have become the targets of a secret hostile takeover. Now it's up to a wounded O'Neill and his neophyte troop to save the command center from a possible alien invasion!",
+							"duration": 3600000,
+							"slug": "proving-ground-2002-5-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234ca0ccb3fb6001341b7e0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234ca0ccb3fb6001341b7e0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234ca0ccb3fb6001341b7e0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234ca0ccb3fb6001341b7e0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234ca0ccb3fb6001341b7e0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234cb976b411b00137624f1",
+							"name": "48 Hours",
+							"description": "During a pursuit by the Goa'uld gliders, Teal'c fails to make it through the Stargate before it is destroyed. Now SG-1 has only 48 hours to reestablish Teal'c's energy signature from the temporary memory of the Stargate before it's erased…for good!",
+							"duration": 3600000,
+							"slug": "48-hours-2002-5-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234cb976b411b00137624f1/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234cb976b411b00137624f1/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234cb976b411b00137624f1/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234cb976b411b00137624f1/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234cb976b411b00137624f1/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234cb846b411b0013762409",
+							"name": "Summit",
+							"description": "A truce is declared among the Goa'uld, so that the warlords can attend a summit on the future of universe domination. As Jackson speaks fluent Goa'uld, he is sent to the summit disguised as an aide. But his real mission is to poison the delegates!",
+							"duration": 3600000,
+							"slug": "summit-2002-5-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234cb846b411b0013762409/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234cb846b411b0013762409/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234cb846b411b0013762409/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234cb846b411b0013762409/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234cb846b411b0013762409/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca8e8119b4c00071a8afb",
+							"name": "Last Stand",
+							"description": "Embattled and under siege, SG-1 attempts to escape a Goa'uld search and destroy mission bent on finding them and the secret crystal they carry. Meanwhile, the balance of life is threatened by the reappearance of the evil System Lord Anubis.",
+							"duration": 3600000,
+							"slug": "last-stand-5-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca8e8119b4c00071a8afb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca8e8119b4c00071a8afb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca8e8119b4c00071a8afb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca8e8119b4c00071a8afb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca8e8119b4c00071a8afb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234cb7d6b411b001376233b",
+							"name": "Fail Safe",
+							"description": "As an asteroid hurtles toward Earth, SG-1 uses an abandoned Goa'uld ship as a launch pad for a mega-bomb designed to destroy the rock before impact. But when SGC loses the ship's signal, it's feared that the team is dead and that Earth is in peril.",
+							"duration": 3600000,
+							"slug": "fail-safe-2002-5-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234cb7d6b411b001376233b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234cb7d6b411b001376233b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234cb7d6b411b001376233b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234cb7d6b411b001376233b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234cb7d6b411b001376233b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca8fb41cc7200074bd72b",
+							"name": "The Warrior",
+							"description": "K'tano, former First Prime of the late Imhotep, is now the leader of a powerful Jaffa rebellion. SG-1 visits his stronghold in hopes of securing an alliance. But O'Neill soon learns that this strategic partnership may well come at a heavy price.",
+							"duration": 3600000,
+							"slug": "the-warrior-5-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca8fb41cc7200074bd72b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca8fb41cc7200074bd72b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca8fb41cc7200074bd72b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca8fb41cc7200074bd72b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca8fb41cc7200074bd72b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca909be5b460007f97e67",
+							"name": "Menace",
+							"description": "A dormant female android discovered on a barren planet is transported back to Earth for study. On reactivation, she exhibits a childlike innocence. But soon, SG-1 discovers that this seemingly innocent being may hold a dangerous secret.",
+							"duration": 3600000,
+							"slug": "menace-5-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca909be5b460007f97e67/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca909be5b460007f97e67/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca909be5b460007f97e67/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca909be5b460007f97e67/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca909be5b460007f97e67/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca917c89fde0007860744",
+							"name": "The Sentinel",
+							"description": "Col. O'Neill (Richard Dean Anderson) must enlist the aid of a couple of convicted felons in a bid to save a planet from the Goa'uld. With an attack looming, an entire world's salvation rests in the hands of SG-1 and two former NID operatives.",
+							"duration": 3600000,
+							"slug": "the-sentinel-5-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca917c89fde0007860744/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca917c89fde0007860744/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca917c89fde0007860744/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca917c89fde0007860744/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca917c89fde0007860744/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca924b14df50007c465c7",
+							"name": "Meridian",
+							"description": "Exposed to a lethal dose of radiation, Jackson has just hours to live. SG-1 tries everything in its power to save him, but as the hours tick away, Jackson's spirit meets with each member individually to discuss his next mission: life after death.",
+							"duration": 3600000,
+							"slug": "meridian-5-21",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca924b14df50007c465c7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca924b14df50007c465c7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca924b14df50007c465c7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca924b14df50007c465c7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca924b14df50007c465c7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6234cb736b411b0013762270",
+							"name": "Revelations",
+							"description": "Still dealing with the death of one of their own, SG-1 must put its mourning aside in order to confront the warlord Anubis—who has captured the Asgard leader Thor so he can extract the secrets of their ancient technology for universal domination.",
+							"duration": 3600000,
+							"slug": "revelations-2002-5-22",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6234cb736b411b0013762270/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6234cb736b411b0013762270/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6234cb736b411b0013762270/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6234cb736b411b0013762270/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6234cb736b411b0013762270/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 6,
+					"episodes": [
+						{
+							"_id": "623ca950cfe1df0007c0e7d0",
+							"name": "Redemption (Part 1)",
+							"description": "The SG-1 team faces two potential disasters light years apart as an energy build-up in the Stargate threatens to destroy Earth, and Teal'c (Christopher Judge) returns home to find his wife dead, his son estranged and his planet under attack.",
+							"duration": 3600000,
+							"slug": "redemption-part-1-6-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca950cfe1df0007c0e7d0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca950cfe1df0007c0e7d0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca950cfe1df0007c0e7d0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca950cfe1df0007c0e7d0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca950cfe1df0007c0e7d0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623db9b11aa2660007eab6c3",
+							"name": "Redemption (Part 2)",
+							"description": "As Teal'c and his son battle to save Earth, O'Neill pilots the X-3, a newly designed interstellar spacecraft that will carry the Stargate far away from Earth so it can explode harmlessly in deep space. But how will SG-1 operate without the Stargate?",
+							"duration": 3600000,
+							"slug": "redemption-part-2-6-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623db9b11aa2660007eab6c3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623db9b11aa2660007eab6c3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623db9b11aa2660007eab6c3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623db9b11aa2660007eab6c3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623db9b11aa2660007eab6c3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ddf1109a69d0007efff74",
+							"name": "Descent",
+							"description": "The SG-1 team investigates an abandoned Goa'uld ship orbiting the Earth. While they try to salvage the ship, saboteurs attack and the vessel plummets to Earth, deep into the ocean, with O'Neill and his crew trapped inside…and time running out.",
+							"duration": 3600000,
+							"slug": "descent-6-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ddf1109a69d0007efff74/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ddf1109a69d0007efff74/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ddf1109a69d0007efff74/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ddf1109a69d0007efff74/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ddf1109a69d0007efff74/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ddf226ab25e0007dd1bbd",
+							"name": "Frozen",
+							"description": "An alien that might predate human evolution by 50 million years is discovered in Antarctica and may be part of the race that invented the Stargate. After SG-1 manages to thaw her back to life, they discover she may be the source of a deadly virus.",
+							"duration": 3600000,
+							"slug": "frozen-6-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ddf226ab25e0007dd1bbd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ddf226ab25e0007dd1bbd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ddf226ab25e0007dd1bbd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ddf226ab25e0007dd1bbd/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ddf226ab25e0007dd1bbd/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ddf32746a3500074c917f",
+							"name": "Nightwalkers",
+							"description": "When a scientist working on stem cell research disappears, Carter, Teal'c and Quinn investigate and discover that the scientist's town is infested with Goa'uld who can only control the citizens by night. Will Carter, Teal'c and Quinn be taken over?",
+							"duration": 3600000,
+							"slug": "nightwalkers-6-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ddf32746a3500074c917f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ddf32746a3500074c917f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ddf32746a3500074c917f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ddf32746a3500074c917f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ddf32746a3500074c917f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ddf3f73ed310007b1a788",
+							"name": "Abyss",
+							"description": "A Goa'uld lord holds O'Neill (Richard Dean Anderson) captive and tortures him for information about the Tok'ra. As O'Neill suffers, Daniel Jackson (Michael Shanks) appears and offers support. Meanwhile, SG-1 races to O'Neill before it's too late.",
+							"duration": 3600000,
+							"slug": "abyss-6-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ddf3f73ed310007b1a788/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ddf3f73ed310007b1a788/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ddf3f73ed310007b1a788/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ddf3f73ed310007b1a788/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ddf3f73ed310007b1a788/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ddf51d32cc600076dc4c3",
+							"name": "Shadow Play",
+							"description": "Quinn is conflicted when a professor from his home planet asks SG-1 to help stage a coup against the Kelownan government in order to stop a civil war. Should SG-1 allow the planet to destroy itself…or are they placing themselves in needless danger?",
+							"duration": 3600000,
+							"slug": "shadow-play-6-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ddf51d32cc600076dc4c3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ddf51d32cc600076dc4c3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ddf51d32cc600076dc4c3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ddf51d32cc600076dc4c3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ddf51d32cc600076dc4c3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de7e7d32cc600076dc4f0",
+							"name": "The Other Guys",
+							"description": "Two scientists working on an off-world research project witness SG-1 captured in a Goa'uld raid and attempt to rescue them. Little do they know that SG-1 staged the capture in order to infiltrate the Goa'uld and make contact with a Tok'ra informant.",
+							"duration": 3600000,
+							"slug": "the-other-guys-6-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de7e7d32cc600076dc4f0/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de7e7d32cc600076dc4f0/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de7e7d32cc600076dc4f0/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de7e7d32cc600076dc4f0/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de7e7d32cc600076dc4f0/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de7fc01d4b70007ae7420",
+							"name": "Allegiance",
+							"description": "The Tok'ra must take refuge from the Goa'uld at the SGC Alpha Site occupied by Jaffa. Bad blood between the races begins to boil as an assassin wreaks havoc on the camp. Can O'Neill stop the bloodshed before the assassin escapes with coordinates?",
+							"duration": 3600000,
+							"slug": "allegiance-6-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de7fc01d4b70007ae7420/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de7fc01d4b70007ae7420/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de7fc01d4b70007ae7420/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de7fc01d4b70007ae7420/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de7fc01d4b70007ae7420/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de80c60d6b6000782bf58",
+							"name": "Cure",
+							"description": "SG-1 visits Pangar, a planet inhabited by humans who have developed a drug that makes their immune systems perfect. Unknown to SG-1 is the means by which the drug is produced, a startling discovery that may hold the key to the origins of the Tok'ra!",
+							"duration": 3600000,
+							"slug": "cure-6-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de80c60d6b6000782bf58/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de80c60d6b6000782bf58/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de80c60d6b6000782bf58/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de80c60d6b6000782bf58/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de80c60d6b6000782bf58/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de820b8a83e000771e59b",
+							"name": "Prometheus",
+							"description": "Rogue NSA officers hijack the X-303 spaceship and demand that Adrian Conrad be brought to the ship. Using his Goa'uld knowledge, Conrad activates the X-303 and takes the ship light-years from Earth as O'Neill and Teal'c stage a daring rescues.",
+							"duration": 3600000,
+							"slug": "prometheus-6-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de820b8a83e000771e59b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de820b8a83e000771e59b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de820b8a83e000771e59b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de820b8a83e000771e59b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de820b8a83e000771e59b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de863d458b400075bf9f8",
+							"name": "Unnatural Selection",
+							"description": "When SG-1 is marooned in deep space, Thor comes to the rescue. He then seek O'Neill's help to combat the Replicators. Convinced they will attack earth if not stopped, O'Neill stages a daring mission to stop the Replicators once and for all.",
+							"duration": 3600000,
+							"slug": "unnatural-selection-6-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de863d458b400075bf9f8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de863d458b400075bf9f8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de863d458b400075bf9f8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de863d458b400075bf9f8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de863d458b400075bf9f8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de8739309ef0007e4c05f",
+							"name": "Sight Unseen",
+							"description": "SG-1 returns from a mission with an artifact that triggers the ability to see hideous yet harmless life forms in a parallel reality. As the effect spreads to civilians, O'Neill and his team must find a solution before mass hysteria breaks out.",
+							"duration": 3600000,
+							"slug": "sight-unseen-6-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de8739309ef0007e4c05f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de8739309ef0007e4c05f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de8739309ef0007e4c05f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de8739309ef0007e4c05f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de8739309ef0007e4c05f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de88575c4bc00075456b5",
+							"name": "Smoke \u0026 Mirrors",
+							"description": "Senator Kinsey suffers an assassination attempt while campaigning for the presidency, and O'Neill is caught on tape leaving the building where the shots were fired. With O'Neill behind bars, Carter, Teal'c and Jonas must prove his innocence.",
+							"duration": 3600000,
+							"slug": "smoke-and-mirrors-6-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de88575c4bc00075456b5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de88575c4bc00075456b5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de88575c4bc00075456b5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de88575c4bc00075456b5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de88575c4bc00075456b5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de898bd0f9a00070b5314",
+							"name": "Paradise Lost",
+							"description": "Colonel Maybourne visits O'Neill and claims to have a key to a cache of alien technology, but demands a presidential pardon in exchange for it. When SG-1 accompanies Maybourne to retrieve it, they find his intentions may not be all they seem.",
+							"duration": 3600000,
+							"slug": "paradise-lost-6-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de898bd0f9a00070b5314/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de898bd0f9a00070b5314/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de898bd0f9a00070b5314/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de898bd0f9a00070b5314/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de898bd0f9a00070b5314/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de8bb2765a7000789b5c7",
+							"name": "Metamorphosis",
+							"description": "SG-1 discovers that Nirrti is mutating the inhabitants of an unexplored planet with a machine that rearranges their DNA. Captured in an attempt to stop her, O'Neill must find a way to escape before he and SG-1 are subjected to the same fate.",
+							"duration": 3600000,
+							"slug": "metamorphosis-6-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de8bb2765a7000789b5c7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de8bb2765a7000789b5c7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de8bb2765a7000789b5c7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de8bb2765a7000789b5c7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de8bb2765a7000789b5c7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de8d03654020007ddfe5e",
+							"name": "Disclosure",
+							"description": "General Hammond and the Pentagon are forced to reveal the existence of the Stargate to other world governments. Senator Kinsey suggests that General Hammond be relieved of his command and that the civilian-run NID oversee the Stargate program.",
+							"duration": 3600000,
+							"slug": "disclosure-6-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de8d03654020007ddfe5e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de8d03654020007ddfe5e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de8d03654020007ddfe5e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de8d03654020007ddfe5e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de8d03654020007ddfe5e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623de8e6effb660008dd4ab4",
+							"name": "Forsaken",
+							"description": "SG-1 discovers three human survivors on an off-world planet who claim to be under attack by hostile aliens. While Carter helps repair the ship's computer, she learns that the survivors are hiding a secret…and things may not be all they seem.",
+							"duration": 3600000,
+							"slug": "forsaken-6-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623de8e6effb660008dd4ab4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623de8e6effb660008dd4ab4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623de8e6effb660008dd4ab4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623de8e6effb660008dd4ab4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623de8e6effb660008dd4ab4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca96c73ed310007b1a1c9",
+							"name": "The Changeling",
+							"description": "Teal'c mysteriously begins to hallucinate and is haunted by visions of an existence where he is a human being. As his paranoia deepens, Teal'c must rely on the help of friend Daniel Jackson to determine where his dreams end...and his reality begins.",
+							"duration": 3600000,
+							"slug": "the-changeling-6-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca96c73ed310007b1a1c9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca96c73ed310007b1a1c9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca96c73ed310007b1a1c9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca96c73ed310007b1a1c9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca96c73ed310007b1a1c9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca980e1977a00079dc304",
+							"name": "Memento",
+							"description": "SG-1 accompanies the X-53 on its voyage into deep space. When the ship drops out of hyperspace, SG-1 is stranded with no means of getting back to Earth. Their only option lies in exploring a nearby planet where a Stargate is thought to be located.",
+							"duration": 3600000,
+							"slug": "memento-6-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca980e1977a00079dc304/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca980e1977a00079dc304/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca980e1977a00079dc304/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca980e1977a00079dc304/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca980e1977a00079dc304/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca9c6a45df90007abc8ba",
+							"name": "Prophecy",
+							"description": "SG-1 encounters a civilization desperate to be freed from the clutches of a Goa'uld. While on the planet, Jonas falls ill. His illness is diagnosed as a brain tumor but it gives him the ability to see the future...where SG-1 are walking into a trap!",
+							"duration": 3600000,
+							"slug": "prophecy-6-21",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca9c6a45df90007abc8ba/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca9c6a45df90007abc8ba/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca9c6a45df90007abc8ba/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca9c6a45df90007abc8ba/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca9c6a45df90007abc8ba/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6245f243d1630000139519ee",
+							"name": "Full Circle",
+							"description": "Daniel appears to O'Neill and alerts him that Anubis has located the Eye of Ra, an object of power hidden on Abydos. With Daniel's help, SG-1 find the Eye first. Determined to have it, Anubis threatens to destroy the planet unless they hand it over.",
+							"duration": 3600000,
+							"slug": "full-circle-2003-6-22",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245f243d1630000139519ee/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245f243d1630000139519ee/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245f243d1630000139519ee/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245f243d1630000139519ee/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245f243d1630000139519ee/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 7,
+					"episodes": [
+						{
+							"_id": "6245f24ad163000013951a79",
+							"name": "Fallen",
+							"description": "As SG-1 begins its search for the Lost City, they discover that Jackson has been returned by the Ancients without any memory of who he was. While SG-1 tries to help him regain his memory, they discover that the Lost City is not on the same planet.",
+							"duration": 3600000,
+							"slug": "fallen-2003-7-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245f24ad163000013951a79/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245f24ad163000013951a79/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245f24ad163000013951a79/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245f24ad163000013951a79/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245f24ad163000013951a79/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca9d6f6deff000746f2cb",
+							"name": "Homecoming",
+							"description": "Anubis travels to Kelowna after discovering that it has mines of a more powerful source of energy that he can use to make his new weapon more destructive. The leaders of Kelowna contact SG-1 for their help, but make an ill-advised deal with Anubis.",
+							"duration": 3600000,
+							"slug": "homecoming-7-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca9d6f6deff000746f2cb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca9d6f6deff000746f2cb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca9d6f6deff000746f2cb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca9d6f6deff000746f2cb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca9d6f6deff000746f2cb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca9e1be5b460007f97e76",
+							"name": "Fragile Balance",
+							"description": "A 15-year-old infiltrates the SGC with the startling news that he is Colonel Jack O'Neill, having mysteriously reverse aged 30 years overnight. Possessing O'Neill's knowledge, exact DNA and, above all, his attitude, can he really be O'Neill?",
+							"duration": 3600000,
+							"slug": "fragile-balance-7-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca9e1be5b460007f97e76/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca9e1be5b460007f97e76/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca9e1be5b460007f97e76/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca9e1be5b460007f97e76/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca9e1be5b460007f97e76/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca9f4bc960f00075e27e6",
+							"name": "Orpheus",
+							"description": "Through the help of Daniel, Teal'c visualizes that Rya'c and Bra'tac are being held prisoner in a Goa'uld death camp. With SG-1's help, Teal'c sets out to rescue his son and his mentor, but can he overcome his fears in time?",
+							"duration": 3600000,
+							"slug": "orpheus-7-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca9f4bc960f00075e27e6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca9f4bc960f00075e27e6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca9f4bc960f00075e27e6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca9f4bc960f00075e27e6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca9f4bc960f00075e27e6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623ca9fec6cdb8000745f196",
+							"name": "Revisions",
+							"description": "Six thousand light-years away, O'Neill and the SG-1 team discover a devastated universe where the inhabitants must live in a protective dome. They survive through an all-controlling computer system called the Link. But is it a savior, or a curse?",
+							"duration": 3600000,
+							"slug": "revisions-7-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623ca9fec6cdb8000745f196/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623ca9fec6cdb8000745f196/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623ca9fec6cdb8000745f196/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623ca9fec6cdb8000745f196/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623ca9fec6cdb8000745f196/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caa0abb834e0007b83ee2",
+							"name": "Lifeboat",
+							"description": "SG-1 finds a crashed spaceship containing hundreds of people in a cryogenic sleep. Stunned by an unseen weapon, the team is struck unconscious and, upon awakening, discovers that several of the frozen personalities now inhabit Daniel's body!",
+							"duration": 3600000,
+							"slug": "lifeboat-7-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caa0abb834e0007b83ee2/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caa0abb834e0007b83ee2/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caa0abb834e0007b83ee2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caa0abb834e0007b83ee2/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caa0abb834e0007b83ee2/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caa1a8f2715000738bc22",
+							"name": "Enemy Mine",
+							"description": "An SGC Naquadah mining operation is attacked by a native tribe of Unas. SG-1 is sent to protect the miners and discovers that the Unas are guarding land they believe is sacred. Instead of eradicating the Unas, Daniel races to negotiate with them.",
+							"duration": 3600000,
+							"slug": "enemy-mine-7-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caa1a8f2715000738bc22/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caa1a8f2715000738bc22/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caa1a8f2715000738bc22/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caa1a8f2715000738bc22/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caa1a8f2715000738bc22/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caa292765a70007899f6c",
+							"name": "Space Race",
+							"description": "The Serakkin Warrick proposes to share his planet's technology with Earth in exchange for Carter helping him win a space race. Carter eagerly agrees and copilots the craft through a perilous obstacle course; but the race isn't without risks.",
+							"duration": 3600000,
+							"slug": "space-race-7-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caa292765a70007899f6c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caa292765a70007899f6c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caa292765a70007899f6c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caa292765a70007899f6c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caa292765a70007899f6c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caa3c4dd39500072ac39d",
+							"name": "Avenger 2.0",
+							"description": "Dr. Felger creates a computer virus meant to disable Goa'uld-controlled worlds. When the program malfunctions and spreads throughout the Stargate network, O'Neill, Teal'c and Daniel are trapped off-world, with danger looming around the corner.",
+							"duration": 3600000,
+							"slug": "avenger-20-7-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caa3c4dd39500072ac39d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caa3c4dd39500072ac39d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caa3c4dd39500072ac39d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caa3c4dd39500072ac39d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caa3c4dd39500072ac39d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241ef0701d4b70007ae89a5",
+							"name": "Birthright",
+							"description": "SG-1 encounters a race of women warriors whose survival depends on symbiotes harvested from Jaffa. Teal'c and SG-1 must convince the warriors' high priestess to put aside her fear of reliance on a life-saving drug before the Goa'uld destroy them.",
+							"duration": 3600000,
+							"slug": "birthright-7-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241ef0701d4b70007ae89a5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241ef0701d4b70007ae89a5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241ef0701d4b70007ae89a5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241ef0701d4b70007ae89a5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241ef0701d4b70007ae89a5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caa4c5dc9550007c7a203",
+							"name": "Evolution (Part 1)",
+							"description": "SG-1 encounters a very advanced bio-engineered warrior endowed with super strength, created by Anubis. While the team sets out to locate the origin of this new foe, Daniel travels to South America in search of a device left on Earth by the Ancients.",
+							"duration": 3600000,
+							"slug": "evolution-part-1-7-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caa4c5dc9550007c7a203/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caa4c5dc9550007c7a203/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caa4c5dc9550007c7a203/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caa4c5dc9550007c7a203/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caa4c5dc9550007c7a203/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241ef23097e1d00072ee384",
+							"name": "Evolution (Part 2)",
+							"description": "Having found the location of the warrior base, Carter is assigned a recon mission to determine Anubis's plans. Meanwhile, O'Neill mounts a mission to South America to rescue Daniel who has been kidnapped by Honduran rebels demanding a ransom.",
+							"duration": 3600000,
+							"slug": "evolution-part-2-7-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241ef23097e1d00072ee384/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241ef23097e1d00072ee384/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241ef23097e1d00072ee384/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241ef23097e1d00072ee384/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241ef23097e1d00072ee384/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241ef3333a1e50007cb4bb7",
+							"name": "Grace",
+							"description": "Having sustained an injury during an alien attack, Carter awakens to find herself abandoned on the Prometheus and trapped. With only her subconscious as a guide, Carter must find a way out of the nebula before it destroys the ship and her way home.",
+							"duration": 3600000,
+							"slug": "grace-7-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241ef3333a1e50007cb4bb7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241ef3333a1e50007cb4bb7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241ef3333a1e50007cb4bb7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241ef3333a1e50007cb4bb7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241ef3333a1e50007cb4bb7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caa68312333000787214e",
+							"name": "Fallout",
+							"description": "Jonas Quinn returns to the SGC with news that Naquadria mines of Kelowna are not native to his world and are threatening to cause an explosion in the planet's core that will leave his home world uninhabitable and millions dead.",
+							"duration": 3600000,
+							"slug": "fallout-7-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caa68312333000787214e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caa68312333000787214e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caa68312333000787214e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caa68312333000787214e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caa68312333000787214e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241f1ff81538100079d37c3",
+							"name": "Chimera",
+							"description": "Daniel experiences strange dreams centered around his possible knowledge of the Lost City of the Ancients. Suspicious that Daniel's mind is being manipulated, the team must find a way to help him while keeping the secret from the Goa'uld.",
+							"duration": 3600000,
+							"slug": "chimera-7-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241f1ff81538100079d37c3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241f1ff81538100079d37c3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241f1ff81538100079d37c3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241f1ff81538100079d37c3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241f1ff81538100079d37c3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caa73b6e5fe0008706ea3",
+							"name": "Death Knell",
+							"description": "Carter flees from a super warrior with a piece of technology that may be the key to defeating Anubis's new army. Injured and unarmed, Carter must use all her training to stay alive, while O'Neill and Teal'c race to find her before it's too late.",
+							"duration": 3600000,
+							"slug": "death-knell-7-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caa73b6e5fe0008706ea3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caa73b6e5fe0008706ea3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caa73b6e5fe0008706ea3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caa73b6e5fe0008706ea3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caa73b6e5fe0008706ea3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623caa8241cc7200074bd73a",
+							"name": "Heroes (Part 1)",
+							"description": "When the Air Force sends a documentary crew to capture the historical importance of the Stargate program, the members of the SGC are resistant. Tensions rise when an emergency forces General Hammond to restrict the access they're given to the SGC.",
+							"duration": 3600000,
+							"slug": "heroes-part-1-7-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623caa8241cc7200074bd73a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623caa8241cc7200074bd73a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623caa8241cc7200074bd73a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623caa8241cc7200074bd73a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623caa8241cc7200074bd73a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241f22d4309d60007cf2b6a",
+							"name": "Heroes (Part 2)",
+							"description": "Assigned the task of capturing the importance of the Stargate program, a documentary crew is given a true look at the heroic nature and family-like bond of the soldiers of Stargate Command, when a key member of the SGC is killed in action.",
+							"duration": 3600000,
+							"slug": "heroes-part-2-7-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241f22d4309d60007cf2b6a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241f22d4309d60007cf2b6a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241f22d4309d60007cf2b6a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241f22d4309d60007cf2b6a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241f22d4309d60007cf2b6a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241f26ce1977a00079dfdb5",
+							"name": "Resurrection",
+							"description": "SG-1 is sent to investigate the murder of a group of rogue NID scientists. They discover that results of the scientists' experiments may have combined DNA to create the ultimate evil: a human being that possesses the conscience of a Goa'uld.",
+							"duration": 3600000,
+							"slug": "resurrection-7-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241f26ce1977a00079dfdb5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241f26ce1977a00079dfdb5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241f26ce1977a00079dfdb5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241f26ce1977a00079dfdb5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241f26ce1977a00079dfdb5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241f2934e8eee000823b9bf",
+							"name": "Inauguration",
+							"description": "On his first day in office, the newly elected president of the United States is told about the Stargate program and must be brought up to speed on the past seven years of its existence. Starring Richard Dean Anderson and Amanda Tapping.",
+							"duration": 3600000,
+							"slug": "inauguration-7-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241f2934e8eee000823b9bf/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241f2934e8eee000823b9bf/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241f2934e8eee000823b9bf/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241f2934e8eee000823b9bf/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241f2934e8eee000823b9bf/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241f2b0dc90f00007f0692a",
+							"name": "Lost City (Part 1)",
+							"description": "O'Neill allows the knowledge of the Ancients to be downloaded into his mind again, even though the first time almost killed him. While he slowly deteriorates, he and SG-1 must race against time to uncover the secret of the Lost City of the Ancients.",
+							"duration": 3600000,
+							"slug": "lost-city-part-1-7-21",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241f2b0dc90f00007f0692a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241f2b0dc90f00007f0692a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241f2b0dc90f00007f0692a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241f2b0dc90f00007f0692a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241f2b0dc90f00007f0692a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241f2bdb8a83e00077241cc",
+							"name": "Lost City (Part 2)",
+							"description": "O'Neill allows the knowledge of the Ancients to be downloaded into his mind again, even though the first time almost killed him. While he slowly deteriorates, he and SG-1 must race against time to uncover the secret of the Lost City of the Ancients.",
+							"duration": 3600000,
+							"slug": "lost-city-part-2-7-22",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241f2bdb8a83e00077241cc/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241f2bdb8a83e00077241cc/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241f2bdb8a83e00077241cc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241f2bdb8a83e00077241cc/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241f2bdb8a83e00077241cc/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 8,
+					"episodes": [
+						{
+							"_id": "623defcf4379350007596c33",
+							"name": "New Order (Part 1)",
+							"description": "When Carter and Teal'c fly to the Asgard world of Hala in hopes of finding a way to revive O'Neill, they are attacked by Replicators, who take Carter prisoner. Meanwhile, Dr. Weir and Jackson attempt to negotiate a treaty with Goa'uld System Lords.",
+							"duration": 3600000,
+							"slug": "new-order-part-1-8-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623defcf4379350007596c33/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623defcf4379350007596c33/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623defcf4379350007596c33/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623defcf4379350007596c33/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623defcf4379350007596c33/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623defdf22ff070007e518ee",
+							"name": "New Order (Part 2)",
+							"description": "The Goa'uld send a mothership to Earth, demanding that it prove its superior defenses. As Dr. Weir applies her most expert diplomatic tactics, Jackson and the still-unconscious body of O'Neill are unexpectedly beamed aboard Thor's ship.",
+							"duration": 3600000,
+							"slug": "new-order-part-2-8-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623defdf22ff070007e518ee/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623defdf22ff070007e518ee/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623defdf22ff070007e518ee/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623defdf22ff070007e518ee/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623defdf22ff070007e518ee/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623deff97529100007026a60",
+							"name": "Lockdown",
+							"description": "When Jackson contracts a mysterious illness, O'Neill is convinced that a contagion has infected the base and orders a lockdown. But when Jackson reveals that he was actually possessed by Anubis, O'Neill must discover the identity of the new host!",
+							"duration": 3600000,
+							"slug": "lockdown-8-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623deff97529100007026a60/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623deff97529100007026a60/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623deff97529100007026a60/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623deff97529100007026a60/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623deff97529100007026a60/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df01622ff070007e51900",
+							"name": "Zero Hour",
+							"description": "O'Neill deals with a visit from the president and negotiations between two warring tribes from Amra. When SG-1 is captured, he's forced to choose between the safety of the team and the fate of a planet, making him question his competency!",
+							"duration": 3600000,
+							"slug": "zero-hour-8-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df01622ff070007e51900/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df01622ff070007e51900/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df01622ff070007e51900/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df01622ff070007e51900/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df01622ff070007e51900/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df02c2765a7000789b5ec",
+							"name": "Icon",
+							"description": "On a distant planet the Stargate has become a symbol to the people, and some believe that the gods will return through it to reward the faithful. SG-1 realizes that those gods are the Goa'uld and warn of the danger they may face.",
+							"duration": 3600000,
+							"slug": "icon-8-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df02c2765a7000789b5ec/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df02c2765a7000789b5ec/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df02c2765a7000789b5ec/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df02c2765a7000789b5ec/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df02c2765a7000789b5ec/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df041bd0f9a00070b5427",
+							"name": "Avatar",
+							"description": "The team agrees that an easy VR simulator is a useless training tool against the Goa'uld. Teal'c lets it learn from him, but as he plays, the game sends a shock each time he dies, and if he doesn't defeat the game, the chair will kill him.",
+							"duration": 3600000,
+							"slug": "avatar-8-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df041bd0f9a00070b5427/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df041bd0f9a00070b5427/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df041bd0f9a00070b5427/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df041bd0f9a00070b5427/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df041bd0f9a00070b5427/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df0536ab25e0007dd1bf5",
+							"name": "Affinity",
+							"description": "Teal'c, having finally been cleared to live off-base, settles into his new neighborhood. His neighbors love him. He's quiet and he has become a sort of protector of his community but not everybody is as pleased about Teal'c's civilian assimilation.",
+							"duration": 3600000,
+							"slug": "affinity-8-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df0536ab25e0007dd1bf5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df0536ab25e0007dd1bf5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df0536ab25e0007dd1bf5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df0536ab25e0007dd1bf5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df0536ab25e0007dd1bf5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df065a290ae0007d094f3",
+							"name": "Covenant",
+							"description": "Alec Colson is claiming he has shocking proof that the government is covering up a liaison with aliens, and that Earth was almost destroyed by an alien invasion, Colson gives all nations involved 24 hours to come clean or he'll do it for them.",
+							"duration": 3600000,
+							"slug": "covenant-8-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df065a290ae0007d094f3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df065a290ae0007d094f3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df065a290ae0007d094f3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df065a290ae0007d094f3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df065a290ae0007d094f3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df07ca45df90007abdd29",
+							"name": "Sacrifices",
+							"description": "Teal'c and Bra'tac have just returned from the planet Ha'ktyl, where they tried to convince the warrior-woman rebel leader Ishta, to wait until her fellow insurgent Jaffa grow numerous enough to wage war against all the Goa'uld system lords at once.",
+							"duration": 3600000,
+							"slug": "sacrifices-8-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df07ca45df90007abdd29/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df07ca45df90007abdd29/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df07ca45df90007abdd29/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df07ca45df90007abdd29/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df07ca45df90007abdd29/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df08eceec840007ee677c",
+							"name": "Endgame",
+							"description": "The Stargate is missing. Upon investigation the team notice a scientist tagging the stargate with a locator beacon. It looks like this is the work of The Trust taking whatever ruthless action they deem necessary to protect Earth from alien invaders.",
+							"duration": 3600000,
+							"slug": "endgame-8-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df08eceec840007ee677c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df08eceec840007ee677c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df08eceec840007ee677c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df08eceec840007ee677c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df08eceec840007ee677c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df8e04e8eee0008239193",
+							"name": "Gemini",
+							"description": "An old IDC comes through; Send M.A.L.P. The M.A.L.P. telemetry shows that the person sending the transmission is Carter but Carter is in the control room at SGC. The Carter on the other side explains that she is a Replicator.",
+							"duration": 3600000,
+							"slug": "gemini-8-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df8e04e8eee0008239193/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df8e04e8eee0008239193/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df8e04e8eee0008239193/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df8e04e8eee0008239193/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df8e04e8eee0008239193/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df8f3b14df50007c476e6",
+							"name": "Prometheus Unbound",
+							"description": "A mission has been greenlit to take the Prometheus to the Pegasus galaxy. Jackson wants in. O'Neill feels he is too valuable to risk. The decision is overridden by the mission commander, none other than Gen. Hammond, now head of home world security.",
+							"duration": 3600000,
+							"slug": "prometheus-unbound-8-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df8f3b14df50007c476e6/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df8f3b14df50007c476e6/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df8f3b14df50007c476e6/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df8f3b14df50007c476e6/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df8f3b14df50007c476e6/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df90633a1e50007cb16a8",
+							"name": "It's Good To Be King",
+							"description": "Hoping to warn Harry Maybourne of Goa'uld attacks, SG-1 arrives at his last known whereabouts to find that he has been appointed king of a primitive people and believes he possesses writings by a time-traveling Ancient predicting these events.",
+							"duration": 3600000,
+							"slug": "its-good-to-be-king-8-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df90633a1e50007cb16a8/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df90633a1e50007cb16a8/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df90633a1e50007cb16a8/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df90633a1e50007cb16a8/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df90633a1e50007cb16a8/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df9185b72240007123e6b",
+							"name": "Full Alert",
+							"description": "When O'Neill finds the door to his home forced open and former Vice President Kinsey waiting for him inside, his first instinct is to call the police. But he allies himself with Kinsey when he learns of a rogue organization known as The Trust.",
+							"duration": 3600000,
+							"slug": "full-alert-8-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df9185b72240007123e6b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df9185b72240007123e6b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df9185b72240007123e6b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df9185b72240007123e6b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df9185b72240007123e6b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df924b8a83e000771e61c",
+							"name": "Citizen Joe",
+							"description": "At a tag sale, civilian Joe Spencer comes across a small stone that gives him visions of SG-1 in action. Delighted, he shares the stories with anyone who will listen. But when he learns that SG-1 really exists, his excitement turns into obsession.",
+							"duration": 3600000,
+							"slug": "citizen-joe-8-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df924b8a83e000771e61c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df924b8a83e000771e61c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df924b8a83e000771e61c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df924b8a83e000771e61c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df924b8a83e000771e61c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df934ea3ade0007ad9d48",
+							"name": "Reckoning (Part 1)",
+							"description": "Teal'c and Bra'tac believe the time is right to lead their people in an uprising against the Goa'uld. Their plan suffers a setback when an army of Replicators begins to systematically take control of Goa'uld ships and Jackson is taken prisoner.",
+							"duration": 3600000,
+							"slug": "reckoning-part-1-8-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df934ea3ade0007ad9d48/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df934ea3ade0007ad9d48/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df934ea3ade0007ad9d48/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df934ea3ade0007ad9d48/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df934ea3ade0007ad9d48/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df949a46189000774d140",
+							"name": "Reckoning (Part 2)",
+							"description": "Hidden in the ruined temple on Dakara is an Ancient weapon powerful enough to destroy the Replicators. Thanks to a timely warning, the team knows it. And thanks to Daniel's repressed Ancient knowledge, Replicator Carter knows it as well.",
+							"duration": 3600000,
+							"slug": "reckoning-part-2-8-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df949a46189000774d140/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df949a46189000774d140/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df949a46189000774d140/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df949a46189000774d140/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df949a46189000774d140/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6241f2db0730360007aa1bdb",
+							"name": "Threads",
+							"description": "With a climactic battle behind them, the team turns towards personal matters. Unbeknownst to them, Anubis prepares one final attempt! Meanwhile, Jackson awakens in a way station between the living world and the world of beings that have ascended.",
+							"duration": 3600000,
+							"slug": "threads-8-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6241f2db0730360007aa1bdb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6241f2db0730360007aa1bdb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6241f2db0730360007aa1bdb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6241f2db0730360007aa1bdb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6241f2db0730360007aa1bdb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df95c32669a00071b80f3",
+							"name": "Moebius (Part 1)",
+							"description": "Jackson receives documents that point to the location of a ZPM in ancient Egypt. Hoping that the energy source could be used to power Earth's defenses and open a wormhole to Atlantis, SG-1 uses an ancient time machine to travel back to 3000 B.C.",
+							"duration": 3600000,
+							"slug": "moebius-part-1-8-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df95c32669a00071b80f3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df95c32669a00071b80f3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df95c32669a00071b80f3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df95c32669a00071b80f3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df95c32669a00071b80f3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623df9683654020007ddff0a",
+							"name": "Moebius (Part 2)",
+							"description": "SG-1's attempt to recover a ZPM from 3000 B.C. has altered the timeline, leading to a present where the Stargate was never discovered! The alternate-reality Carter and Jackson convince a reluctant O'Neill to take them on their first mission through.",
+							"duration": 3600000,
+							"slug": "moebius-part-2-8-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df9683654020007ddff0a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df9683654020007ddff0a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df9683654020007ddff0a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df9683654020007ddff0a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df9683654020007ddff0a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 9,
+					"episodes": [
+						{
+							"_id": "623df98718efb500072f074f",
+							"name": "Avalon (Part 1)",
+							"description": "Lieutenant Colonel Cameron Mitchell, the newest member of the SG-1 team, sets out on a mission with Daniel Jackson, Teal'c and Vala to uncover a stash of hidden ancient riches. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "avalon-part-1-9-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623df98718efb500072f074f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623df98718efb500072f074f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623df98718efb500072f074f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623df98718efb500072f074f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623df98718efb500072f074f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6245ee87ffa0a9001396f52f",
+							"name": "Avalon (Part 2)",
+							"description": "Still bound together by the Jaffa bracelets, Daniel Jackson and Vala are transported to a galaxy populated by worshippers of a potentially threatening authority called the Ori. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "avalon-part-2-2005-9-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245ee87ffa0a9001396f52f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245ee87ffa0a9001396f52f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245ee87ffa0a9001396f52f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245ee87ffa0a9001396f52f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245ee87ffa0a9001396f52f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6245f24ed163000013951b03",
+							"name": "Origin",
+							"description": "Daniel and Vala learn that their reactivation of an ancient communications device has inadvertently exposed Earth to the wrath of the group of unforgiving deities called Ori. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "origin-2005-9-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245f24ed163000013951b03/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245f24ed163000013951b03/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245f24ed163000013951b03/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245f24ed163000013951b03/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245f24ed163000013951b03/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6245ee7bffa0a9001396f413",
+							"name": "The Ties That Bind",
+							"description": "Daniel Jackson and Vala embark on a series of dangerous missions in their quest to unlock the frustrating Jaffa bracelets that seems to have bound them together for eternity. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "the-ties-that-bind-2005-9-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245ee7bffa0a9001396f413/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245ee7bffa0a9001396f413/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245ee7bffa0a9001396f413/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245ee7bffa0a9001396f413/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245ee7bffa0a9001396f413/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624201b0c9735d00076fcd8e",
+							"name": "The Powers That Be",
+							"description": "When Daniel and Vala attempt to undo the teachings of the Ori on a distant planet, they and the planet's inhabitants find themselves subject to their foe's vengeful wrath. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "the-powers-that-be-9-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624201b0c9735d00076fcd8e/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624201b0c9735d00076fcd8e/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624201b0c9735d00076fcd8e/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624201b0c9735d00076fcd8e/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624201b0c9735d00076fcd8e/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6245ee7fffa0a9001396f49d",
+							"name": "Beachhead",
+							"description": "The brilliant astrophysicist and former member Samantha Carter returns to SG-1 to join the team on a mission to free a distant planet called Kallana from the Ori's control. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "beachhead-2005-9-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245ee7fffa0a9001396f49d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245ee7fffa0a9001396f49d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245ee7fffa0a9001396f49d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245ee7fffa0a9001396f49d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245ee7fffa0a9001396f49d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6245f7eefc8de900130eef9b",
+							"name": "Ex Deus Machina",
+							"description": "The SG-1 team must intervene when a major ongoing conflict between the strident Jaffa Gerak and their former enemy Ba'al puts the entire United States at risk of destruction. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "ex-deus-machina-2005-9-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245f7eefc8de900130eef9b/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245f7eefc8de900130eef9b/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245f7eefc8de900130eef9b/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245f7eefc8de900130eef9b/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245f7eefc8de900130eef9b/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624201c162970100072ef3cd",
+							"name": "Babylon",
+							"description": "Lieutenant Colonel Cameron Mitchell disappears while trying to contact the Sodan, a band of legendary Jaffa warriors who escaped Goa'uld rule and colonized their own planet. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "babylon-9-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624201c162970100072ef3cd/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624201c162970100072ef3cd/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624201c162970100072ef3cd/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624201c162970100072ef3cd/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624201c162970100072ef3cd/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624201dbbd0f9a00070b7dc7",
+							"name": "Prototype",
+							"description": "Hank Landry (Beau Bridges) and his government overseers disagree over what to do about what they found in a lab: Anubis' dangerous, genetically engineered Goa'uld creation. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "prototype-9-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624201dbbd0f9a00070b7dc7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624201dbbd0f9a00070b7dc7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624201dbbd0f9a00070b7dc7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624201dbbd0f9a00070b7dc7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624201dbbd0f9a00070b7dc7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6245f258d163000013951cf7",
+							"name": "The Fourth Horseman (Part 1)",
+							"description": "As SG-1 tries to stop the spread of a deadly virus that was caused by the devious Ori, the Jaffa Gerak works on converting the rest of the Jaffa to worshippers of the Ori. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "the-fourth-horseman-part-1-2005-9-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245f258d163000013951cf7/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245f258d163000013951cf7/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245f258d163000013951cf7/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245f258d163000013951cf7/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245f258d163000013951cf7/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6245f252d163000013951b8d",
+							"name": "The Fourth Horseman (Part 2)",
+							"description": "As the Jaffa Gerak amasses forces to rise against them, the Stargate team races to find an antidote to stop a deadly Ori plague from becoming a devastating global pandemic. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "the-fourth-horseman-part-2-2006-9-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6245f252d163000013951b8d/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6245f252d163000013951b8d/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6245f252d163000013951b8d/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6245f252d163000013951b8d/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6245f252d163000013951b8d/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6242023a5128ad0007abc190",
+							"name": "Collateral Damage",
+							"description": "Complications arise when lieutenant Colonel Cameron Mitchell becomes the victim of powerful and dangerous technology that allows individuals to share memories with each other. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "collateral-damage-9-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6242023a5128ad0007abc190/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6242023a5128ad0007abc190/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6242023a5128ad0007abc190/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6242023a5128ad0007abc190/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6242023a5128ad0007abc190/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6242024a4fb51700077f32ce",
+							"name": "Ripple Effect",
+							"description": "Stargate Command is baffled by the arrival of several virtually identical SG-1 teams and must find a way to return them to their respective universes before calamity occurs. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "ripple-effect-9-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6242024a4fb51700077f32ce/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6242024a4fb51700077f32ce/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6242024a4fb51700077f32ce/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6242024a4fb51700077f32ce/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6242024a4fb51700077f32ce/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62420256e1977a00079dfe02",
+							"name": "Stronghold",
+							"description": "Daniel fears the worst when Teal'c mysteriously disappears after investigating corruption. His fears are confirmed when he finds that Jaffa have been kidnapped and brainwashed. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "stronghold-9-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62420256e1977a00079dfe02/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62420256e1977a00079dfe02/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62420256e1977a00079dfe02/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62420256e1977a00079dfe02/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62420256e1977a00079dfe02/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624202621c41f700075e22a5",
+							"name": "Ethon",
+							"description": "SG-1 sets out to destroy a massive and deadly weapon invented by their increasingly powerful foe, the Ori. If not, the Caledonian Federation and its people will be destroyed. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "ethon-9-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624202621c41f700075e22a5/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624202621c41f700075e22a5/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624202621c41f700075e22a5/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624202621c41f700075e22a5/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624202621c41f700075e22a5/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62420271b8a83e00077242ec",
+							"name": "Off The Grid",
+							"description": "Hank Landry (Beau Bridges) and the rest of the Stargate team plan an offensive when they learn that the Goa'uld Ba'al is in the United States and is once again regaining power. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "off-the-grid-9-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62420271b8a83e00077242ec/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62420271b8a83e00077242ec/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62420271b8a83e00077242ec/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62420271b8a83e00077242ec/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62420271b8a83e00077242ec/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6242028075c4bc0007548a6c",
+							"name": "The Scourge",
+							"description": "A crop of genetically engineered insects turns deadly, forcing the SG-1 team to destroy them before they and the visiting international diplomats becoming their next victims. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "the-scourge-9-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6242028075c4bc0007548a6c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6242028075c4bc0007548a6c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6242028075c4bc0007548a6c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6242028075c4bc0007548a6c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6242028075c4bc0007548a6c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6242028e004f8000079b0d5a",
+							"name": "Arthur's Mantle",
+							"description": "While Teal'c sets off to investigate foul play on a Jaffa planet, Mitchell, Carter and Daniel become out of phase while experimenting with a powerful and ancient device. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "arthurs-mantle-9-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6242028e004f8000079b0d5a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6242028e004f8000079b0d5a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6242028e004f8000079b0d5a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6242028e004f8000079b0d5a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6242028e004f8000079b0d5a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6242029cd458b400075c13fe",
+							"name": "Crusade",
+							"description": "Vala returns to Stargate Command to deliver startling news: the Ori have been building military forces, and plan to launch crusades against their dissidents in the near future. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "crusade-9-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6242029cd458b400075c13fe/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6242029cd458b400075c13fe/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6242029cd458b400075c13fe/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6242029cd458b400075c13fe/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6242029cd458b400075c13fe/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624202a9ec419d0008c30f90",
+							"name": "Camelot",
+							"description": "As the Ori's all out assault. looms closer, lieutenant Colonel Cameron Mitchell and Daniel Jackson race to locate a device that will obliterate the evil enemy once and for all. Ben Browder, Michael Shanks, Amanda Tapping, and Christopher Judge star.",
+							"duration": 3600000,
+							"slug": "camelot-9-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624202a9ec419d0008c30f90/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624202a9ec419d0008c30f90/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624202a9ec419d0008c30f90/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624202a9ec419d0008c30f90/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624202a9ec419d0008c30f90/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				},
+				{
+					"number": 10,
+					"episodes": [
+						{
+							"_id": "624202b962970100072ef3f4",
+							"name": "Flesh And Blood",
+							"description": "As their battle with the Ori continues, the team struggles to reunite and formulate a plan to defeat their enemy. Vala (Claudia Black), still aboard an Ori ship, watches as her newly born child quickly ages and is molded to lead the Ori army.",
+							"duration": 3600000,
+							"slug": "flesh-and-blood-10-1",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624202b962970100072ef3f4/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624202b962970100072ef3f4/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624202b962970100072ef3f4/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624202b962970100072ef3f4/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624202b962970100072ef3f4/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6242038a92a8ec0007eee662",
+							"name": "Morpheus",
+							"description": "On a mission to find a weapon that will defeat their powerful foe, the team finds a planet whose inhabitants were killed by a mysterious illness, and unwittingly fall victim to the illness themselves. Starring Ben Browder and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "morpheus-10-2",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6242038a92a8ec0007eee662/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6242038a92a8ec0007eee662/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6242038a92a8ec0007eee662/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6242038a92a8ec0007eee662/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6242038a92a8ec0007eee662/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62420398b8a83e00077242fb",
+							"name": "The Pegasus Project",
+							"description": "SG-1 travels to the Pegasus Galaxy and the city of Atlantis in hopes to find a clue to a weapon that can destroy the Ori. Starring Ben Browder, Amanda Tapping, Christopher Judge, Claudia Black, Beau Bridges, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "the-pegasus-project-10-3",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62420398b8a83e00077242fb/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62420398b8a83e00077242fb/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62420398b8a83e00077242fb/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62420398b8a83e00077242fb/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62420398b8a83e00077242fb/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624203d40853690007bd8bd3",
+							"name": "Insiders",
+							"description": "The team makes a pact with an old enemy to fight their common foe, and the results are disastrous. Starring Ben Browder as Lt. Colonel Cameron Mitchell, Christopher Judge as Teal'c, and Amanda Tapping as Lt. Colonel Samantha Carter.",
+							"duration": 3600000,
+							"slug": "insiders-10-4",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624203d40853690007bd8bd3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624203d40853690007bd8bd3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624203d40853690007bd8bd3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624203d40853690007bd8bd3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624203d40853690007bd8bd3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624203e6119b4c00071ac4fa",
+							"name": "Uninvited",
+							"description": "SG-1 struggles to control a rash of brutal attacks by an elusive and savage alien creature. Starring Ben Browder as Lt. Col. Mitchell, Amanda Tapping as Lt. Col. Carter, Christopher Judge as Teal'c, and Michael Shanks as Dr. Jackson.",
+							"duration": 3600000,
+							"slug": "uninvited-10-5",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624203e6119b4c00071ac4fa/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624203e6119b4c00071ac4fa/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624203e6119b4c00071ac4fa/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624203e6119b4c00071ac4fa/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624203e6119b4c00071ac4fa/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "6242047377b474000859f2e3",
+							"name": "200",
+							"description": "A reluctant SG-1 assists Martin Lloyd (guest star Willie Garson) with his feature film script as a cover story to keep the Stargate Program secret. Also starring Ben Browder, Amanda Tapping, Christopher Judge, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "200-10-6",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/6242047377b474000859f2e3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/6242047377b474000859f2e3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/6242047377b474000859f2e3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/6242047377b474000859f2e3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/6242047377b474000859f2e3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62420480004f8000079b0d6c",
+							"name": "Counterstrike",
+							"description": "When the Jaffa modify an Ancient device so that it is capable of defeating the Ori, Adria (Morena Baccarin) leads an attack on Dakara. Starring Ben Browder, Amanda Tapping, Christopher Judge, Claudia Black, Beau Bridges, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "counterstrike-10-7",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62420480004f8000079b0d6c/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62420480004f8000079b0d6c/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62420480004f8000079b0d6c/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62420480004f8000079b0d6c/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62420480004f8000079b0d6c/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "62420493ccefed0007b22ad3",
+							"name": "Memento Mori",
+							"description": "When Vala (Claudia Black) is kidnapped by Trust members acting under the orders of the Goa'uld Athena, an accident causes her to lose all memory of who she is and where she came from. Also starring Ben Browder, Amanda Tapping, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "memento-mori-10-8",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/62420493ccefed0007b22ad3/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/62420493ccefed0007b22ad3/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/62420493ccefed0007b22ad3/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/62420493ccefed0007b22ad3/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/62420493ccefed0007b22ad3/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624204a7dc90f00007f06ad9",
+							"name": "Company Of Thieves",
+							"description": "Lt. Col. Cameron Mitchell (Ben Browder) goes undercover to track down the Odyssey, which SG-1 believes was hijacked by the Lucian Alliance. Also starring Amanda Tapping, Christopher Judge, Claudia Black, Beau Bridges, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "company-of-thieves-10-9",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624204a7dc90f00007f06ad9/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624204a7dc90f00007f06ad9/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624204a7dc90f00007f06ad9/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624204a7dc90f00007f06ad9/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624204a7dc90f00007f06ad9/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfe37e1055700079ca4ef",
+							"name": "The Quest (Part 1)",
+							"description": "SG-1 finds the planet where they believe the Sangraal is. Forced to forge temporary alliances with Adria (guest star Morena Baccarin) and Ba'al (guest star Cliff Simon) they undertake a quest to find it. Starring Ben Browder and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "the-quest-part-1-10-10",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfe37e1055700079ca4ef/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfe37e1055700079ca4ef/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfe37e1055700079ca4ef/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfe37e1055700079ca4ef/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfe37e1055700079ca4ef/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfe46eb53ba0007a91b92",
+							"name": "Quest, The: Part II",
+							"description": "Discovering the frozen body of Merlin (guest star Matthew Walker), SG-1 works to help him build the Sangraal before Adria (guest star Morena Baccarin) and her Ori army can track them down. Starring Ben Browder, Amanda Tapping, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "quest-the-part-ii-10-11",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfe46eb53ba0007a91b92/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfe46eb53ba0007a91b92/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfe46eb53ba0007a91b92/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfe46eb53ba0007a91b92/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfe46eb53ba0007a91b92/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfe5ab6e5fe0008707ced",
+							"name": "Line In The Sand",
+							"description": "Hoping to use Merlin's phasing device to hide a village from the Ori army, something goes wrong forcing Mitchell (Ben Browder) and a critically injured Carter (Amanda Tapping) to hide themselves out of phase from an occupation of Ori soldiers.",
+							"duration": 3600000,
+							"slug": "line-in-the-sand-10-12",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfe5ab6e5fe0008707ced/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfe5ab6e5fe0008707ced/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfe5ab6e5fe0008707ced/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfe5ab6e5fe0008707ced/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfe5ab6e5fe0008707ced/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfe7a6ab25e0007dd1cab",
+							"name": "The Road Not Taken",
+							"description": "An experiment goes wrong leaving Lt. Colonel Samantha Carter (Amanda Tapping) trapped in a parallel reality where martial law has been enforced and Earth is under attack from the Ori. Also starring Ben Browder, Christopher Judge, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "the-road-not-taken-10-13",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfe7a6ab25e0007dd1cab/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfe7a6ab25e0007dd1cab/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfe7a6ab25e0007dd1cab/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfe7a6ab25e0007dd1cab/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfe7a6ab25e0007dd1cab/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfe861c41f700075df9dc",
+							"name": "The Shroud",
+							"description": "When Daniel Jackson turns up as a Prior asking SG-1 to aid him in a plan that might very well be a trap, it's up to Maj. Gen. Jack O'Neill and the team to not only save Jackson's life, but possibly end the war with the Ori once and for all.",
+							"duration": 3600000,
+							"slug": "the-shroud-10-14",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfe861c41f700075df9dc/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfe861c41f700075df9dc/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfe861c41f700075df9dc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfe861c41f700075df9dc/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfe861c41f700075df9dc/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfe942765a7000789b602",
+							"name": "Bounty",
+							"description": "After Netan (Eric Steinberg), and the Lucian Alliance, are undermined by SG-1 yet again, he decides to put a bounty out on their heads. Starring Ben Browder, Amanda Tapping, Christopher Judge, Claudia Black, Beau Bridges, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "bounty-10-15",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfe942765a7000789b602/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfe942765a7000789b602/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfe942765a7000789b602/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfe942765a7000789b602/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfe942765a7000789b602/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfea03654020007ddff3a",
+							"name": "Bad Guys",
+							"description": "Mistaken for rebels on an alien planet, SG-1 must play the part of hostage takers in hopes to buy themselves enough time to be rescued before they're executed. Starring Ben Browder, Amanda Tapping, Christopher Judge, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "bad-guys-10-16",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfea03654020007ddff3a/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfea03654020007ddff3a/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfea03654020007ddff3a/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfea03654020007ddff3a/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfea03654020007ddff3a/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "624204c66ab25e0007dd5574",
+							"name": "Talion",
+							"description": "Barely surviving the bombing massacre of a peaceful Jaffa summit, Teal'c (Christopher Judge) must go rogue to track down and stop a Jaffa leader named Arkad (Craig Fairbrass) who plans to take control of the Jaffa nation and deliver them to the Ori.",
+							"duration": 3600000,
+							"slug": "talion-10-17",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/624204c66ab25e0007dd5574/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/624204c66ab25e0007dd5574/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/624204c66ab25e0007dd5574/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/624204c66ab25e0007dd5574/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/624204c66ab25e0007dd5574/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfeaebeae6e00074e538f",
+							"name": "Family Ties",
+							"description": "Vala's (Claudia Black) father Jacek (guest star Fred Willard) contacts Stargate Command wishing to trade information about a series of planned attacks on Earth in exchange for sanctuary on the planet. Also starring Ben Browder and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "family-ties-10-18",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfeaebeae6e00074e538f/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfeaebeae6e00074e538f/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfeaebeae6e00074e538f/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfeaebeae6e00074e538f/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfeaebeae6e00074e538f/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dfebc1c41f700075df9ee",
+							"name": "Dominion",
+							"description": "In an elaborate plan using Vala Mal Doran (Claudia Black) as bait to capture Adria (guest star Morena Baccarin), SG-1 themselves are surprised when Ba'al (guest star Cliff Simon) intercepts Adria from under them to use in his own evil plan.",
+							"duration": 3600000,
+							"slug": "dominion-10-19",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dfebc1c41f700075df9ee/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dfebc1c41f700075df9ee/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dfebc1c41f700075df9ee/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dfebc1c41f700075df9ee/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dfebc1c41f700075df9ee/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						},
+						{
+							"_id": "623dff5c22ff070007e51949",
+							"name": "Unending",
+							"description": "With extinction imminent, the Asgard hand over all their knowledge and technology to SG-1, but not before the Ori launch an attack trying to intercede. Starring Ben Browder, Amanda Tapping, Christopher Judge, Beau Bridges, and Michael Shanks.",
+							"duration": 3600000,
+							"slug": "unending-10-20",
+							"rating": "TV-14",
+							"genre": "Sci-Fi \u0026 Fantasy",
+							"stitched": {
+								"paths": [
+									{
+										"type": "mpd",
+										"path": "/stitch/dash/episode/623dff5c22ff070007e51949/main.mpd"
+									},
+									{
+										"type": "hls",
+										"path": "/stitch/hls/episode/623dff5c22ff070007e51949/master.m3u8"
+									}
+								]
+							},
+							"covers": [
+								{
+									"aspectRatio": "347:500",
+									"url": "https://images.pluto.tv/episodes/623dff5c22ff070007e51949/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+								},
+								{
+									"aspectRatio": "4:3",
+									"url": "https://images.pluto.tv/episodes/623dff5c22ff070007e51949/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+								},
+								{
+									"aspectRatio": "16:9",
+									"url": "https://images.pluto.tv/episodes/623dff5c22ff070007e51949/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+								}
+							],
+							"seriesID": "",
+							"categoryID": "",
+							"type": "episode"
+						}
+					]
+				}
+			],
+			"stitched": {},
+			"covers": [
+				{
+					"aspectRatio": "347:500",
+					"url": "https://images.pluto.tv/series/6234b65ffc8de900130ab0d2/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+				},
+				{
+					"aspectRatio": "1:1",
+					"url": "https://images.pluto.tv/series/6234b65ffc8de900130ab0d2/tile.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=660\u0026q=75\u0026w=660"
+				}
+			],
+			"seriesID": "",
+			"categoryID": "",
+			"type": "series"
+		},
+		{
+			"id": "629ff609cb032400134d42bc",
+			"name": "Forrest Gump",
+			"description": "Tom Hanks gives an astonishing performance as Forrest, an everyman whose simple innocence comes to embody a generation.",
+			"duration": 10800000,
+			"slug": "forrest-gump-1994-1-1",
+			"rating": "PG-13",
+			"genre": "Drama",
+			"stitched": {
+				"paths": [
+					{
+						"type": "mpd",
+						"path": "/stitch/dash/episode/629ff609cb032400134d42bc/main.mpd"
+					},
+					{
+						"type": "hls",
+						"path": "/stitch/hls/episode/629ff609cb032400134d42bc/master.m3u8"
+					}
+				]
+			},
+			"covers": [
+				{
+					"aspectRatio": "347:500",
+					"url": "https://images.pluto.tv/episodes/629ff609cb032400134d42bc/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+				},
+				{
+					"aspectRatio": "4:3",
+					"url": "https://images.pluto.tv/episodes/629ff609cb032400134d42bc/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+				},
+				{
+					"aspectRatio": "16:9",
+					"url": "https://images.pluto.tv/episodes/629ff609cb032400134d42bc/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+				}
+			],
+			"seriesID": "629ff605cb032400134d42b5",
+			"categoryID": "",
+			"type": "movie"
+		},
+		{
+			"id": "616872fc0b4e8f001a960443",
+			"name": "Titanic",
+			"description": "Leonardo DiCaprio and Oscar-nominee Kate Winslet light up the screen as Jack and Rose, the young lovers who find one another on the maiden voyage of the \"unsinkable\" R.M.S. Titanic.",
+			"duration": 14400000,
+			"slug": "titanic-1997-1-1",
+			"rating": "PG-13",
+			"genre": "Romance",
+			"stitched": {
+				"paths": [
+					{
+						"type": "mpd",
+						"path": "/stitch/dash/episode/616872fc0b4e8f001a960443/main.mpd"
+					},
+					{
+						"type": "hls",
+						"path": "/stitch/hls/episode/616872fc0b4e8f001a960443/master.m3u8"
+					}
+				]
+			},
+			"covers": [
+				{
+					"aspectRatio": "347:500",
+					"url": "https://images.pluto.tv/episodes/616872fc0b4e8f001a960443/poster.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=1000\u0026q=75\u0026w=694"
+				},
+				{
+					"aspectRatio": "4:3",
+					"url": "https://images.pluto.tv/episodes/616872fc0b4e8f001a960443/screenshot4_3.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=480\u0026q=75\u0026w=640"
+				},
+				{
+					"aspectRatio": "16:9",
+					"url": "https://images.pluto.tv/episodes/616872fc0b4e8f001a960443/screenshot16_9.jpg?fill=blur\u0026fit=fill\u0026fm=jpg\u0026h=540\u0026q=75\u0026w=960"
+				}
+			],
+			"seriesID": "616872f90b4e8f001a96043c",
+			"categoryID": "58e1a299dca3c3a22fbd8319",
+			"type": "movie"
+		}
+	],
+	"notifications": [
+		{
+			"message": "Sizzle Reel",
+			"action": "https://siloh.pluto.tv/d71341_Pluto_TV_OandO/clip/5f69381af8cd3d000764662c_PlutoTV_NewUserOnboardingVideo_10_A_V4/720p/20200921_163301/hls/master.m3u8"
+		}
+	],
+	"ratings": {
+		"R": {
+			"displayName": "R",
+			"image": ""
+		},
+		"PG-13": {
+			"displayName": "PG-13",
+			"image": ""
+		},
+		"TV-Y": {
+			"displayName": "TV-Y",
+			"image": ""
+		},
+		"NSFW": {
+			"displayName": "NSFW",
+			"image": ""
+		},
+		"TV-PG": {
+			"displayName": "TV-PG",
+			"image": ""
+		},
+		"TV-14": {
+			"displayName": "TV-14",
+			"image": ""
+		},
+		"TV-Y7FV": {
+			"displayName": "TV-Y7FV",
+			"image": ""
+		},
+		"TV-MA": {
+			"displayName": "TV-MA",
+			"image": ""
+		},
+		"PG": {
+			"displayName": "PG",
+			"image": ""
+		},
+		"NC-17": {
+			"displayName": "NC-17",
+			"image": ""
+		},
+		"TV-G": {
+			"displayName": "TV-G",
+			"image": ""
+		},
+		"TV-Y7": {
+			"displayName": "TV-Y7",
+			"image": ""
+		},
+		"G": {
+			"displayName": "G",
+			"image": ""
+		}
+	},
+	"ratingDescriptors": {
+		"us-l": {
+			"displayName": "L"
+		},
+		"us-suicide": {
+			"displayName": "Suicide"
+		},
+		"us-smoking": {
+			"displayName": "Smoking"
+		},
+		"us-s": {
+			"displayName": "S"
+		},
+		"us-v": {
+			"displayName": "V"
+		},
+		"us-d": {
+			"displayName": "D"
+		},
+		"us-nudity": {
+			"displayName": "Nudity"
+		}
+	},
+	"startingChannel": {
+		"id": "617b37b361e0fd0008cfd8c5",
+		"slug": "pluto-tv-reaction"
+	},
+	"stitcherParams": "advertisingId=\u0026appName=web\u0026appVersion=7.4.1-9c652bb3f73b3a4ec5b0a09c668bd63cffe57d94\u0026app_name=web\u0026clientDeviceType=0\u0026clientID=62d79355-afbd-489c-abb2-499c45197f73\u0026clientModelNumber=1.0.0\u0026country=US\u0026deviceDNT=false\u0026deviceId=62d79355-afbd-489c-abb2-499c45197f73\u0026deviceLat=40.7930\u0026deviceLon=-74.0247\u0026deviceMake=firefox\u0026deviceModel=web\u0026deviceType=web\u0026deviceVersion=115.0.0\u0026marketingRegion=US\u0026serverSideAds=false\u0026sessionID=494501c4-2ba7-11ee-b629-429bafd60572\u0026sid=494501c4-2ba7-11ee-b629-429bafd60572\u0026userId=",
+	"serverTime": "2023-07-26T11:26:38.385Z",
+	"refreshInSec": 28800,
+	"sessionToken": "eyJhbGciOiJIUzI1NiIsImtpZCI6Ijc1ZTAwMDlkLTJhOTItNGUxMy04OGJhLTlmZjVhMTc4NTc1OCIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uSUQiOiI0OTQ1MDFjNC0yYmE3LTExZWUtYjYyOS00MjliYWZkNjA1NzIiLCJjbGllbnRJUCI6IjEwNC4yNDYuMTI1LjE0MSIsImNpdHkiOiJOb3J0aCBCZXJnZW4iLCJwb3N0YWxDb2RlIjoiMDcwNDciLCJjb3VudHJ5IjoiVVMiLCJkbWEiOjUwMSwiYWN0aXZlUmVnaW9uIjoiVVMiLCJkZXZpY2VMYXQiOjQwLjc5MywiZGV2aWNlTG9uIjotNzQuMDI0NywicHJlZmVycmVkTGFuZ3VhZ2UiOiJlbiIsImRldmljZVR5cGUiOiJ3ZWIiLCJkZXZpY2VWZXJzaW9uIjoiMTE1LjAuMCIsImRldmljZU1ha2UiOiJmaXJlZm94IiwiZGV2aWNlTW9kZWwiOiJ3ZWIiLCJhcHBOYW1lIjoid2ViIiwiYXBwVmVyc2lvbiI6IjcuNC4xLTljNjUyYmIzZjczYjNhNGVjNWIwYTA5YzY2OGJkNjNjZmZlNTdkOTQiLCJjbGllbnRJRCI6IjYyZDc5MzU1LWFmYmQtNDg5Yy1hYmIyLTQ5OWM0NTE5N2Y3MyIsImNtQXVkaWVuY2VJRCI6IiIsImlzQ2xpZW50RE5UIjpmYWxzZSwidXNlcklEIjoiIiwibG9nTGV2ZWwiOiJERUZBVUxUIiwidGltZVpvbmUiOiJBbWVyaWNhL05ld19Zb3JrIiwic2VydmVyU2lkZUFkcyI6ZmFsc2UsImUyZUJlYWNvbnMiOmZhbHNlLCJmZWF0dXJlcyI6eyJpc1N0aXRjaGVyRWtzIjp0cnVlLCJtdWx0aVBvZEFkcyI6eyJlbmFibGVkIjp0cnVlfSwic2VhcmNoQVBJIjp7Im1hdGNoRXhhY3RJblBocmFzZUVuYWJsZWQiOnRydWUsIm1hdGNoSW5BY3RvcnNFbmFibGVkIjp0cnVlLCJtYXRjaEluRGlyZWN0b3JzRW5hYmxlZCI6dHJ1ZSwicXVlcnlTeW5vbnltc0VuYWJsZWQiOnRydWV9fSwiZm1zUGFyYW1zIjp7ImZ3VmNJRDIiOiI2MmQ3OTM1NS1hZmJkLTQ4OWMtYWJiMi00OTljNDUxOTdmNzMiLCJmd1ZjSUQyQ29wcGEiOiI2MmQ3OTM1NS1hZmJkLTQ4OWMtYWJiMi00OTljNDUxOTdmNzMiLCJjdXN0b21QYXJhbXMiOnsiZm1zX2xpdmVyYW1wX2lkbCI6IiIsImZtc19lbWFpbGhhc2giOiIiLCJmbXNfc3Vic2NyaWJlcmlkIjoiIiwiZm1zX2lmYSI6IiIsImZtc19pZGZ2IjoiIiwiZm1zX3VzZXJpZCI6IjYyZDc5MzU1LWFmYmQtNDg5Yy1hYmIyLTQ5OWM0NTE5N2Y3MyIsImZtc192Y2lkMnR5cGUiOiJ1c2VyaWQiLCJmbXNfcmFtcF9pZCI6IiIsImZtc19oaF9yYW1wX2lkIjoiIiwiZm1zX2JpZGlkdHlwZSI6IiIsIl9md18zUF9VSUQiOiIifX0sImRybSI6eyJuYW1lIjoid2lkZXZpbmUiLCJsZXZlbCI6IkwzIn0sImlzcyI6ImJvb3QucGx1dG8udHYiLCJzdWIiOiJwcmk6djE6cGx1dG86ZGV2aWNlczpVUzpOakprTnprek5UVXRZV1ppWkMwME9EbGpMV0ZpWWpJdE5EazVZelExTVRrM1pqY3oiLCJhdWQiOiIqLnBsdXRvLnR2IiwiZXhwIjoxNjkwNDU3MTk4LCJpYXQiOjE2OTAzNzA3OTgsImp0aSI6IjE0MjMzZDNiLTU2NDItNGZjYy05ODZjLWVlNzA3ZTdlMjA0NCJ9.M6kNM0ssoxQJahbaIITfUFk8G2EP1OEDA0YS4Ce40BA"
+}

--- a/server/tests/unit/services/plutotv.spec.ts
+++ b/server/tests/unit/services/plutotv.spec.ts
@@ -1,6 +1,7 @@
 import PlutoAdapter, { PlutoBootResponse, type PlutoParsedIds } from "../../../services/pluto";
 import { AxiosResponse } from "axios";
 import fs from "fs";
+import { VideoRequest } from "../../../serviceadapter";
 
 const singleVideoLinks: [string, PlutoParsedIds][] = [
 	[
@@ -142,6 +143,51 @@ describe("Pluto TV", () => {
 			});
 		});
 	});
+
+	describe("fetchManyVideoInfo", () => {
+		const adapter = new PlutoAdapter();
+		let apiGetSpy: jest.SpyInstance;
+
+		beforeAll(() => {
+			apiGetSpy = jest.spyOn(adapter.api, "get").mockImplementation(mockPlutoBoot);
+		});
+
+		afterEach(() => {
+			apiGetSpy.mockClear();
+		});
+
+		afterAll(() => {
+			apiGetSpy.mockRestore();
+		});
+
+		it("should fetch many videos with a single request", async () => {
+			const requests: VideoRequest[] = [
+				{
+					id: "series/603db25de7c979001a88f77a/603db2a8e7c979001a890535",
+					missingInfo: ["title", "description", "thumbnail", "length"],
+				},
+				{
+					id: "series/603db25de7c979001a88f77a/603db2a8e7c979001a890520",
+					missingInfo: ["title", "description", "thumbnail", "length"],
+				},
+				{
+					id: "series/6234b65ffc8de900130ab0d2/62704a8e73a0a1001450f4c6",
+					missingInfo: ["title", "description", "thumbnail", "length"],
+				},
+				{
+					id: "movies/629ff609cb032400134d42bc",
+					missingInfo: ["title", "description", "thumbnail", "length"],
+				},
+				{
+					id: "movies/616872fc0b4e8f001a960443",
+					missingInfo: ["title", "description", "thumbnail", "length"],
+				},
+			];
+			const result = await adapter.fetchManyVideoInfo(requests);
+
+			expect(result).toHaveLength(5);
+		});
+	});
 });
 
 const FIXTURE_DIRECTORY = "./tests/unit/fixtures/services/pluto";
@@ -151,6 +197,8 @@ const fixtureMappings = {
 	"629ff609cb032400134d42bc": "boot-v4_movie_forest_gump.json",
 	"6234b65ffc8de900130ab0d2": "boot-v4_series_stargate.json",
 	"603db25de7c979001a88f77a": "boot-v4_series_judge_judy.json",
+	"603db25de7c979001a88f77a,6234b65ffc8de900130ab0d2,629ff609cb032400134d42bc,616872fc0b4e8f001a960443":
+		"boot-v4_series_judge_judy_stargate_forest_gump_titanic.json",
 };
 
 async function mockPlutoBoot(url, params): Promise<AxiosResponse<PlutoBootResponse>> {

--- a/server/tests/unit/services/plutotv.spec.ts
+++ b/server/tests/unit/services/plutotv.spec.ts
@@ -187,6 +187,22 @@ describe("Pluto TV", () => {
 
 			expect(result).toHaveLength(5);
 		});
+
+		it("should not outright fail if some videos aren't present", async () => {
+			const requests: VideoRequest[] = [
+				{
+					id: "series/603db25de7c979001a88f77a/603db2a8e7c979001a890535",
+					missingInfo: ["title", "description", "thumbnail", "length"],
+				},
+				{
+					id: "series/603db25de7c979001a88f77a/703db2a8e7c9e9001z123abc", // doesn't exist
+					missingInfo: ["title", "description", "thumbnail", "length"],
+				},
+			];
+			const result = await adapter.fetchManyVideoInfo(requests);
+
+			expect(result).toHaveLength(1);
+		});
 	});
 });
 


### PR DESCRIPTION
- pluto: batch multiple requests into a single api call
- fix unnecessary cache scans in getManyVideoInfo
