### PR TITLE
balancer: fix monolith discovery not removing monoliths when told to

### DIFF
--- a/crates/harness-tests/src/main.rs
+++ b/crates/harness-tests/src/main.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use harness::{Monolith, TestRunner};
 use test_context::test_context;
 
@@ -9,9 +7,11 @@ async fn sample_test(ctx: &mut TestRunner) {
     let m = Monolith::new(ctx).await.unwrap();
     println!("monolith port: {}", m.port());
     assert_ne!(m.port(), 0);
-    m.show().await;
 
-    tokio::time::sleep(Duration::from_secs(30)).await;
+    for _ in 0..10 {
+        m.show().await;
+        m.hide().await;
+    }
 }
 
 fn main() {}

--- a/crates/harness-tests/src/main.rs
+++ b/crates/harness-tests/src/main.rs
@@ -4,13 +4,25 @@ use test_context::test_context;
 #[test_context(TestRunner)]
 #[tokio::test]
 async fn sample_test(ctx: &mut TestRunner) {
-    let m = Monolith::new(ctx).await.unwrap();
+    let mut m = Monolith::new(ctx).await.unwrap();
+    println!("monolith port: {}", m.port());
+    assert_ne!(m.port(), 0);
+    m.show().await;
+}
+
+/// Add and remove a monolith a bunch of times to make sure that monolith discovery works.
+#[test_context(TestRunner)]
+#[tokio::test]
+async fn discovery_add_remove(ctx: &mut TestRunner) {
+    let mut m = Monolith::new(ctx).await.unwrap();
     println!("monolith port: {}", m.port());
     assert_ne!(m.port(), 0);
 
     for _ in 0..10 {
         m.show().await;
+        assert!(m.connected());
         m.hide().await;
+        assert!(!m.connected());
     }
 }
 

--- a/crates/harness/src/monolith.rs
+++ b/crates/harness/src/monolith.rs
@@ -6,7 +6,7 @@ use std::{
 use futures_util::{SinkExt, StreamExt};
 use ott_balancer_protocol::monolith::*;
 use tokio::{net::TcpListener, sync::Notify};
-use tracing::{debug, trace, warn};
+use tracing::{warn};
 use tungstenite::Message;
 
 use crate::TestRunner;

--- a/crates/harness/src/monolith.rs
+++ b/crates/harness/src/monolith.rs
@@ -5,7 +5,7 @@ use std::{
 
 use futures_util::{SinkExt, StreamExt};
 use ott_balancer_protocol::monolith::*;
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, sync::Notify};
 use tungstenite::Message;
 
 use crate::TestRunner;
@@ -20,6 +20,9 @@ pub struct Monolith {
 
     monolith_add_tx: tokio::sync::mpsc::Sender<SocketAddr>,
     monolith_remove_tx: tokio::sync::mpsc::Sender<SocketAddr>,
+
+    notif_connect: Arc<Notify>,
+    notif_disconnect: Arc<Notify>,
 }
 
 impl Monolith {
@@ -28,11 +31,15 @@ impl Monolith {
         // for prototyping, using a fixed port.
         let listener =
             Arc::new(TcpListener::bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0)).await?);
+        let notif_connect = Arc::new(Notify::new());
+        let notif_disconnect = Arc::new(Notify::new());
 
         let (outgoing_tx, mut outgoing_rx) = tokio::sync::mpsc::channel(50);
         let (incoming_tx, incoming_rx) = tokio::sync::mpsc::channel(50);
 
         let _listener = listener.clone();
+        let _notif_connect = notif_connect.clone();
+        let _notif_disconnect = notif_disconnect.clone();
         let task = tokio::task::Builder::new()
             .name("emulated monolith")
             .spawn(async move {
@@ -42,17 +49,26 @@ impl Monolith {
                     let init = M2BInit { port: addr.port() };
                     let msg = serde_json::to_string(&MsgM2B::Init(init)).unwrap();
                     ws.send(Message::Text(msg)).await.unwrap();
+                    _notif_connect.notify_one();
                     loop {
+                        println!("monolith: waiting for message");
                         tokio::select! {
                             Some(msg) = outgoing_rx.recv() => {
                                 ws.send(msg).await.unwrap();
                             }
                             Some(msg) = ws.next() => {
-                                incoming_tx.send(msg.unwrap()).await.unwrap();
+                                match msg {
+                                    Ok(msg) => incoming_tx.send(msg).await.unwrap(),
+                                    Err(e) => {
+                                        println!("monolith: websocket error: {:?}", e);
+                                        break;
+                                    }
+                                }
                             }
                             else => break,
                         }
                     }
+                    _notif_disconnect.notify_one();
                 }
             })?;
 
@@ -64,6 +80,8 @@ impl Monolith {
             task,
             monolith_add_tx: ctx.monolith_add_tx.clone(),
             monolith_remove_tx: ctx.monolith_remove_tx.clone(),
+            notif_connect,
+            notif_disconnect,
         })
     }
 
