### PR TITLE
refactor: make balancers connect to monoliths instead of the other way around

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +813,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,7 +922,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -976,7 +999,7 @@ dependencies = [
  "hyper 1.0.0-rc.4",
  "once_cell",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower",
  "tower-service",
@@ -988,6 +1011,17 @@ name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1057,6 +1091,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2 0.5.3",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -1130,6 +1176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1223,21 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -1428,6 +1495,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
+ "trust-dns-resolver",
  "tungstenite",
  "uuid",
 ]
@@ -1628,6 +1696,12 @@ checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1878,7 +1952,17 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.10.1",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -2155,6 +2239,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,7 +2371,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "tracing",
  "windows-sys 0.45.0",
@@ -2626,6 +2720,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.2.3",
+ "ipnet",
+ "lazy_static",
+ "rand 0.8.5",
+ "smallvec 1.10.0",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url 2.3.1",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "lru-cache",
+ "parking_lot 0.12.1",
+ "resolv-conf",
+ "smallvec 1.10.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +3086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3143,6 +3288,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,10 +1493,12 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "trust-dns-resolver",
  "tungstenite",
+ "url 2.3.1",
  "uuid",
 ]
 
@@ -2530,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes 1.4.0",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }
 tokio = { version = "1", features = ["full", "tracing"] }
 tokio-tungstenite = "0.19.0"
+tokio-util = "0.7.8"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 tungstenite = "0.19.0"

--- a/crates/ott-balancer-bin/Cargo.toml
+++ b/crates/ott-balancer-bin/Cargo.toml
@@ -24,8 +24,10 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tokio.workspace = true
 tokio-tungstenite.workspace = true
+tokio-util.workspace = true
 tungstenite.workspace = true
 uuid.workspace = true
+url.workspace = true
 ott-balancer-protocol = { path = "../ott-balancer-protocol" }
 route-recognizer = "0.3.1"
 once_cell = "1.17.1"

--- a/crates/ott-balancer-bin/Cargo.toml
+++ b/crates/ott-balancer-bin/Cargo.toml
@@ -30,3 +30,4 @@ ott-balancer-protocol = { path = "../ott-balancer-protocol" }
 route-recognizer = "0.3.1"
 once_cell = "1.17.1"
 pin-project = "1.0.12"
+trust-dns-resolver = "0.22.0"

--- a/crates/ott-balancer-bin/Cargo.toml
+++ b/crates/ott-balancer-bin/Cargo.toml
@@ -32,4 +32,4 @@ ott-balancer-protocol = { path = "../ott-balancer-protocol" }
 route-recognizer = "0.3.1"
 once_cell = "1.17.1"
 pin-project = "1.0.12"
-trust-dns-resolver = "0.22.0"
+trust-dns-resolver = { version = "0.22.0", features = ["system-config"] }

