### PR TITLE
add must_use directive to `TestRunner::url` and allow scheme to be specified

### DIFF
--- a/crates/harness-tests/src/main.rs
+++ b/crates/harness-tests/src/main.rs
@@ -63,7 +63,7 @@ async fn sample_http(ctx: &mut TestRunner) {
     );
     m.show().await;
 
-    reqwest::get(ctx.url("/"))
+    reqwest::get(ctx.http_url("/"))
         .await
         .expect("http request failed")
         .error_for_status()

--- a/crates/harness-tests/src/routing.rs
+++ b/crates/harness-tests/src/routing.rs
@@ -30,7 +30,7 @@ async fn route_http_to_correct_monolith(ctx: &mut TestRunner) {
     // Since the purpose of this test is to test routing, we can just wait a bit for the balancer to acknowledge the room load.
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    reqwest::get(ctx.url("/api/room/foo"))
+    reqwest::get(ctx.http_url("/api/room/foo"))
         .await
         .expect("http request failed")
         .error_for_status()
@@ -58,7 +58,7 @@ async fn route_http_to_any_monolith_once(ctx: &mut TestRunner) {
     let mut m2 = Monolith::new(ctx).await.unwrap();
     m2.show().await;
 
-    reqwest::get(ctx.url("/api/user"))
+    reqwest::get(ctx.http_url("/api/user"))
         .await
         .expect("http request failed")
         .error_for_status()
@@ -84,7 +84,7 @@ async fn route_http_room_list(ctx: &mut TestRunner) {
     let mut m2 = Monolith::new(ctx).await.unwrap();
     m2.show().await;
 
-    reqwest::get(ctx.url("/api/room/list"))
+    reqwest::get(ctx.http_url("/api/room/list"))
         .await
         .expect("http request failed")
         .error_for_status()
@@ -207,7 +207,7 @@ async fn monolith_double_load_room(ctx: &mut TestRunner) {
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let resp = reqwest::get(ctx.url("/api/room/foo"))
+    let resp = reqwest::get(ctx.http_url("/api/room/foo"))
         .await
         .expect("http request failed")
         .error_for_status()
@@ -286,7 +286,7 @@ async fn should_prioritize_same_region_http(ctx: &mut TestRunner) {
 
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    reqwest::get(ctx.url("/api/foo"))
+    reqwest::get(ctx.http_url("/api/foo"))
         .await
         .expect("http request failed");
 

--- a/crates/harness/src/test_runner.rs
+++ b/crates/harness/src/test_runner.rs
@@ -147,12 +147,19 @@ impl TestRunner {
         Ok(child)
     }
 
-    /// Create a URL that points to the balancer. This creates URLs that clients should connect to when making HTTP requests.
-    pub fn url(&self, path: impl AsRef<str>) -> reqwest::Url {
+    /// Create a URL that points to the balancer.
+    #[must_use]
+    pub fn url(&self, scheme: impl AsRef<str>, path: impl AsRef<str>) -> reqwest::Url {
         let path = path.as_ref();
         assert!(path.starts_with('/'), "path must start with '/'");
-        let built = format!("http://[::1]:{}{}", self.port(), path);
+        let built = format!("{}://[::1]:{}{}", scheme.as_ref(), self.port(), path);
         reqwest::Url::parse(&built).expect("failed to parse URL")
+    }
+
+    /// Create a URL that points to the balancer. This creates URLs that clients should connect to when making HTTP requests.
+    #[must_use]
+    pub fn http_url(&self, path: impl AsRef<str>) -> reqwest::Url {
+        self.url("http", path)
     }
 }
 

--- a/crates/harness/src/test_runner.rs
+++ b/crates/harness/src/test_runner.rs
@@ -147,7 +147,18 @@ impl TestRunner {
         Ok(child)
     }
 
-    /// Create a URL that points to the balancer.
+    /// Create a URL that points to the balancer. This creates URLs that clients should use when connecting to the balancer or making HTTP requests.
+    ///
+    /// ```no_run
+    /// # use test_context::test_context;
+    /// # use harness::TestRunner;
+    ///
+    /// # #[test_context(TestRunner)]
+    /// # #[tokio::test]
+    /// # async fn sample_test(ctx: &mut TestRunner) {
+    /// let client = tokio_tungstenite::connect_async(ctx.url("ws", "/api/room/test")).await.expect("failed to connect");
+    /// # }
+    /// ````
     #[must_use]
     pub fn url(&self, scheme: impl AsRef<str>, path: impl AsRef<str>) -> reqwest::Url {
         let path = path.as_ref();
@@ -157,6 +168,16 @@ impl TestRunner {
     }
 
     /// Create a URL that points to the balancer. This creates URLs that clients should connect to when making HTTP requests.
+    ///
+    /// ```no_run
+    /// # use test_context::test_context;
+    /// # use harness::TestRunner;
+    /// # #[test_context(TestRunner)]
+    /// # #[tokio::test]
+    /// # async fn sample_test(ctx: &mut TestRunner) {
+    /// reqwest::get(ctx.http_url("/api/status")).await.expect("http request failed");
+    /// }
+    /// ````
     #[must_use]
     pub fn http_url(&self, path: impl AsRef<str>) -> reqwest::Url {
         self.url("http", path)


### PR DESCRIPTION
Allows customizing the scheme of `ctx.url()`, adds examples to the doc comments, and adds `must_use` directive for better lints

cc @cjrkoa 