### PR TITLE
client: show playback errors in the UI

### DIFF
--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -19,6 +19,23 @@
 					</div>
 				</v-container>
 			</v-sheet>
+			<v-sheet color="error" v-if="playbackError !== undefined">
+				<v-container fluid style="padding: 6px">
+					<div style="display: flex; align-items: center">
+						<v-icon>mdi:alert-circle</v-icon>
+						<span>{{ playbackError.message }}</span>
+						<v-spacer />
+						<v-btn
+							size="x-small"
+							variant="text"
+							icon
+							@click="playbackError = undefined"
+						>
+							<v-icon>fa:fas fa-times</v-icon>
+						</v-btn>
+					</div>
+				</v-container>
+			</v-sheet>
 		</div>
 
 		<Suspense>
@@ -355,6 +372,7 @@ export default defineComponent({
 		function onPlaying() {
 			hackReadyEdgeCase();
 			emit("playing");
+			playbackError.value = undefined;
 		}
 
 		function onPaused() {
@@ -367,9 +385,12 @@ export default defineComponent({
 			emit("buffering");
 		}
 
-		function onError() {
+		const playbackError: Ref<MediaError | undefined> = ref(undefined);
+
+		function onError(event: any) {
 			store.commit("PLAYBACK_STATUS", PlayerStatus.error);
 			emit("error");
+			playbackError.value = event.explicitOriginalTarget?.error as MediaError;
 		}
 
 		function onBufferProgress(percent: number) {
@@ -424,6 +445,7 @@ export default defineComponent({
 			isPlayerPresent,
 			showBufferWarning,
 			renderedSpans,
+			playbackError,
 			play,
 			pause,
 			setVolume,

--- a/client/src/components/players/PlyrPlayer.vue
+++ b/client/src/components/players/PlyrPlayer.vue
@@ -187,7 +187,7 @@ export default defineComponent({
 				emit("buffer-progress", player.value.buffered);
 			});
 			player.value.on("error", err => {
-				emit("error");
+				emit("error", err);
 				console.error("PlyrPlayer: error:", err);
 			});
 


### PR DESCRIPTION
Currently, this doesn't show any error when the server responds with a failure. Strangely, the video element does not raise the `error` event when this occurs, nor does it set the `error` field on the element.