### PR TITLE
attempt to make `route_ws_to_correct_monolith_race` less flaky

### DIFF
--- a/crates/harness/src/client.rs
+++ b/crates/harness/src/client.rs
@@ -80,6 +80,15 @@ impl Client {
         let _ = stream.close(None).await;
     }
 
+    pub async fn wait_for_disconnect(&mut self) {
+        if !self.connected() {
+            return;
+        }
+
+        let mut stream = self.stream.take().unwrap();
+        while let Some(_) = stream.next().await {}
+    }
+
     pub async fn recv(&mut self) -> anyhow::Result<Message> {
         if let Some(stream) = self.stream.as_mut() {
             match tokio::time::timeout(Duration::from_millis(200), stream.next()).await {

--- a/crates/harness/src/client.rs
+++ b/crates/harness/src/client.rs
@@ -86,7 +86,7 @@ impl Client {
         }
 
         let mut stream = self.stream.take().unwrap();
-        while let Some(_) = stream.next().await {}
+        while stream.next().await.is_some() {}
     }
 
     pub async fn recv(&mut self) -> anyhow::Result<Message> {


### PR DESCRIPTION
closes #1101
