### PR TITLE
log job

### DIFF
--- a/deploy/fly.prod.logs.toml
+++ b/deploy/fly.prod.logs.toml
@@ -1,0 +1,18 @@
+# fly.toml app configuration file generated for ott-logs-prod on 2023-07-27T15:12:42-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "ott-logs-prod"
+primary_region = "ewr"
+
+[build]
+image = "ghcr.io/superfly/fly-log-shipper:latest"
+
+[[services]]
+http_checks = []
+internal_port = 8686
+
+[metrics]
+port = 9598
+path = "/metrics"

--- a/deploy/jobs/backup_pg.sh
+++ b/deploy/jobs/backup_pg.sh
@@ -6,11 +6,14 @@ cd "$(dirname "$0")"
 
 echo "$DATABASE_URL"
 
-curl https://downloads.rclone.org/rclone-current-linux-amd64.zip -o rclone.zip
-unzip rclone.zip
-find . -name rclone -type f -exec mv {} /app \;
-rm -rf rclone.zip rclone-v*
-chmod +x ./rclone
+if [[ ! -f ./rclone ]]; then
+	echo "rclone not found, downloading..."
+	curl https://downloads.rclone.org/rclone-current-linux-amd64.zip -o rclone.zip
+	unzip rclone.zip
+	find . -name rclone -type f -exec mv {} /app \;
+	rm -rf rclone.zip rclone-v*
+	chmod +x ./rclone
+fi
 
 cat > ./rclone.conf << EOF
 [b2]

--- a/deploy/jobs/fly.prod.job-runner.toml
+++ b/deploy/jobs/fly.prod.job-runner.toml
@@ -5,4 +5,5 @@ primary_region = "ewr"
 dockerfile = "job-runner.Dockerfile"
 
 [metrics]
+path = "/metrics"
 port = 9746


### PR DESCRIPTION
- jobs: don't download rclone if it's already there
- maybe fix job runner metrics not working?
- deploy another app to ship logs to betterstack

closes #1038
