### PR TITLE
Bump alpine to 3.19

### DIFF
--- a/deploy/monolith.Dockerfile
+++ b/deploy/monolith.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.16 as build-stage
+FROM node:18-alpine3.19 as build-stage
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
 
@@ -11,7 +11,7 @@ RUN yarn run build
 
 RUN rm -rf node_modules && yarn install --production=true
 
-FROM node:18-alpine3.16 as production-stage
+FROM node:18-alpine3.19 as production-stage
 ARG DEPLOY_TARGET
 
 WORKDIR /usr/app/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.16 as build-stage
+FROM node:18-alpine3.19 as build-stage
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
 
@@ -11,7 +11,7 @@ RUN yarn run build
 
 RUN rm -rf node_modules && yarn install --production=true
 
-FROM node:18-alpine3.16 as production-stage
+FROM node:18-alpine3.19 as production-stage
 
 WORKDIR /usr/app/
 


### PR DESCRIPTION
This PR updates Alpine to version 3.19 which includes fixes for 10 vulnerabilities (8 Medium-level vulnerabilities and 2 Unknown ones).
I will send @dyc3 an email with a screenshot of affected packages and CVE numbers.

Please look in your spam folder too, google flags some of my mails...