### PR TITLE
fix ott-common import woes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,7 @@
     "hls.js": "1.4.8",
     "load-script": "^1.0.0",
     "material-design-icons-iconfont": "^5.0.1",
-    "ott-common": "./common",
+    "ott-common": "*",
     "plyr": "3.7.8",
     "sortablejs": "^1.15.0",
     "sortablejs-vue3": "^1.2.3",
@@ -49,7 +49,7 @@
     "jsdom": "^21.1.0",
     "sass": "^1.41.1",
     "vite": "^5.0.12",
-    "vite-plugin-vuetify": "1.0.2",
+    "vite-plugin-vuetify": "2.0.1",
     "vitest": "^0.25.1"
   }
 }

--- a/client/src/components/VoteSkip.vue
+++ b/client/src/components/VoteSkip.vue
@@ -16,25 +16,9 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 import { useStore } from "@/store";
-// import { voteSkipThreshold, countEligibleVoters } from "ott-common/voteskip";
-import type { RoomUserInfo } from "ott-common/models/types";
-import { Grants } from "ott-common/permissions";
+import { voteSkipThreshold, countEligibleVoters } from "ott-common/voteskip";
 
 const store = useStore();
-
-// FIXME: fix the import
-function voteSkipThreshold(users: number): number {
-	return Math.ceil(users * 0.5);
-}
-function countEligibleVoters(users: RoomUserInfo[], grants: Grants): number {
-	let count = 0;
-	for (const user of users) {
-		if (grants.granted(user.role, "playback.skip")) {
-			count++;
-		}
-	}
-	return count;
-}
 
 const votesRemaining = computed(() => {
 	const users = Array.from(store.state.users.users.values());

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
     "nocache": "^3.0.0",
     "node-abort-controller": "3.0.1",
     "node-mailjet": "^6.0.3",
-    "ott-common": "./common",
+    "ott-common": "*",
     "passport": "0.6.0",
     "passport-discord": "^0.1.4",
     "passport-google": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4908,12 +4908,11 @@
   resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.2.1.tgz#c16061e081e0f1d3d5a126b79ae93d2abb6d2c17"
   integrity sha512-AkLt24wnnxedJ3NX090JYiueog184QqlR5TVNZM+lggCrK8XjeuPr274okaLqDmiRgp4XVCaGa07KqKLGQbsMQ==
 
-"@vuetify/loader-shared@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@vuetify/loader-shared/-/loader-shared-1.7.1.tgz#0f63a3d41b6df29a2db1ff438aa1819b237c37a3"
-  integrity sha512-kLUvuAed6RCvkeeTNJzuy14pqnkur8lTuner7v7pNE/kVhPR97TuyXwBSBMR1cJeiLiOfu6SF5XlCYbXByEx1g==
+"@vuetify/loader-shared@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@vuetify/loader-shared/-/loader-shared-2.0.1.tgz#4bb50ce6455b1c37958a58a63cc32e4ae6829287"
+  integrity sha512-zy5/ohEO7RcJaWYu2Xiy8TBEOkTb42XvWvSAJwXAtY8OlwqyGhzzBp9OvMVjLGIuFXumBpXKlsaVIkeN0OWWSw==
   dependencies:
-    find-cache-dir "^3.3.2"
     upath "^2.0.1"
 
 "@vueuse/core@^9.6.0":
@@ -12042,9 +12041,6 @@ ospath@^1.2.2:
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==
 
-ott-common@./common:
-  version "0.9.0"
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -15519,12 +15515,12 @@ videojs-vtt.js@^0.15.4:
   dependencies:
     global "^4.3.1"
 
-vite-plugin-vuetify@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/vite-plugin-vuetify/-/vite-plugin-vuetify-1.0.2.tgz#d1777c63aa1b3a308756461b3d0299fd101ee8f4"
-  integrity sha512-MubIcKD33O8wtgQXlbEXE7ccTEpHZ8nPpe77y9Wy3my2MWw/PgehP9VqTp92BLqr0R1dSL970Lynvisx3UxBFw==
+vite-plugin-vuetify@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-vuetify/-/vite-plugin-vuetify-2.0.1.tgz#172ffb6c46fec469fa96b3df03fd11b90d48f5d6"
+  integrity sha512-GlRVAruohE8b0FqmeYYh1cYg3n8THGOv066uMA44qLv9uhUxSLw55CS7fi2yU0wH363TJ2vq36zUsPTjRFrjGQ==
   dependencies:
-    "@vuetify/loader-shared" "^1.7.1"
+    "@vuetify/loader-shared" "^2.0.1"
     debug "^4.3.3"
     upath "^2.0.1"
 


### PR DESCRIPTION
fixes #1309 

The fix here was that if you specify a package by path, it will make a copy of it in a node_modules folder. Setting it to `*` instead lets it search the workspaces for the package.