### PR TITLE
add config option `users.enable_registration` to allow admins to disable creating user accounts

### DIFF
--- a/server/ott-config.ts
+++ b/server/ott-config.ts
@@ -434,6 +434,13 @@ export const conf = convict({
 			default: 2 * 3600, // 2 hours
 		},
 	},
+	users: {
+		enable_registration: {
+			doc: "Whether to allow user account registration.",
+			format: Boolean,
+			default: true,
+		},
+	},
 });
 
 function getExtraBaseConfig(): string | undefined {

--- a/server/tests/unit/usermanager.spec.ts
+++ b/server/tests/unit/usermanager.spec.ts
@@ -1,6 +1,12 @@
 import usermanager from "../../usermanager";
+import { conf } from "../../../server/ott-config";
+import { FeatureDisabledException } from "../../exceptions";
 
 describe("Usermanager spec", () => {
+	beforeEach(() => {
+		conf.set("users.enable_registration", true);
+	});
+
 	it("should check passwords correctly", () => {
 		expect(usermanager.isPasswordValid("aaaa1234")).toBe(true);
 		expect(usermanager.isPasswordValid("AAAA1111")).toBe(true);
@@ -15,5 +21,16 @@ describe("Usermanager spec", () => {
 		expect(usermanager.isPasswordValid("AAAAAAAAAAAAAA")).toBe(false);
 		expect(usermanager.isPasswordValid("$$$$$$$$$$$$$$")).toBe(false);
 		expect(usermanager.isPasswordValid("11111111111111")).toBe(false);
+	});
+
+	it("should not register social user when registration is disabled", () => {
+		conf.set("users.enable_registration", false);
+
+		expect(
+			usermanager.registerUserSocial({
+				username: "foo",
+				discordId: "123456789",
+			})
+		).rejects.toThrow(FeatureDisabledException);
 	});
 });

--- a/server/usermanager.ts
+++ b/server/usermanager.ts
@@ -584,6 +584,9 @@ function passportErrorHandler(err, req: express.Request, res: express.Response, 
 }
 
 async function registerUser({ email, username, password }): Promise<User> {
+	if (!conf.get("users.enable_registration")) {
+		throw new FeatureDisabledException("Disabled by administrator.");
+	}
 	if (!isPasswordValid(password)) {
 		throw new BadPasswordError();
 	}
@@ -624,6 +627,9 @@ async function registerUser({ email, username, password }): Promise<User> {
 }
 
 async function registerUserSocial({ username, discordId }): Promise<User> {
+	if (!conf.get("users.enable_registration")) {
+		throw new FeatureDisabledException("Disabled by administrator.");
+	}
 	return await UserModel.create({
 		discordId,
 		username,

--- a/server/usermanager.ts
+++ b/server/usermanager.ts
@@ -350,6 +350,12 @@ router.post("/register", async (req, res) => {
 					},
 				});
 				return;
+			} else if (err.name === "FeatureDisabledException") {
+				res.status(403).json({
+					success: false,
+					error: err,
+				});
+				return;
 			} else if (err.name === "UsernameTakenError") {
 				res.status(400).json({
 					success: false,


### PR DESCRIPTION
closes #1145