@@ -77,6 +95,7 @@ impl Monolith {
             .send(self.listener.local_addr().unwrap())
             .await
             .unwrap();
+        self.notif_connect.notified().await;
     }
 
     /// Tell the provider to remove this monolith from the list of available monoliths.
@@ -85,6 +104,7 @@ impl Monolith {
             .send(self.listener.local_addr().unwrap())
             .await
             .unwrap();
+        self.notif_disconnect.notified().await;
     }
 
     pub async fn recv(&mut self) {

--- a/crates/harness/src/monolith.rs
+++ b/crates/harness/src/monolith.rs
@@ -6,7 +6,7 @@ use std::{
 use futures_util::{SinkExt, StreamExt};
 use ott_balancer_protocol::monolith::*;
 use tokio::{net::TcpListener, sync::Notify};
-use tracing::{warn};
+use tracing::warn;
 use tungstenite::Message;
 
 use crate::TestRunner;

--- a/crates/harness/src/test_runner.rs
+++ b/crates/harness/src/test_runner.rs
@@ -33,7 +33,14 @@ impl AsyncTestContext for TestRunner {
         }
 
         let child = Command::new("cargo")
-            .args(["run", "-p", "ott-balancer-bin", "--"])
+            .args([
+                "run",
+                "-p",
+                "ott-balancer-bin",
+                "--",
+                "--log-level",
+                "debug",
+            ])
             .env("BALANCER_PORT", format!("{}", port))
             .env(
                 "BALANCER_DISCOVERY",

--- a/crates/ott-balancer-bin/src/connection.rs
+++ b/crates/ott-balancer-bin/src/connection.rs
@@ -45,6 +45,7 @@ impl MonolithConnectionManager {
             .recv()
             .await
             .ok_or_else(|| anyhow::anyhow!("Discovery channel closed"))?;
+        debug!("Monolith discovery message: {:?}", msg);
         for m in &msg.removed {
             self.monoliths.remove(m);
             if let Some(active) = self.connection_tasks.remove(m) {

--- a/crates/ott-balancer-bin/src/discovery.rs
+++ b/crates/ott-balancer-bin/src/discovery.rs
@@ -139,8 +139,8 @@ fn build_discovery_msg(
     current: &HashSet<MonolithConnectionConfig>,
     new: &HashSet<MonolithConnectionConfig>,
 ) -> MonolithDiscoveryMsg {
-    let monoliths_added = new.difference(&current).cloned().collect::<Vec<_>>();
-    let monoliths_removed = current.difference(&new).cloned().collect::<Vec<_>>();
+    let monoliths_added = new.difference(current).cloned().collect::<Vec<_>>();
+    let monoliths_removed = current.difference(new).cloned().collect::<Vec<_>>();
     MonolithDiscoveryMsg {
         added: monoliths_added,
         removed: monoliths_removed,


### PR DESCRIPTION
- make it so that `show` and `hide` block until the balancer has connected/disconnected
- balancer: fix monolith discovery not removing monoliths when told to
