### PR TITLE
vis: tree display: place monolith trees in 2 columns on both sides of the balancers

### DIFF
--- a/packages/ott-vis-panel/.eslintrc
+++ b/packages/ott-vis-panel/.eslintrc
@@ -1,7 +1,8 @@
 {
 	"extends": "./.config/.eslintrc",
 	"rules": {
-		"camelcase": ["error", { "properties": "never" }]
+		"camelcase": ["error", { "properties": "never" }],
+		"@typescript-eslint/array-type": ["error", { "default": "array" }]
 	},
 	"overrides": [
 		{

--- a/packages/ott-vis-panel/src/components/TreeDisplay.spec.tsx
+++ b/packages/ott-vis-panel/src/components/TreeDisplay.spec.tsx
@@ -63,7 +63,7 @@ describe("TreeDisplay", () => {
 		expect(box).toEqual([-5, 0, 5, 20]);
 	});
 
-	const flipBoundingBoxHTestCases: Array<[BoundingBox, BoundingBox]> = [
+	const flipBoundingBoxHTestCases: [BoundingBox, BoundingBox][] = [
 		[
 			[0, 0, 0, 0],
 			[-0, 0, -0, 0],

--- a/packages/ott-vis-panel/src/components/TreeDisplay.spec.tsx
+++ b/packages/ott-vis-panel/src/components/TreeDisplay.spec.tsx
@@ -64,12 +64,24 @@ describe("TreeDisplay", () => {
 	});
 
 	const flipBoundingBoxHTestCases: [BoundingBox, BoundingBox][] = [
-		[[0, 0, 0, 0], [-0, 0, -0, 0]],
-		[[0, 0, 10, 10], [-10, 0, -0, 10]],
-		[[5, 0, 10, 10], [-10, 0, -5, 10]],
+		[
+			[0, 0, 0, 0],
+			[-0, 0, -0, 0],
+		],
+		[
+			[0, 0, 10, 10],
+			[-10, 0, -0, 10],
+		],
+		[
+			[5, 0, 10, 10],
+			[-10, 0, -5, 10],
+		],
 	];
-	it.each(flipBoundingBoxHTestCases)("should flip bounding box", (input: BoundingBox, expected: BoundingBox) => {
-		const got = flipBoundingBoxH(input);
-		expect(got).toEqual(expected);
-	});
+	it.each(flipBoundingBoxHTestCases)(
+		"should flip bounding box",
+		(input: BoundingBox, expected: BoundingBox) => {
+			const got = flipBoundingBoxH(input);
+			expect(got).toEqual(expected);
+		}
+	);
 });

--- a/packages/ott-vis-panel/src/components/TreeDisplay.spec.tsx
+++ b/packages/ott-vis-panel/src/components/TreeDisplay.spec.tsx
@@ -63,7 +63,7 @@ describe("TreeDisplay", () => {
 		expect(box).toEqual([-5, 0, 5, 20]);
 	});
 
-	const flipBoundingBoxHTestCases: [BoundingBox, BoundingBox][] = [
+	const flipBoundingBoxHTestCases: Array<[BoundingBox, BoundingBox]> = [
 		[
 			[0, 0, 0, 0],
 			[-0, 0, -0, 0],

--- a/packages/ott-vis-panel/src/components/TreeDisplay.spec.tsx
+++ b/packages/ott-vis-panel/src/components/TreeDisplay.spec.tsx
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import { sizeOfTree, treeBoundingBox } from "./TreeDisplay";
+import { sizeOfTree, treeBoundingBox, type BoundingBox, flipBoundingBoxH } from "./TreeDisplay";
 
 describe("TreeDisplay", () => {
 	it("should find the size of any d3 tree", () => {
@@ -61,5 +61,15 @@ describe("TreeDisplay", () => {
 		treeLayout(root);
 		const box = treeBoundingBox(root);
 		expect(box).toEqual([-5, 0, 5, 20]);
+	});
+
+	const flipBoundingBoxHTestCases: [BoundingBox, BoundingBox][] = [
+		[[0, 0, 0, 0], [-0, 0, -0, 0]],
+		[[0, 0, 10, 10], [-10, 0, -0, 10]],
+		[[5, 0, 10, 10], [-10, 0, -5, 10]],
+	];
+	it.each(flipBoundingBoxHTestCases)("should flip bounding box", (input: BoundingBox, expected: BoundingBox) => {
+		const got = flipBoundingBoxH(input);
+		expect(got).toEqual(expected);
 	});
 });

--- a/packages/ott-vis-panel/src/components/TreeDisplay.tsx
+++ b/packages/ott-vis-panel/src/components/TreeDisplay.tsx
@@ -247,6 +247,19 @@ const TreeDisplay: React.FC<TreeDisplayProps> = ({ systemState, width, height })
 			monolithTreeBoxes.push(...boxesLeft);
 			const monolithTreeYsRight: number[] = stackBoxes(boxesRight);
 			const monolithTreeYsLeft: number[] = stackBoxes(boxesLeft);
+			// add an offset to the smaller column to center it
+			const largestRight = monolithTreeYsRight[monolithTreeYsRight.length - 1] ?? 0;
+			const largestLeft = monolithTreeYsLeft[monolithTreeYsLeft.length - 1] ?? 0;
+			const offsetY = Math.abs(largestRight - largestLeft) / 2;
+			if (largestRight > largestLeft) {
+				monolithTreeYsLeft.forEach((y, i) => {
+					monolithTreeYsLeft[i] = y + offsetY;
+				});
+			} else if (largestLeft > largestRight) {
+				monolithTreeYsRight.forEach((y, i) => {
+					monolithTreeYsRight[i] = y + offsetY;
+				});
+			}
 			const monolithTreeYs = monolithTreeYsRight.concat(monolithTreeYsLeft);
 			const monolithNodes = monolithTrees.map((monolith, i) => {
 				const isRight = i < boxesRight.length;

--- a/packages/ott-vis-panel/src/components/TreeDisplay.tsx
+++ b/packages/ott-vis-panel/src/components/TreeDisplay.tsx
@@ -145,9 +145,7 @@ export function stackBoxes(boxes: BoundingBox[]): number[] {
 			const [_pleft, _ptop, _pright, pbottom] = boxes[i - 1];
 			const [_left, top, _right, _bottom] = boxes[i];
 			const spacing = -top + pbottom + NODE_RADIUS * 2 + 10;
-			boxYs.push(
-				boxYs[i - 1] + Math.max(spacing, NODE_RADIUS * 2 + 10)
-			);
+			boxYs.push(boxYs[i - 1] + Math.max(spacing, NODE_RADIUS * 2 + 10));
 		}
 	}
 
@@ -243,7 +241,9 @@ const TreeDisplay: React.FC<TreeDisplayProps> = ({ systemState, width, height })
 			// compute positions of monolith trees
 			const monolithTreeBoxes = builtMonolithTrees.map(tree => treeBoundingBox(tree));
 			const boxesRight = monolithTreeBoxes.slice(0, Math.floor(monolithTreeBoxes.length / 2));
-			const boxesLeft = monolithTreeBoxes.splice(Math.floor(monolithTreeBoxes.length / 2)).map(flipBoundingBoxH);
+			const boxesLeft = monolithTreeBoxes
+				.splice(Math.floor(monolithTreeBoxes.length / 2))
+				.map(flipBoundingBoxH);
 			monolithTreeBoxes.push(...boxesLeft);
 			const monolithTreeYsRight: number[] = stackBoxes(boxesRight);
 			const monolithTreeYsLeft: number[] = stackBoxes(boxesLeft);


### PR DESCRIPTION
![image](https://github.com/dyc3/opentogethertube/assets/1808807/d0adb44d-f5a7-4688-a51a-978f6ec0306d)
