### PR TITLE
redis bandwidth optimizations

### DIFF
--- a/deploy/base.toml
+++ b/deploy/base.toml
@@ -8,6 +8,9 @@ metrics = true
 [redis]
 metrics = true
 
+[info_extractor.youtube]
+truncate_description = 509
+
 [info_extractor.direct]
 ffprobe_path = "/usr/bin/ffprobe"
 ffprobe_strategy = "stream"

--- a/server/ott-config.ts
+++ b/server/ott-config.ts
@@ -232,6 +232,12 @@ export const conf = convict({
 				env: "YOUTUBE_API_KEY",
 				sensitive: true,
 			},
+			truncate_description: {
+				doc: "The number of characters to truncate the description to, or null to not truncate.",
+				format: "nat",
+				default: null as number | null,
+				nullable: true,
+			},
 		},
 		direct: {
 			ffprobe_path: {

--- a/server/room.ts
+++ b/server/room.ts
@@ -857,8 +857,10 @@ export class Room implements RoomState {
 
 		msg = Object.assign(msg, _.pick(state, Array.from(this._dirty)));
 		await redisClient.set(`room:${this.name}`, this.serializeState());
-		await redisClient.set(`room-sync:${this.name}`, this.serializeSyncableState());
-		await this.publish(msg);
+		if (!_.isEmpty(msg)) {
+			await redisClient.set(`room-sync:${this.name}`, this.serializeSyncableState());
+			await this.publish(msg);
+		}
 
 		let settings: Partial<RoomStatePersistable> = _.pick(
 			this,

--- a/server/services/youtube.ts
+++ b/server/services/youtube.ts
@@ -527,7 +527,12 @@ export default class YouTubeAdapter extends ServiceAdapter {
 		};
 		if (item.snippet) {
 			video.title = item.snippet.title;
-			video.description = item.snippet.description;
+			const truncDescription = conf.get("info_extractor.youtube.truncate_description");
+			if (truncDescription && item.snippet.description.length > truncDescription) {
+				video.description = item.snippet.description.substring(0, truncDescription) + "...";
+			} else {
+				video.description = item.snippet.description;
+			}
 			if (item.snippet.thumbnails) {
 				if (item.snippet.thumbnails.medium) {
 					video.thumbnail = item.snippet.thumbnails.medium.url;


### PR DESCRIPTION
- add an option to trucate youtube video descriptions to save on storage and bandwidth
- don't write `room-sync` to redis if it would not change it
- avoid saving full room state to redis if it's not necessary