--- a/crates/ott-balancer-bin/src/balancer.rs
+++ b/crates/ott-balancer-bin/src/balancer.rs
@@ -550,9 +550,10 @@ pub async fn dispatch_monolith_message(
                         .get(monolith_id)
                         .unwrap()
                         .rooms()
-                        .get(&room) else {
-                            anyhow::bail!("room not found on monolith");
-                        };
+                        .get(&room)
+                    else {
+                        anyhow::bail!("room not found on monolith");
+                    };
 
                     // TODO: also handle the case where the client_id is Some
 

--- a/crates/ott-balancer-bin/src/client.rs
+++ b/crates/ott-balancer-bin/src/client.rs
@@ -75,12 +75,14 @@ pub async fn client_entry<'r>(
 
     let result = tokio::time::timeout(Duration::from_secs(20), stream.next()).await;
     let Ok(Some(Ok(message))) = result else {
-                stream.close(Some(CloseFrame {
-                    code: CloseCode::Library(4004),
-                    reason: "did not send auth token".into(),
-                })).await?;
-                return Ok(());
-            };
+        stream
+            .close(Some(CloseFrame {
+                code: CloseCode::Library(4004),
+                reason: "did not send auth token".into(),
+            }))
+            .await?;
+        return Ok(());
+    };
 
     let mut outbound_rx;
     match message {
@@ -91,12 +93,14 @@ pub async fn client_entry<'r>(
                     debug!("client authenticated, handing off to balancer");
                     let client = client.into_new_client(message.token);
                     let Ok(rx) = balancer.send_client(client).await else {
-                                stream.close(Some(CloseFrame {
-                                    code: CloseCode::Library(4000),
-                                    reason: "failed to send client to balancer".into(),
-                                })).await?;
-                                return Ok(());
-                            };
+                        stream
+                            .close(Some(CloseFrame {
+                                code: CloseCode::Library(4000),
+                                reason: "failed to send client to balancer".into(),
+                            }))
+                            .await?;
+                        return Ok(());
+                    };
                     outbound_rx = rx;
                 }
                 _ => {

--- a/crates/ott-balancer-bin/src/config.rs
+++ b/crates/ott-balancer-bin/src/config.rs
@@ -13,11 +13,34 @@ static CONFIG_INIT: Once = Once::new();
 pub struct BalancerConfig {
     /// The port to listen on for HTTP requests.
     pub port: u16,
+    pub discovery: DiscoveryConfig,
 }
 
 impl Default for BalancerConfig {
     fn default() -> Self {
-        Self { port: 8081 }
+        Self {
+            port: 8081,
+            discovery: DiscoveryConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct DiscoveryConfig {
+    pub enabled: bool,
+    /// The port that monoliths should be listening on for load balancer connections.
+    pub port: u16,
+    pub fly_app: String,
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            port: 3002,
+            fly_app: "".into(),
+        }
     }
 }
 

--- a/crates/ott-balancer-bin/src/config.rs
+++ b/crates/ott-balancer-bin/src/config.rs
@@ -4,6 +4,8 @@ use clap::{Parser, ValueEnum};
 use figment::providers::Format;
 use serde::Deserialize;
 
+use crate::discovery::{FlyDiscoveryConfig, ManualDiscoveryConfig};
+
 static mut CONFIG: Option<BalancerConfig> = None;
 
 static CONFIG_INIT: Once = Once::new();
@@ -26,21 +28,15 @@ impl Default for BalancerConfig {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(default)]
-pub struct DiscoveryConfig {
-    pub enabled: bool,
-    /// The port that monoliths should be listening on for load balancer connections.
-    pub port: u16,
-    pub fly_app: String,
+#[serde(tag = "method", rename_all = "lowercase")]
+pub enum DiscoveryConfig {
+    Fly(FlyDiscoveryConfig),
+    Manual(ManualDiscoveryConfig),
 }
 
 impl Default for DiscoveryConfig {
     fn default() -> Self {
-        Self {
-            enabled: false,
-            port: 3002,
-            fly_app: "".into(),
-        }
+        Self::Manual(ManualDiscoveryConfig::default())
     }
 }
 

--- a/crates/ott-balancer-bin/src/connection.rs
+++ b/crates/ott-balancer-bin/src/connection.rs
@@ -184,6 +184,7 @@ async fn connect_and_maintain(
                         stream = s;
                     } else {
                         warn!("Failed to reconnect to monolith: {}", conf.uri());
+                        tokio::time::sleep(Duration::from_secs(5)).await;
                     }
                 }
             }

--- a/crates/ott-balancer-bin/src/connection.rs
+++ b/crates/ott-balancer-bin/src/connection.rs
@@ -1,0 +1,40 @@
+//! Manages connections to Monoliths.
+
+use std::collections::HashSet;
+
+use crate::balancer::BalancerLink;
+use crate::discovery::{MonolithConnectionConfig, MonolithDiscoveryMsg};
+
+pub struct MonolithConnectionManager {
+    discovery_rx: tokio::sync::mpsc::Receiver<MonolithDiscoveryMsg>,
+    link: BalancerLink,
+
+    monoliths: HashSet<MonolithConnectionConfig>,
+}
+
+impl MonolithConnectionManager {
+    pub fn new(
+        discovery_rx: tokio::sync::mpsc::Receiver<MonolithDiscoveryMsg>,
+        link: BalancerLink,
+    ) -> Self {
+        Self {
+            discovery_rx,
+            monoliths: Default::default(),
+            link,
+        }
+    }
+
+    pub async fn do_connection_job(&mut self) -> anyhow::Result<()> {
+        let msg = self
+            .discovery_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Discovery channel closed"))?;
+        self.monoliths.extend(msg.added);
+        self.monoliths.retain(|m| !msg.removed.contains(m));
+
+        // TODO: actually start connections and manage them
+
+        Ok(())
+    }
+}

--- a/crates/ott-balancer-bin/src/connection.rs
+++ b/crates/ott-balancer-bin/src/connection.rs
@@ -108,13 +108,18 @@ async fn connect_and_maintain(
 
     let result = tokio::time::timeout(Duration::from_secs(20), stream.next()).await;
     let Ok(Some(Ok(message))) = result else {
-                let _ = stream.close(Some(CloseFrame {
-                    code: CloseCode::Library(4000),
-                    reason: "did not send init".into(),
-                })).await;
-                warn!("Monolith misbehaved, did not send init, timed out: {}", conf.uri());
-                return;
-            };
+        let _ = stream
+            .close(Some(CloseFrame {
+                code: CloseCode::Library(4000),
+                reason: "did not send init".into(),
+            }))
+            .await;
+        warn!(
+            "Monolith misbehaved, did not send init, timed out: {}",
+            conf.uri()
+        );
+        return;
+    };
 
     // Handle connection initialization
     let mut outbound_rx;
@@ -130,10 +135,12 @@ async fn connect_and_maintain(
                         proxy_port: init.port,
                     };
                     let Ok(rx) = link.send_monolith(monolith).await else {
-                        let _ = stream.close(Some(CloseFrame {
-                            code: CloseCode::Library(4000),
-                            reason: "failed to send monolith to balancer".into(),
-                        })).await;
+                        let _ = stream
+                            .close(Some(CloseFrame {
+                                code: CloseCode::Library(4000),
+                                reason: "failed to send monolith to balancer".into(),
+                            }))
+                            .await;
                         warn!("Could not send Monolith to balancer: {}", conf.uri());
                         return;
                     };

--- a/crates/ott-balancer-bin/src/connection.rs
+++ b/crates/ott-balancer-bin/src/connection.rs
@@ -1,15 +1,29 @@
 //! Manages connections to Monoliths.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use ott_balancer_protocol::monolith::MsgM2B;
+use tokio_tungstenite::connect_async;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info};
+use tungstenite::protocol::frame::coding::CloseCode;
+use tungstenite::protocol::CloseFrame;
+use tungstenite::Message;
+use uuid::Uuid;
 
 use crate::balancer::BalancerLink;
 use crate::discovery::{MonolithConnectionConfig, MonolithDiscoveryMsg};
