### PR TITLE
balancer: fix memory leak caused by clients connecting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1969,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.2.0",
  "hyper-util",
+ "jemallocator",
  "once_cell",
  "ott-balancer-protocol",
  "ott-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ humantime-serde = "1.1"
 hyper = { version = "1.2.0", features = ["full"] }
 hyper-util = { version = "0.1.3", features = ["full"] }
 http-body-util = "0.1.0"
+jemallocator = "0.5.4"
 once_cell = "1.17.1"
 ott-common = { path = "crates/ott-common" }
 ott-balancer = { path = "crates/ott-balancer" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ humantime-serde = "1.1"
 hyper = { version = "1.2.0", features = ["full"] }
 hyper-util = { version = "0.1.3", features = ["full"] }
 http-body-util = "0.1.0"
-jemallocator = "0.5.4"
+jemallocator = { version = "0.5.4" }
 once_cell = "1.17.1"
 ott-common = { path = "crates/ott-common" }
 ott-balancer = { path = "crates/ott-balancer" }

--- a/crates/ott-balancer/Cargo.toml
+++ b/crates/ott-balancer/Cargo.toml
@@ -14,6 +14,7 @@ futures-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 http-body-util.workspace = true
+jemallocator.workspace = true
 rand.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/crates/ott-balancer/src/balancer.rs
+++ b/crates/ott-balancer/src/balancer.rs
@@ -125,10 +125,8 @@ impl Balancer {
                 }
                 // process completed tasks
                 task_result = tasks.next() => {
-                    if let Some(task_result) = task_result {
-                        if let Err(err) = task_result {
-                            error!("error in task: {:?}", err);
-                        }
+                    if let Some(Err(err)) = task_result {
+                        error!("error in task: {:?}", err);
                     }
                 }
             }

--- a/crates/ott-balancer/src/balancer.rs
+++ b/crates/ott-balancer/src/balancer.rs
@@ -126,7 +126,6 @@ impl Balancer {
                 // process completed tasks
                 task_result = tasks.next() => {
                     if let Some(task_result) = task_result {
-                        info!("task completed");
                         if let Err(err) = task_result {
                             error!("error in task: {:?}", err);
                         }

--- a/crates/ott-balancer/src/config.rs
+++ b/crates/ott-balancer/src/config.rs
@@ -79,10 +79,14 @@ pub struct Cli {
     #[clap(short, long, default_value_t = LogLevel::Info, value_enum)]
     pub log_level: LogLevel,
 
+    /// Enable the console-subscriber for debugging via tokio-console.
+    #[clap(long)]
+    pub console: bool,
+
     /// Allow remote connections via tokio-console for debugging. By default, only local connections are allowed.
     ///
     /// The default port for tokio-console is 6669.
-    #[clap(long)]
+    #[clap(long, requires("console"))]
     pub remote_console: bool,
 
     /// Validate the configuration file.

--- a/crates/ott-balancer/src/lib.rs
+++ b/crates/ott-balancer/src/lib.rs
@@ -163,10 +163,8 @@ pub async fn run() -> anyhow::Result<()> {
 
             // process completed tasks
             result = tasks.next() => {
-                if let Some(result) = result {
-                    if let Err(err) = result {
-                        error!("Error in http serving task: {:?}", err);
-                    }
+                if let Some(Err(err)) = result {
+                    error!("Error in http serving task: {:?}", err);
                 }
                 continue;
             }

--- a/crates/ott-balancer/src/lib.rs
+++ b/crates/ott-balancer/src/lib.rs
@@ -134,7 +134,6 @@ pub async fn run() -> anyhow::Result<()> {
     let service = BalancerService {
         ctx,
         link: service_link,
-        addr: bind_addr6,
     };
 
     // on linux, binding ipv6 will also bind ipv4
@@ -144,15 +143,14 @@ pub async fn run() -> anyhow::Result<()> {
 
     info!("Serving on {}", bind_addr6);
     loop {
-        let (stream, addr) = tokio::select! {
+        let (stream, _addr) = tokio::select! {
             stream = listener6.accept() => {
                 let (stream, addr) = stream?;
                 (stream, addr)
             }
         };
 
-        let mut service = service.clone();
-        service.addr = addr;
+        let service = service.clone();
 
         let io = hyper_util::rt::TokioIo::new(stream);
 

--- a/crates/ott-balancer/src/lib.rs
+++ b/crates/ott-balancer/src/lib.rs
@@ -30,6 +30,9 @@ pub mod selection;
 pub mod service;
 pub mod state_stream;
 
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 pub async fn run() -> anyhow::Result<()> {
     let args = config::Cli::parse();
 

--- a/crates/ott-balancer/src/service.rs
+++ b/crates/ott-balancer/src/service.rs
@@ -46,7 +46,6 @@ static ROUTER: Lazy<Router<&'static str>> = Lazy::new(|| {
 pub struct BalancerService {
     pub(crate) ctx: Arc<RwLock<BalancerContext>>,
     pub(crate) link: BalancerLink,
-    pub(crate) addr: std::net::SocketAddr,
 }
 
 impl Service<Request<IncomingBody>> for BalancerService {
@@ -73,7 +72,6 @@ impl Service<Request<IncomingBody>> for BalancerService {
 
         let ctx: Arc<RwLock<BalancerContext>> = self.ctx.clone();
         let link = self.link.clone();
-        let _addr = self.addr;
 
         let Ok(route) = ROUTER.recognize(req.uri().path()) else {
             warn!("no route found for {}", req.uri().path());

--- a/tests/load/extreme-connects.js
+++ b/tests/load/extreme-connects.js
@@ -1,0 +1,45 @@
+import ws from "k6/ws";
+import { sleep, check } from "k6";
+import { randomItem } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+import { getAuthToken, createRoom, HOSTNAME } from "./utils.js";
+
+export const options = {
+	rate: 50,
+	duration: "1h",
+};
+
+export function setup() {
+	const rooms = [];
+	for (let i = 0; i < 50; i++) {
+		rooms.push(`load-test-${i}`);
+	}
+
+	const token = getAuthToken();
+	for (let room of rooms) {
+		createRoom(room, token, { visibility: "public", isTemporary: true });
+	}
+	sleep(1);
+
+	const tokens = [token];
+	for (let i = 0; i < 100; i++) {
+		tokens.push(getAuthToken());
+	}
+
+	return { rooms, tokens };
+}
+
+export default function (data) {
+	const { rooms, tokens } = data;
+	const room = randomItem(rooms);
+	const token = randomItem(tokens);
+	console.log(`User is joining room ${room}`);
+	const url = `ws://${HOSTNAME}/api/room/${room}`;
+
+	const res = ws.connect(url, null, socket => {
+		socket.on("open", () => {
+			socket.send(JSON.stringify({ action: "auth", token: token }));
+			socket.close(1000);
+		});
+	});
+	check(res, { "ws status is 101": r => r && r.status === 101 });
+}


### PR DESCRIPTION
- avoid spawning unnecessary tasks
- use jemallocator instead of system allocator
- ensure tasks get cleaned up instead of hanging around with no wakers
- disable console subscriber by default, putting it behind a `--console` flag

fixes #1540
