### PR TITLE
fix `start-lean`

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -2,8 +2,28 @@
   "name": "ott-common",
   "version": "0.10.0",
   "license": "AGPL-3.0-or-later",
-  "module": "es2020",
   "type": "module",
+  "main": "ts-out/index.js",
+  "module": "ts-out/index.js",
+  "files": [
+    "ts-out/"
+  ],
+  "exports": {
+    ".": "./ts-out/index.js",
+    "./constants": "./ts-out/constants.js",
+    "./exceptions": "./ts-out/exceptions.js",
+    "./models/messages": "./ts-out/models/messages.js",
+    "./models/rest-api": "./ts-out/models/rest-api.js",
+    "./models/types": "./ts-out/models/types.js",
+    "./models/video": "./ts-out/models/video.js",
+    "./permissions": "./ts-out/permissions.js",
+    "./queueexport": "./ts-out/queueexport.js",
+    "./result": "./ts-out/result.js",
+    "./serialize": "./ts-out/serialize.js",
+    "./timestamp": "./ts-out/timestamp.js",
+    "./userutils": "./ts-out/userutils.js",
+    "./voteskip": "./ts-out/voteskip.js"
+  },
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit && eslint --ext .js,.ts --fix .",

--- a/deploy/monolith.Dockerfile
+++ b/deploy/monolith.Dockerfile
@@ -32,4 +32,4 @@ COPY deploy/$DEPLOY_TARGET.toml /usr/app/env/production.toml
 HEALTHCHECK --interval=30s --timeout=3s CMD ( curl -f http://localhost:8080/api/status || exit 1 )
 
 # Start Server
-CMD ["yarn", "workspace", "ott-server", "run", "start"]
+CMD ["yarn", "workspace", "ott-server", "run", "start-lean"]


### PR DESCRIPTION
fixes #1372 by more correctly defining `ott-common` so that it builds into a package that node is expecting
