### PR TITLE
harness: add http mocking to emulated monoliths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "console-subscriber",
  "figment",
  "futures-util",
+ "http-body-util",
  "hyper 1.0.0-rc.4",
  "hyper-util",
  "ott-balancer-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ version = "0.1.0"
 dependencies = [
  "harness",
  "ott-balancer-protocol",
+ "reqwest",
  "test-context",
  "tokio",
 ]

--- a/crates/harness-tests/Cargo.toml
+++ b/crates/harness-tests/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 harness.workspace = true
 ott-balancer-protocol.workspace = true
+reqwest.workspace = true
 test-context.workspace = true
 tokio.workspace = true

--- a/crates/harness-tests/src/main.rs
+++ b/crates/harness-tests/src/main.rs
@@ -7,8 +7,7 @@ use test_context::test_context;
 #[test_context(TestRunner)]
 #[tokio::test]
 async fn sample_test(ctx: &mut TestRunner) {
-    let s = service_fn(hello);
-    let mut m = Monolith::new(ctx, s).await.unwrap();
+    let mut m = Monolith::new(ctx, service_fn(hello)).await.unwrap();
     println!("monolith port: {}", m.balancer_port());
     assert_ne!(m.balancer_port(), 0);
     m.show().await;
@@ -47,6 +46,24 @@ async fn discovery_add_remove(ctx: &mut TestRunner) {
         m.hide().await;
         assert!(!m.connected());
     }
+}
+
+#[test_context(TestRunner)]
+#[tokio::test]
+async fn sample_http(ctx: &mut TestRunner) {
+    let mut m = Monolith::new(ctx, service_fn(hello)).await.unwrap();
+    println!(
+        "monolith port: {} http: {}",
+        m.balancer_port(),
+        m.http_port()
+    );
+    m.show().await;
+
+    reqwest::get(format!("http://[::1]:{}/", m.http_port()))
+        .await
+        .expect("http request failed")
+        .error_for_status()
+        .expect("bad http status");
 }
 
 fn main() {}

--- a/crates/harness-tests/src/main.rs
+++ b/crates/harness-tests/src/main.rs
@@ -1,15 +1,16 @@
 use std::collections::HashMap;
 
-use harness::{Client, Monolith, TestRunner, WebsocketSender};
+use harness::{hello, service_fn, Client, Monolith, TestRunner, WebsocketSender};
 use ott_balancer_protocol::client::*;
 use test_context::test_context;
 
 #[test_context(TestRunner)]
 #[tokio::test]
 async fn sample_test(ctx: &mut TestRunner) {
-    let mut m = Monolith::new(ctx).await.unwrap();
-    println!("monolith port: {}", m.port());
-    assert_ne!(m.port(), 0);
+    let s = service_fn(hello);
+    let mut m = Monolith::new(ctx, s).await.unwrap();
+    println!("monolith port: {}", m.balancer_port());
+    assert_ne!(m.balancer_port(), 0);
     m.show().await;
 
     let mut c = Client::new(ctx).unwrap();
@@ -36,9 +37,9 @@ async fn sample_test(ctx: &mut TestRunner) {
 #[test_context(TestRunner)]
 #[tokio::test]
 async fn discovery_add_remove(ctx: &mut TestRunner) {
-    let mut m = Monolith::new(ctx).await.unwrap();
-    println!("monolith port: {}", m.port());
-    assert_ne!(m.port(), 0);
+    let mut m = Monolith::new(ctx, service_fn(hello)).await.unwrap();
+    println!("monolith port: {}", m.balancer_port());
+    assert_ne!(m.balancer_port(), 0);
 
     for _ in 0..10 {
         m.show().await;

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -13,6 +13,7 @@ figment.workspace = true
 futures-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
+http-body-util.workspace = true
 ott-balancer-protocol.workspace = true
 reqwest.workspace = true
 rand.workspace = true

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -9,3 +9,5 @@ pub use client::*;
 pub use monolith::*;
 pub use test_runner::*;
 pub use traits::*;
+
+pub use hyper::service::*;


### PR DESCRIPTION
- harness: add http server to emulated monoliths
- fix sending wrong port in M2BInit
- add another sample test that makes an http request to the monolith

closes #1085
