### PR TITLE
fix room migrations

### DIFF
--- a/common/models/types.ts
+++ b/common/models/types.ts
@@ -22,6 +22,7 @@ export enum BehaviorOption {
 }
 
 export enum OttWebsocketError {
+	AWAY = 1001,
 	UNKNOWN = 4000,
 	INVALID_CONNECTION_URL = 4001,
 	ROOM_NOT_FOUND = 4002,

--- a/crates/ott-balancer/src/balancer.rs
+++ b/crates/ott-balancer/src/balancer.rs
@@ -505,21 +505,16 @@ pub async fn join_monolith(
     tokio::task::Builder::new()
         .name(format!("monolith {}", monolith_id).as_ref())
         .spawn(async move {
-            loop {
-                if let Some(msg) = client_inbound_rx.recv().await {
-                    if let Err(e) =
-                        handle_client_inbound(ctx.clone(), msg, monolith_outbound_tx.clone()).await
-                    {
-                        error!("failed to handle client inbound: {:?}", e);
-                        if monolith_outbound_tx.is_closed() {
-                            // the monolith has disconnected
-                            info!("monolith disconnected, stopping client inbound handler");
-                            break;
-                        }
+            while let Some(msg) = client_inbound_rx.recv().await {
+                if let Err(e) =
+                    handle_client_inbound(ctx.clone(), msg, monolith_outbound_tx.clone()).await
+                {
+                    error!("failed to handle client inbound: {:?}", e);
+                    if monolith_outbound_tx.is_closed() {
+                        // the monolith has disconnected
+                        info!("monolith disconnected, stopping client inbound handler");
+                        break;
                     }
-                } else {
-                    // at this point, the monolith has disconnected
-                    break;
                 }
             }
         })?;

--- a/crates/ott-balancer/src/balancer.rs
+++ b/crates/ott-balancer/src/balancer.rs
@@ -241,10 +241,10 @@ impl BalancerContext {
 
         for client in self.clients.values() {
             match client
-                .send(SocketMessage::Message(Message::Close(Some(CloseFrame {
+                .send(Message::Close(Some(CloseFrame {
                     code: CloseCode::Away,
                     reason: "Monolith disconnect".into(),
-                }))))
+                })))
                 .await
             {
                 Ok(()) => {}

--- a/crates/ott-balancer/src/balancer.rs
+++ b/crates/ott-balancer/src/balancer.rs
@@ -556,26 +556,6 @@ pub async fn leave_monolith(
 ) -> anyhow::Result<()> {
     info!("monolith left");
     let mut ctx_write = ctx.write().await;
-    let rooms = ctx_write
-        .monoliths
-        .get(&id)
-        .unwrap()
-        .rooms()
-        .values()
-        .collect::<Vec<_>>();
-    for room in rooms {
-        for client in room.clients().iter() {
-            ctx_write
-                .clients
-                .get(client)
-                .unwrap()
-                .send(Message::Close(Some(CloseFrame {
-                    code: CloseCode::Library(4003),
-                    reason: "Monolith disconnect".into(),
-                })))
-                .await?;
-        }
-    }
     ctx_write.remove_monolith(id).await?;
     Ok(())
 }

--- a/crates/ott-balancer/src/balancer.rs
+++ b/crates/ott-balancer/src/balancer.rs
@@ -511,6 +511,11 @@ pub async fn join_monolith(
                         handle_client_inbound(ctx.clone(), msg, monolith_outbound_tx.clone()).await
                     {
                         error!("failed to handle client inbound: {:?}", e);
+                        if monolith_outbound_tx.is_closed() {
+                            // the monolith has disconnected
+                            info!("monolith disconnected, stopping client inbound handler");
+                            break;
+                        }
                     }
                 } else {
                     // at this point, the monolith has disconnected

--- a/crates/ott-balancer/src/connection.rs
+++ b/crates/ott-balancer/src/connection.rs
@@ -198,8 +198,8 @@ async fn connect_and_maintain(
                             stream = s;
                             reconnect_attempts = 0;
                         } else {
-                            warn!("Failed to soft reconnect to monolith: {} monolith {}", conf.uri(), monolith_id);
                             reconnect_attempts += 1;
+                            warn!("Failed to soft reconnect to monolith: {} monolith {} (attempt {}/3)", conf.uri(), monolith_id, reconnect_attempts);
                             if reconnect_attempts > 2 {
                                 // we need to notify the balancer that this monolith is dead
                                 // because otherwise the room won't get reallocated to another monolith

--- a/server/app.ts
+++ b/server/app.ts
@@ -62,6 +62,9 @@ export async function main() {
 		setupPostgresMetricsCollection(sequelize);
 	}
 
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+
 	app.use(metricsMiddleware);
 	const server = http.createServer(app);
 	async function checkRedis() {
@@ -222,6 +225,13 @@ export async function main() {
 	return {
 		app,
 	};
+}
+
+function shutdown() {
+	// The order here is important. We want to get all the clients disconnected first, so they don't get the room unloaded message when all the rooms get unloaded.
+	clientmanager.shutdown();
+	roommanager.shutdown();
+	process.exit(0);
 }
 
 main();

--- a/server/clientmanager.ts
+++ b/server/clientmanager.ts
@@ -61,12 +61,9 @@ export async function setup(): Promise<void> {
 		log.silly("subscribing to announcement channel");
 		await redisSubscriber.subscribe(ANNOUNCEMENT_CHANNEL, onAnnouncement);
 	}
-
-	process.on("SIGINT", shutdown);
-	process.on("SIGTERM", shutdown);
 }
 
-function shutdown() {
+export function shutdown() {
 	log.info("Shutting down client manager");
 	for (const client of connections) {
 		client.kick(OttWebsocketError.AWAY);
@@ -496,6 +493,7 @@ const gaugeClients = new Gauge({
 
 export default {
 	setup,
+	shutdown,
 	onUserModified,
 	getClientByToken,
 	makeRoomRequest,

--- a/server/clientmanager.ts
+++ b/server/clientmanager.ts
@@ -61,6 +61,16 @@ export async function setup(): Promise<void> {
 		log.silly("subscribing to announcement channel");
 		await redisSubscriber.subscribe(ANNOUNCEMENT_CHANNEL, onAnnouncement);
 	}
+
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+}
+
+function shutdown() {
+	log.info("Shutting down client manager");
+	for (const client of connections) {
+		client.kick(OttWebsocketError.AWAY);
+	}
 }
 
 /**

--- a/server/roommanager.ts
+++ b/server/roommanager.ts
@@ -48,11 +48,9 @@ export async function start() {
 	log.info("Starting room manager");
 
 	updaterInterval = setInterval(update, 1000);
-	process.on("SIGINT", shutdown);
-	process.on("SIGTERM", shutdown);
 }
 
-async function shutdown() {
+export async function shutdown() {
 	log.info("Shutting down room manager");
 	if (updaterInterval) {
 		clearInterval(updaterInterval);
@@ -270,6 +268,7 @@ const roommanager = {
 	rooms,
 	log,
 	start,
+	shutdown,
 
 	createRoom,
 	getRoom,


### PR DESCRIPTION
closes #1204

- fix a possible panic
- improve log message
- clientmanager: manually kick all clients on shutdown
- remove sleeps from soft reconnects because they introduced too much complexity
- remove some duplicated code
- minor refactor
- have client inbound task end when outbound tx is closed
- make it so that the client manager is guarenteed to shut down first
