### PR TITLE
Improve type checks for sync message serialization and add support for serializing bigint

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -1,2 +1,4 @@
+export * from "./constants";
+export * from "./models/index";
 export * from "./result";
 export * from "./voteskip";

--- a/common/models/index.ts
+++ b/common/models/index.ts
@@ -1,0 +1,4 @@
+export * from "./messages";
+export * from "./rest-api";
+export * from "./types";
+export * from "./video";

--- a/common/models/messages.ts
+++ b/common/models/messages.ts
@@ -1,3 +1,4 @@
+import type { Category, Segment } from "sponsorblock-api";
 import {
 	ClientId,
 	ClientInfo,
@@ -9,6 +10,7 @@ import {
 	RoomEventContext,
 	RoomSettings,
 	AuthToken,
+	BehaviorOption,
 } from "./types";
 import { QueueItem, VideoId } from "./video";
 
@@ -38,14 +40,18 @@ export interface ServerMessageSync extends ServerMessageBase {
 	queueMode?: QueueMode;
 	isPlaying?: boolean;
 	playbackPosition?: number;
-	currentSource?: QueueItem;
+	currentSource?: QueueItem | null;
+	queue?: QueueItem[];
+	prevQueue?: QueueItem[] | null;
 	grants?: [Role, number][];
 	playbackSpeed?: number;
 	voteCounts?: [string, number][];
 	hasOwner?: boolean;
 	enableVoteSkip?: boolean;
 	votesToSkip?: string[];
-	videoSegments?: unknown[];
+	autoSkipSegmentCategories?: Category[];
+	videoSegments?: Segment[];
+	restoreQueueBehavior?: BehaviorOption;
 }
 
 /**

--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -20,9 +20,7 @@ export interface VideoMetadata {
 
 export type Video = VideoId & Partial<VideoMetadata>;
 
-export interface QueueItemExtras {
+export interface QueueItem extends Video {
 	startAt?: number;
 	endAt?: number;
 }
-
-export type QueueItem = Video & QueueItemExtras;

--- a/common/serialize.ts
+++ b/common/serialize.ts
@@ -14,12 +14,30 @@ export function deserializeSet<T>(set: T[]): Set<T> {
 	return new Set(set);
 }
 
-export function replacer(key, value) {
+export function replacer<T>(key, value: T): ConvertToJsonSafe<T> {
 	if (value instanceof Map) {
-		return serializeMap(value);
+		return serializeMap(value) as ConvertToJsonSafe<T>;
 	} else if (value instanceof Set) {
-		return serializeSet(value);
+		return serializeSet(value) as ConvertToJsonSafe<T>;
+	} else if (typeof value === "bigint") {
+		return value.toString() as ConvertToJsonSafe<T>;
 	} else {
-		return value;
+		return value as ConvertToJsonSafe<T>;
 	}
 }
+
+export type ConvertToJsonSafe<T> = T extends Map<infer K, infer V>
+	? [ConvertToJsonSafe<K>, ConvertToJsonSafe<V>][]
+	: T extends Set<infer U>
+	? ConvertToJsonSafe<U>[]
+	: T extends bigint
+	? string
+	: T extends null | undefined | string | number | boolean
+	? T
+	: T extends { toJSON(): infer R }
+	? R
+	: T extends object
+	? {
+			[P in keyof T]: T[P] extends ConvertToJsonSafe<T[P]> ? T[P] : ConvertToJsonSafe<T[P]>;
+	  }
+	: T;

--- a/common/tests/unit/permissions.spec.ts
+++ b/common/tests/unit/permissions.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { PermissionDeniedException } from "../../exceptions";
-import { Role } from "../../models/types";
+import { Role } from "../..";
 import permissions, { Grants, GrantMask } from "../../permissions";
 
 describe("Permission System", () => {

--- a/common/tests/unit/serialize.spec-d.ts
+++ b/common/tests/unit/serialize.spec-d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable vitest/expect-expect */
 import { assertType, expectTypeOf, describe, it } from "vitest";
-import { ConvertToJsonSafe } from "../../serialize.js";
-import { QueueItem } from "models/video.js";
+import type { ConvertToJsonSafe } from "../../serialize.js";
+import type { QueueItem } from "../../models/video.js";
 
 describe("serialize helper types", () => {
 	it("should convert types to a type that is actually json serializable", () => {

--- a/common/tests/unit/serialize.spec.ts
+++ b/common/tests/unit/serialize.spec.ts
@@ -4,21 +4,27 @@ import { deserializeMap, deserializeSet, replacer } from "../../serialize";
 describe("Serialize helpers", () => {
 	describe("JSON with replacer round trips", () => {
 		it("should de/serialize maps", () => {
-			const map = new Map();
-			map.set("a", 1);
-			map.set("b", 2);
+			const map = new Map([
+				["a", 1],
+				["b", 2],
+			]);
 			const serialized = JSON.stringify(map, replacer);
 			const map2 = deserializeMap(JSON.parse(serialized));
 			expect(map2).toEqual(map);
 		});
 
 		it("should de/serialize sets", () => {
-			const set = new Set();
-			set.add(1);
-			set.add(2);
+			const set = new Set([1, 2]);
 			const serialized = JSON.stringify(set, replacer);
 			const set2 = deserializeSet(JSON.parse(serialized));
 			expect(set2).toEqual(set);
+		});
+
+		it("should handle BigInts", () => {
+			const bigInt = 123n;
+			const serialized = JSON.stringify(bigInt, replacer);
+			const bigInt2 = JSON.parse(serialized);
+			expect(bigInt2).toEqual("123");
 		});
 	});
 });

--- a/common/tests/unit/serialize.test-d.ts
+++ b/common/tests/unit/serialize.test-d.ts
@@ -1,0 +1,88 @@
+/* eslint-disable vitest/expect-expect */
+import { assertType, expectTypeOf, describe, it } from "vitest";
+import { ConvertToJsonSafe } from "../../serialize.js";
+import { QueueItem } from "models/video.js";
+
+describe("serialize helper types", () => {
+	it("should convert types to a type that is actually json serializable", () => {
+		expectTypeOf<ConvertToJsonSafe<Map<string, number>>>().toEqualTypeOf<[string, number][]>();
+		expectTypeOf<ConvertToJsonSafe<Set<string>>>().toEqualTypeOf<string[]>();
+		expectTypeOf<ConvertToJsonSafe<bigint>>().toEqualTypeOf<string>();
+	});
+
+	it("should not convert other primative types", () => {
+		expectTypeOf<ConvertToJsonSafe<number>>().toEqualTypeOf<number>();
+		expectTypeOf<ConvertToJsonSafe<string>>().toEqualTypeOf<string>();
+		expectTypeOf<ConvertToJsonSafe<boolean>>().toEqualTypeOf<boolean>();
+		expectTypeOf<ConvertToJsonSafe<null>>().toEqualTypeOf<null>();
+	});
+
+	it("should not convert arrays of primatives", () => {
+		expectTypeOf<ConvertToJsonSafe<number[]>>().toEqualTypeOf<number[]>();
+	});
+
+	it("should convert maps recursively", () => {
+		expectTypeOf<ConvertToJsonSafe<Map<string, Map<string, number>>>>().toEqualTypeOf<
+			[string, [string, number][]][]
+		>();
+	});
+
+	it("should convert arbitrary objects recursively", () => {
+		type Foo = {
+			bar: Bar;
+			baz: number;
+			qux: Map<string, Set<number>>;
+		};
+		type Bar = {
+			qur: Map<string, number>;
+		};
+
+		type FooSafe = {
+			bar: BarSafe;
+			baz: number;
+			qux: [string, number[]][];
+		};
+		type BarSafe = {
+			qur: [string, number][];
+		};
+		expectTypeOf<ConvertToJsonSafe<Foo>>().toEqualTypeOf<FooSafe>();
+	});
+
+	it("should handle union types", () => {
+		type Foo = {
+			bar: Map<string, number> | null;
+		};
+
+		type FooSafe = {
+			bar: [string, number][] | null;
+		};
+		expectTypeOf<ConvertToJsonSafe<Foo>>().toEqualTypeOf<FooSafe>();
+	});
+
+	it("should not mangle types that are already json safe", () => {
+		type Foo = {
+			bar: string;
+		};
+
+		type Bar = {
+			baz?: QueueItem | null;
+		};
+
+		expectTypeOf<ConvertToJsonSafe<Foo>>().toEqualTypeOf<Foo>();
+		expectTypeOf<ConvertToJsonSafe<QueueItem>>().toEqualTypeOf<QueueItem>();
+		expectTypeOf<ConvertToJsonSafe<QueueItem | undefined>>().toEqualTypeOf<
+			QueueItem | undefined
+		>();
+		expectTypeOf<ConvertToJsonSafe<Bar>>().toEqualTypeOf<Bar>();
+	});
+
+	it("should handle types that have a toJSON method", () => {
+		class Foo {
+			toJSON() {
+				return { bar: "baz" };
+			}
+		}
+
+		expectTypeOf<ConvertToJsonSafe<Foo>>().toEqualTypeOf<{ bar: string }>();
+	});
+});

--- a/common/typeutils.ts
+++ b/common/typeutils.ts
@@ -52,3 +52,13 @@ export type PickFunctions<T, Arg1, Arg2> = Omit<
 	Pick<T, NeverIfArg2NotMatch<T, Arg1, Arg2>[keyof T]>,
 	keyof NonNever<HasNoArgs<T>>
 >;
+
+// expands object types one level deep - useful for debugging types
+export type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+
+// expands object types recursively - useful for debugging types
+export type ExpandRecursively<T> = T extends object
+	? T extends infer O
+		? { [K in keyof O]: ExpandRecursively<O[K]> }
+		: never
+	: T;

--- a/common/vitest.config.ts
+++ b/common/vitest.config.ts
@@ -4,5 +4,9 @@ import { defineConfig, configDefaults } from "vitest/config";
 export default defineConfig({
 	test: {
 		exclude: [...configDefaults.exclude, "ts-out"],
+		typecheck: {
+			enabled: true,
+			include: ["**/*.spec-d.ts"],
+		},
 	},
 });

--- a/common/vitest.config.ts
+++ b/common/vitest.config.ts
@@ -4,6 +4,9 @@ import { defineConfig, configDefaults } from "vitest/config";
 export default defineConfig({
 	test: {
 		exclude: [...configDefaults.exclude, "ts-out"],
+		coverage: {
+			exclude: [...(configDefaults.coverage.exclude ?? []), "**/*.spec-d.ts"],
+		},
 		typecheck: {
 			enabled: true,
 			include: ["**/*.spec-d.ts"],

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "start-lean": "node --experimental-specifier-resolution=node --optimize-for-size --max-old-space-size=200 --conditions=lean ts-out/app.js",
     "debug": "nodemon --exec node --experimental-specifier-resolution=node --loader ts-node/esm --ignore 'tests/*' --inspect -e ts,js app.ts",
     "build": "tsc",
-    "lint": "tsc --noEmit && eslint --fix .",
+    "lint": "tsc --noEmit --noErrorTruncation && eslint --fix .",
     "lint-ci": "tsc --noEmit && eslint .",
     "test": "vitest run --coverage"
   },

--- a/server/room.ts
+++ b/server/room.ts
@@ -122,7 +122,7 @@ export class RoomUser {
  * This rule does not necessarily apply to inherited fields.
  */
 export interface RoomState extends RoomOptions, RoomStateComputed {
-	currentSource: Video | null;
+	currentSource: QueueItem | null;
 	queue: VideoQueue;
 	isPlaying: boolean;
 	playbackPosition: number;

--- a/server/tests/unit/room.spec-d.ts
+++ b/server/tests/unit/room.spec-d.ts
@@ -1,0 +1,38 @@
+/* eslint-disable vitest/expect-expect */
+import { describe, it, expectTypeOf } from "vitest";
+import type { ServerMessageSync } from "ott-common/models/messages";
+import type { RoomStateSyncable } from "../../room";
+import type { ConvertToJsonSafe } from "ott-common/serialize";
+
+describe("room state types", () => {
+	it("should always keep RoomStateSyncable and ServerMessageSync in sync", () => {
+		type B =
+			| "name"
+			| "title"
+			| "description"
+			| "isTemporary"
+			| "visibility"
+			| "queueMode"
+			| "currentSource"
+			| "queue"
+			| "isPlaying"
+			| "playbackPosition"
+			| "playbackSpeed"
+			| "grants"
+			| "hasOwner"
+			| "voteCounts"
+			| "videoSegments"
+			| "autoSkipSegmentCategories"
+			| "prevQueue"
+			| "restoreQueueBehavior"
+			| "enableVoteSkip"
+			| "votesToSkip";
+		type ExMsg = Pick<ServerMessageSync, B>;
+		type ExRoom = Pick<Partial<ConvertToJsonSafe<RoomStateSyncable>>, B>;
+		expectTypeOf<ExMsg>().toEqualTypeOf<ExRoom>();
+
+		expectTypeOf<Omit<ServerMessageSync, "action">>().toEqualTypeOf<
+			Partial<ConvertToJsonSafe<RoomStateSyncable>>
+		>();
+	});
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 				"migrations/**",
 				"**/tests/**",
 				"**/common/**",
+				"**/*.spec-d.ts",
 			],
 		},
 		typecheck: {

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -15,5 +15,9 @@ export default defineConfig({
 				"**/common/**",
 			],
 		},
+		typecheck: {
+			enabled: true,
+			include: ["**/*.spec-d.ts"],
+		},
 	},
 });


### PR DESCRIPTION
- **add `ConvertToJsonSafe` helper type with tests**
- **reconcile type compatability between `RoomStateSyncable` and `ServerMessageSync`**
