### PR TITLE
client: fix video queue item buttons wrapping to new row on mobile

### DIFF
--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -423,6 +423,7 @@ export default VideoQueueItem;
 	}
 
 	.button-container {
+		display: flex;
 		flex-direction: row;
 		justify-content: center;
 		flex-wrap: nowrap;


### PR DESCRIPTION
related: #1550
related: #641
