### PR TITLE
fix join race again

### DIFF
--- a/crates/harness-tests/src/routing.rs
+++ b/crates/harness-tests/src/routing.rs
@@ -127,7 +127,7 @@ async fn route_ws_to_correct_monolith_race(ctx: &mut TestRunner) {
     m.show().await;
     tokio::time::sleep(Duration::from_millis(200)).await; // ensure that the monoliths are fully connected before sending the room load message
 
-    for i in 0..20 {
+    for i in 0..100 {
         let room_name = format!("foo{}", i);
         m.load_room(room_name.clone()).await;
 
@@ -154,8 +154,6 @@ async fn route_ws_to_correct_monolith_race(ctx: &mut TestRunner) {
         assert_eq!(recvd.len(), 1);
         m.clear_recv();
         dummy.clear_recv();
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
 

--- a/crates/ott-balancer-bin/src/balancer.rs
+++ b/crates/ott-balancer-bin/src/balancer.rs
@@ -13,7 +13,6 @@ use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, trace, warn};
 
-
 use crate::room::RoomLocator;
 use crate::{
     client::{BalancerClient, NewClient},

--- a/crates/ott-balancer-bin/src/balancer.rs
+++ b/crates/ott-balancer-bin/src/balancer.rs
@@ -13,7 +13,7 @@ use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::monolith::Room;
+
 use crate::room::RoomLocator;
 use crate::{
     client::{BalancerClient, NewClient},

--- a/crates/ott-balancer-bin/src/balancer.rs
+++ b/crates/ott-balancer-bin/src/balancer.rs
@@ -297,17 +297,6 @@ impl BalancerContext {
         Ok(())
     }
 
-    pub fn add_room(&mut self, room: Room, locator: RoomLocator) -> anyhow::Result<()> {
-        debug!("add_room {} {:?}", room.name(), locator);
-        let monolith = self
-            .monoliths
-            .get_mut(&locator.monolith_id())
-            .ok_or(anyhow::anyhow!("monolith not found"))?;
-        self.rooms_to_monoliths.insert(room.name().clone(), locator);
-        monolith.add_room(room);
-        Ok(())
-    }
-
     pub async fn remove_room(
         &mut self,
         room: &RoomName,


### PR DESCRIPTION
- add load_notifiers
- possibly make it work better?
- keep load notifiers around after the room has loaded to prevent rugpulling state
- fix rare join race in multithreaded runtime
- adjust iterations for `route_ws_to_correct_monolith_race`

closes #1101 again, hopefully for the last time