+use crate::messages::SocketMessage;
+use crate::monolith::NewMonolith;
 
 pub struct MonolithConnectionManager {
     discovery_rx: tokio::sync::mpsc::Receiver<MonolithDiscoveryMsg>,
     link: BalancerLink,
 
     monoliths: HashSet<MonolithConnectionConfig>,
+    connection_tasks: HashMap<MonolithConnectionConfig, ActiveConnection>,
 }
 
 impl MonolithConnectionManager {
@@ -19,8 +33,9 @@ impl MonolithConnectionManager {
     ) -> Self {
         Self {
             discovery_rx,
-            monoliths: Default::default(),
             link,
+            monoliths: Default::default(),
+            connection_tasks: Default::default(),
         }
     }
 
@@ -30,11 +45,137 @@ impl MonolithConnectionManager {
             .recv()
             .await
             .ok_or_else(|| anyhow::anyhow!("Discovery channel closed"))?;
-        self.monoliths.extend(msg.added);
-        self.monoliths.retain(|m| !msg.removed.contains(m));
+        for m in &msg.removed {
+            // TODO: cancel connection task and remove from connection_tasks
+            self.monoliths.remove(m);
+        }
 
-        // TODO: actually start connections and manage them
+        for conf in msg.added {
+            let c = conf.clone();
+            let link = self.link.clone();
+            self.monoliths.insert(conf.clone());
+
+            let handle = tokio::task::Builder::new()
+                .name("monolith connection")
+                .spawn(async move {
+                    match connect_and_maintain(conf.clone(), link.clone()).await {
+                        Ok(_) => {
+                            info!("Monolith connection ended: {}", conf.uri());
+                        }
+                        Err(err) => {
+                            error!("Monolith connection failed: {}", err);
+                        }
+                    }
+                })?;
+            let active = ActiveConnection {
+                handle,
+                cancel: CancellationToken::new(),
+            };
+
+            self.connection_tasks.insert(c, active);
+        }
 
         Ok(())
     }
+}
+
+async fn connect_and_maintain(
+    conf: MonolithConnectionConfig,
+    link: BalancerLink,
+) -> anyhow::Result<()> {
+    let (mut stream, _) = connect_async(conf.uri()).await?;
+
+    let monolith_id = Uuid::new_v4().into();
+
+    let result = tokio::time::timeout(Duration::from_secs(20), stream.next()).await;
+    let Ok(Some(Ok(message))) = result else {
+                stream.close(Some(CloseFrame {
+                    code: CloseCode::Library(4000),
+                    reason: "did not send init".into(),
+                })).await?;
+                return Ok(());
+            };
+
+    // Handle connection initialization
+    let mut outbound_rx;
+    match message {
+        Message::Text(text) => {
+            let message: MsgM2B = serde_json::from_str(&text).unwrap();
+            match message {
+                MsgM2B::Init(init) => {
+                    debug!("monolith sent init, handing off to balancer");
+                    let monolith = NewMonolith {
+                        id: monolith_id,
+                        config: conf.clone(),
+                        proxy_port: init.port,
+                    };
+                    let Ok(rx) = link.send_monolith(monolith).await else {
+                        stream.close(Some(CloseFrame {
+                                    code: CloseCode::Library(4000),
+                                    reason: "failed to send monolith to balancer".into(),
+                                })).await?;
+                                return Ok(());
+                            };
+                    info!("Monolith {id} linked to balancer", id = monolith_id);
+                    outbound_rx = rx;
+                }
+                _ => {
+                    stream
+                        .close(Some(CloseFrame {
+                            code: CloseCode::Library(4004),
+                            reason: "did not send auth token".into(),
+                        }))
+                        .await?;
+                    return Ok(());
+                }
+            }
+        }
+        _ => {
+            return Ok(());
+        }
+    }
+
+    loop {
+        tokio::select! {
+            msg = outbound_rx.recv() => {
+                if let Some(SocketMessage::Message(msg)) = msg {
+                    if let Err(err) = stream.send(msg).await {
+                        error!("Error sending ws message to monolith: {:?}", err);
+                        break;
+                    }
+                } else {
+                    continue;
+                }
+            }
+
+            msg = stream.next() => {
+                if let Some(Ok(msg)) = msg {
+                    if let Err(err) = link
+                        .send_monolith_message(monolith_id, SocketMessage::Message(msg))
+                        .await {
+                            error!("Error sending monolith message to balancer: {:?}", err);
+                            break;
+                        }
+                } else {
+                    info!("Monolith websocket stream ended: {}", monolith_id);
+                    // TODO: reconnect instead
+                    #[allow(deprecated)]
+                    if let Err(err) = link
+                        .send_monolith_message(monolith_id, SocketMessage::End)
+                        .await {
+                            error!("Error sending monolith message to balancer: {:?}", err);
+                            break;
+                        }
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct ActiveConnection {
+    handle: tokio::task::JoinHandle<()>,
+    cancel: CancellationToken,
 }

--- a/crates/ott-balancer-bin/src/connection.rs
+++ b/crates/ott-balancer-bin/src/connection.rs
@@ -55,18 +55,18 @@ impl MonolithConnectionManager {
 
         for conf in msg.added {
             info!("Connecting to monolith at {}", conf.uri());
-            let c = conf.clone();
             let link = self.link.clone();
             self.monoliths.insert(conf.clone());
 
             let cancel = CancellationToken::new();
+            let conf_clone = conf.clone();
             let cancel_clone = cancel.clone();
             let handle = tokio::task::Builder::new()
                 .name("monolith connection")
                 .spawn(async move {
-                    match connect_and_maintain(conf.clone(), link.clone(), cancel_clone).await {
+                    match connect_and_maintain(conf_clone, link.clone(), cancel_clone).await {
                         Ok(_) => {
-                            error!("Monolith connection ended, unsafe task end: {}", conf.uri());
+                            error!("Monolith connection ended, unsafe task end");
                         }
                         Err(err) => {
                             error!("Monolith connection failed, unsafe task end: {}", err);
@@ -75,7 +75,7 @@ impl MonolithConnectionManager {
                 })?;
             let active = ActiveConnection { handle, cancel };
 
-            self.connection_tasks.insert(c, active);
+            self.connection_tasks.insert(conf, active);
         }
 
         Ok(())

--- a/crates/ott-balancer-bin/src/connection.rs
+++ b/crates/ott-balancer-bin/src/connection.rs
@@ -51,6 +51,7 @@ impl MonolithConnectionManager {
         }
 
         for conf in msg.added {
+            info!("Connecting to monolith at {}", conf.uri());
             let c = conf.clone();
             let link = self.link.clone();
             self.monoliths.insert(conf.clone());

--- a/crates/ott-balancer-bin/src/discovery.rs
+++ b/crates/ott-balancer-bin/src/discovery.rs
@@ -13,7 +13,7 @@ pub use manual::*;
 use async_trait::async_trait;
 use serde::Deserialize;
 use tokio::task::JoinHandle;
-use tracing::{error, warn};
+use tracing::{debug, error, info, warn};
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize)]
@@ -110,6 +110,7 @@ impl DiscoveryTask {
             removed: monoliths_removed,
         };
         self.discovery_tx.send(msg).await?;
+        self.monoliths.extend(monoliths_new);
 
         if self.monoliths.is_empty() {
             warn!("No monoliths discovered");

--- a/crates/ott-balancer-bin/src/discovery.rs
+++ b/crates/ott-balancer-bin/src/discovery.rs
@@ -1,0 +1,78 @@
+//! Handles discovery of Monoliths.
+
+mod fly;
+
+use std::{collections::HashSet, net::IpAddr, time::Duration};
+
+use async_trait::async_trait;
+pub use fly::*;
+use tokio::task::JoinHandle;
+use tracing::error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct MonolithConnectionConfig {
+    pub host: HostOrIp,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum HostOrIp {
+    Host(String),
+    Ip(IpAddr),
+}
+
+#[async_trait]
+pub trait MonolithDiscovery {
+    async fn discover(&self) -> anyhow::Result<Vec<MonolithConnectionConfig>>;
+}
+
+pub struct DiscoveryTask<D> {
+    discovery: D,
+
+    monoliths: HashSet<MonolithConnectionConfig>,
+}
+
+impl<D> DiscoveryTask<D>
+where
+    D: MonolithDiscovery,
+{
+    pub fn new(discovery: D) -> Self {
+        Self {
+            discovery,
+            monoliths: Default::default(),
+        }
+    }
+
+    pub async fn do_continuous_discovery(&mut self) {
+        loop {
+            if let Err(e) = self.do_discovery().await {
+                error!("Monolith Discovery failed: {:?}", e);
+            }
+
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+    }
+
+    async fn do_discovery(&mut self) -> anyhow::Result<()> {
+        let monoliths = self.discovery.discover().await?;
+        self.monoliths = monoliths.into_iter().collect();
+        Ok(())
+    }
+
+    pub fn discovered_monoliths(&self) -> &HashSet<MonolithConnectionConfig> {
+        &self.monoliths
+    }
+}
+
+pub fn start_discovery_task<D>(discovery: D) -> JoinHandle<()>
+where
+    D: MonolithDiscovery + Send + Sync + 'static,
+{
+    tokio::task::Builder::new()
+        .name("discovery")
+        .spawn(async move {
+            let mut task = DiscoveryTask::new(discovery);
+            task.do_continuous_discovery().await;
+        })
+        .expect("failed to spawn discovery task")
+}

--- a/crates/ott-balancer-bin/src/discovery.rs
+++ b/crates/ott-balancer-bin/src/discovery.rs
@@ -14,11 +14,29 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use tokio::task::JoinHandle;
 use tracing::{error, warn};
+use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize)]
 pub struct MonolithConnectionConfig {
     pub host: HostOrIp,
     pub port: u16,
+}
+
+impl MonolithConnectionConfig {
+    pub fn uri(&self) -> Url {
+        let mut url = Url::parse("ws://localhost").unwrap();
+        match self.host {
+            HostOrIp::Host(ref host) => {
+                url.set_host(Some(host)).unwrap();
+            }
+            HostOrIp::Ip(ip) => {
+                url.set_ip_host(ip).unwrap();
+            }
+        }
+        url.set_port(Some(self.port)).unwrap();
+
+        url
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/ott-balancer-bin/src/discovery.rs
+++ b/crates/ott-balancer-bin/src/discovery.rs
@@ -13,7 +13,7 @@ pub use manual::*;
 use async_trait::async_trait;
 use serde::Deserialize;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, warn};
+use tracing::{error, warn};
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize)]
@@ -117,10 +117,6 @@ impl DiscoveryTask {
         }
 
         Ok(())
-    }
-
-    pub fn discovered_monoliths(&self) -> &HashSet<MonolithConnectionConfig> {
-        &self.monoliths
     }
 }
 

--- a/crates/ott-balancer-bin/src/discovery/fly.rs
+++ b/crates/ott-balancer-bin/src/discovery/fly.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use tracing::info;
-use trust_dns_resolver::{config::*, TokioAsyncResolver};
+use trust_dns_resolver::{TokioAsyncResolver};
 
-use crate::config::BalancerConfig;
+
 
 use super::*;
 

--- a/crates/ott-balancer-bin/src/discovery/fly.rs
+++ b/crates/ott-balancer-bin/src/discovery/fly.rs
@@ -33,8 +33,7 @@ impl FlyMonolithDiscoverer {
 impl MonolithDiscovery for FlyMonolithDiscoverer {
     async fn discover(&self) -> anyhow::Result<Vec<MonolithConnectionConfig>> {
         let resolver =
-            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default())
-                .expect("failed to create resolver");
+            TokioAsyncResolver::tokio_from_system_conf().expect("failed to create resolver");
 
         let lookup = resolver.ipv6_lookup(&self.query).await?;
         let monoliths = lookup

--- a/crates/ott-balancer-bin/src/discovery/fly.rs
+++ b/crates/ott-balancer-bin/src/discovery/fly.rs
@@ -9,7 +9,7 @@ use super::*;
 #[derive(Debug, Clone, Deserialize)]
 pub struct FlyDiscoveryConfig {
     /// The port that monoliths should be listening on for load balancer connections.
-    pub port: u16,
+    pub monolith_port: u16,
     pub fly_app: String,
 }
 
@@ -41,7 +41,7 @@ impl MonolithDiscovery for FlyMonolithDiscoverer {
             .iter()
             .map(|ip| MonolithConnectionConfig {
                 host: HostOrIp::Ip(IpAddr::V6(*ip)),
-                port: self.config.port,
+                port: self.config.monolith_port,
             })
             .collect::<Vec<_>>();
 

--- a/crates/ott-balancer-bin/src/discovery/fly.rs
+++ b/crates/ott-balancer-bin/src/discovery/fly.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use tracing::info;
+use trust_dns_resolver::{config::*, TokioAsyncResolver};
+
+use crate::config::BalancerConfig;
+
+use super::*;
+
+pub struct FlyMonolithDiscoverer {
+    query: String,
+}
+
+impl FlyMonolithDiscoverer {
+    pub fn new() -> Self {
+        let config = BalancerConfig::get();
+        info!(
+            "Creating FlyMonolithDiscoverer, fly app: {}",
+            config.discovery.fly_app
+        );
+        Self {
+            query: format!("global.{}.internal", config.discovery.fly_app),
+        }
+    }
+}
+
+#[async_trait]
+impl MonolithDiscovery for FlyMonolithDiscoverer {
+    async fn discover(&self) -> anyhow::Result<Vec<MonolithConnectionConfig>> {
+        let resolver =
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default())
+                .expect("failed to create resolver");
+        let config = BalancerConfig::get();
+
+        let lookup = resolver.ipv6_lookup(&self.query).await?;
+        let monoliths = lookup
+            .iter()
+            .map(|ip| MonolithConnectionConfig {
+                host: HostOrIp::Ip(IpAddr::V6(*ip)),
+                port: config.discovery.port,
+            })
+            .collect::<Vec<_>>();
+
+        Ok(monoliths)
+    }
+}

--- a/crates/ott-balancer-bin/src/discovery/fly.rs
+++ b/crates/ott-balancer-bin/src/discovery/fly.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
 use tracing::info;
-use trust_dns_resolver::{TokioAsyncResolver};
-
-
+use trust_dns_resolver::TokioAsyncResolver;
 
 use super::*;
 

--- a/crates/ott-balancer-bin/src/discovery/manual.rs
+++ b/crates/ott-balancer-bin/src/discovery/manual.rs
@@ -1,0 +1,26 @@
+use tracing::info;
+
+use super::*;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ManualDiscoveryConfig {
+    pub monoliths: Vec<MonolithConnectionConfig>,
+}
+
+pub struct ManualMonolithDiscoverer {
+    config: ManualDiscoveryConfig,
+}
+
+impl ManualMonolithDiscoverer {
+    pub fn new(config: ManualDiscoveryConfig) -> Self {
+        info!("Creating ManualMonolithDiscoverer");
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl MonolithDiscovery for ManualMonolithDiscoverer {
+    async fn discover(&self) -> anyhow::Result<Vec<MonolithConnectionConfig>> {
+        Ok(self.config.monoliths.clone())
+    }
+}

--- a/crates/ott-balancer-bin/src/main.rs
+++ b/crates/ott-balancer-bin/src/main.rs
@@ -41,6 +41,8 @@ async fn main() -> anyhow::Result<()> {
         .with(fmt_layer)
         .init();
 
+    let (discovery_tx, discovery_rx) = tokio::sync::mpsc::channel(2);
+
     info!("Starting balancer");
     let ctx = Arc::new(RwLock::new(BalancerContext::new()));
     let balancer = Balancer::new(ctx.clone());
@@ -52,11 +54,11 @@ async fn main() -> anyhow::Result<()> {
     let _discovery_handle = match &config.discovery {
         DiscoveryConfig::Fly(config) => {
             let discovery = discovery::FlyMonolithDiscoverer::new(config.clone());
-            start_discovery_task(discovery)
+            start_discovery_task(discovery, discovery_tx)
         }
         DiscoveryConfig::Manual(config) => {
             let discovery = discovery::ManualMonolithDiscoverer::new(config.clone());
-            start_discovery_task(discovery)
+            start_discovery_task(discovery, discovery_tx)
         }
     };
     info!("Monolith discovery started");

--- a/crates/ott-balancer-bin/src/monolith.rs
+++ b/crates/ott-balancer-bin/src/monolith.rs
@@ -95,7 +95,10 @@ impl BalancerMonolith {
 
     pub fn set_room_metadata(&mut self, room: &RoomName, metadata: RoomMetadata) {
         let Some(room) = self.rooms.get_mut(room) else {
-            error!("Error setting metadata, Monolith {} does not have room {}", self.id, room);
+            error!(
+                "Error setting metadata, Monolith {} does not have room {}",
+                self.id, room
+            );
             return;
         };
         room.set_metadata(metadata);

--- a/crates/ott-balancer-bin/src/monolith.rs
+++ b/crates/ott-balancer-bin/src/monolith.rs
@@ -1,18 +1,12 @@
 use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::time::Duration;
 
-use futures_util::{SinkExt, StreamExt};
-use ott_balancer_protocol::{monolith::*, *};
+use ott_balancer_protocol::monolith::*;
+use ott_balancer_protocol::*;
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{debug, error, info};
-use tungstenite::protocol::frame::coding::CloseCode;
-use tungstenite::protocol::CloseFrame;
-use uuid::Uuid;
+use tracing::error;
 
 use crate::discovery::MonolithConnectionConfig;
-use crate::websocket::HyperWebsocket;
-use crate::{balancer::BalancerLink, messages::*};
+use crate::messages::*;
 
 /// A Monolith refers to the NodeJS server that manages rooms and performs all business logic.
 #[derive(Debug)]

--- a/crates/ott-balancer-bin/src/service.rs
+++ b/crates/ott-balancer-bin/src/service.rs
@@ -173,6 +173,7 @@ async fn proxy_request(
 ) -> anyhow::Result<Response<Full<Bytes>>> {
     let client = target.http_client();
     let mut url: Url = target.config().uri().clone();
+    url.set_scheme("http").expect("failed to set scheme");
     url.set_port(Some(target.proxy_port()))
         .expect("failed to set port");
     url.set_path(in_req.uri().path());

--- a/crates/ott-balancer-bin/src/service.rs
+++ b/crates/ott-balancer-bin/src/service.rs
@@ -124,10 +124,12 @@ impl Service<Request<IncomingBody>> for BalancerService {
                         };
                         if let Some(monolith) = monolith {
                             info!("proxying request to monolith {}", monolith.id());
-                            if let Ok(res) = proxy_request(req, monolith).await {
-                                Ok(res)
-                            } else {
-                                mk_response("error proxying request".to_owned())
+                            match proxy_request(req, monolith).await {
+                                Ok(res) => Ok(res),
+                                Err(err) => {
+                                    error!("error proxying request: {}", err);
+                                    mk_response("error proxying request".to_owned())
+                                }
                             }
                         } else {
                             mk_response("no monoliths available".to_owned())
@@ -139,10 +141,12 @@ impl Service<Request<IncomingBody>> for BalancerService {
                     let monolith = ctx_read.random_monolith().ok();
                     if let Some(monolith) = monolith {
                         info!("proxying request to monolith {}", monolith.id());
-                        if let Ok(res) = proxy_request(req, monolith).await {
-                            Ok(res)
-                        } else {
-                            mk_response("error proxying request".to_owned())
+                        match proxy_request(req, monolith).await {
+                            Ok(res) => Ok(res),
+                            Err(err) => {
+                                error!("error proxying request: {}", err);
+                                mk_response("error proxying request".to_owned())
+                            }
                         }
                     } else {
                         mk_response("no monoliths available".to_owned())

--- a/crates/ott-balancer-bin/src/service.rs
+++ b/crates/ott-balancer-bin/src/service.rs
@@ -60,7 +60,7 @@ impl Service<Request<IncomingBody>> for BalancerService {
 
         let Ok(route) = ROUTER.recognize(req.uri().path()) else {
             warn!("no route found for {}", req.uri().path());
-            return Box::pin(async move {Ok(not_found())});
+            return Box::pin(async move { Ok(not_found()) });
         };
         info!(
             "Inbound request: {} {} => {}",

--- a/crates/ott-balancer-bin/src/service.rs
+++ b/crates/ott-balancer-bin/src/service.rs
@@ -56,7 +56,7 @@ impl Service<Request<IncomingBody>> for BalancerService {
 
         let ctx: Arc<RwLock<BalancerContext>> = self.ctx.clone();
         let link = self.link.clone();
-        let addr = self.addr;
+        let _addr = self.addr;
 
         let Ok(route) = ROUTER.recognize(req.uri().path()) else {
             warn!("no route found for {}", req.uri().path());

--- a/deploy/balancer.Dockerfile
+++ b/deploy/balancer.Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /usr/app/
 
 COPY --from=build-stage /usr/app/ott-balancer-bin /usr/app/
 
-RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y openssl dnsutils && rm -rf /var/lib/apt/lists/*
 
 RUN ulimit -c unlimited
 

--- a/deploy/ott-balancer-staging.toml
+++ b/deploy/ott-balancer-staging.toml
@@ -1,0 +1,4 @@
+[discovery]
+method = "fly"
+fly_app = "ott-staging"
+monolith_port = 3002

--- a/deploy/ott-staging.toml
+++ b/deploy/ott-staging.toml
@@ -5,6 +5,5 @@ cors_proxy = "cors.opentogethertube.com"
 [log]
 level = "silly"
 
-[[balancers]]
-host = "ewr.ott-balancer-staging.internal"
-port = 8081
+[balancing]
+enabled = true

--- a/env/.gitignore
+++ b/env/.gitignore
@@ -3,5 +3,6 @@ development.toml
 test.toml
 production.toml
 staging.toml
+balancer.toml
 
 *.env

--- a/server/balancer.ts
+++ b/server/balancer.ts
@@ -32,6 +32,7 @@ export function initBalancerConnections() {
 		port: conf.get("balancing.port"),
 	});
 	wss.on("connection", ws => {
+		log.debug("New balancer connection");
 		const conn = new BalancerConnection(ws);
 		balancerManager.addBalancerConnection(conn);
 	});
@@ -53,6 +54,7 @@ class BalancerManager {
 
 	addBalancerConnection(conn: BalancerConnection) {
 		this.balancerConnections.push(conn);
+		this.onBalancerConnect(conn);
 		conn.on("connect", () => this.onBalancerConnect(conn));
 		conn.on("disconnect", () => this.onBalancerDisconnect(conn));
 		conn.on("message", msg => this.onBalancerMessage(conn, msg));

--- a/server/balancer.ts
+++ b/server/balancer.ts
@@ -68,6 +68,14 @@ class BalancerManager {
 	private onBalancerConnect(conn: BalancerConnection) {
 		log.info(`Connected to balancer ${conn.id}`);
 		this.emit("connect", conn);
+
+		const init: MsgM2BInit = {
+			type: "init",
+			payload: {
+				port: conf.get("port"),
+			},
+		};
+		conn.send(init);
 	}
 
 	private onBalancerDisconnect(conn: BalancerConnection, code: number, reason: string) {

--- a/server/ott-config.ts
+++ b/server/ott-config.ts
@@ -369,6 +369,18 @@ export const conf = convict({
 			},
 		},
 	},
+	balancing: {
+		enabled: {
+			doc: "Whether to listen for connections from load balancers.",
+			format: Boolean,
+			default: false,
+		},
+		port: {
+			doc: "The port to listen for load balancer connections on.",
+			format: "port",
+			default: 3002,
+		},
+	},
 	mail: {
 		enabled: {
 			doc: "Whether to enable sending emails.",


### PR DESCRIPTION
This makes it so that the websocket connections flow from the client to the monolith, rather than the monoliths manually connecting to the load balancer. This makes it work more like a normal reverse proxy.

Connection flow before:

```mermaid
flowchart LR
monolith --> balancer
client --> balancer
```

Connection flow now:

```mermaid
flowchart LR
client --> balancer --> monolith
```