### PR TITLE
balancer: degrade more gracefully when overloaded with new clients

### DIFF
--- a/crates/ott-balancer/src/balancer.rs
+++ b/crates/ott-balancer/src/balancer.rs
@@ -479,11 +479,12 @@ pub async fn join_client(
         client_outbound_unicast_rx,
     );
     let client = BalancerClient::new(new_client, client_outbound_unicast_tx);
+    // attempt to add the client to the monolith first so we don't have to worry about cleaning up the client if it fails
+    ctx_write.add_client(client, monolith_id).await?;
     client_link_tx
         .send(link)
         .map_err(|_| anyhow::anyhow!("receiver closed"))?;
-
-    ctx_write.add_client(client, monolith_id).await?;
+    info!("client added");
     Ok(())
 }
 

--- a/crates/ott-balancer/src/lib.rs
+++ b/crates/ott-balancer/src/lib.rs
@@ -60,13 +60,16 @@ pub async fn run() -> anyhow::Result<()> {
     let console_layer = if args.console {
         let console_layer = if args.remote_console {
             console_subscriber::ConsoleLayer::builder()
+                .with_default_env()
                 .server_addr((
                     Ipv6Addr::UNSPECIFIED,
                     console_subscriber::Server::DEFAULT_PORT,
                 ))
                 .spawn()
         } else {
-            console_subscriber::ConsoleLayer::builder().spawn()
+            console_subscriber::ConsoleLayer::builder()
+                .with_default_env()
+                .spawn()
         }
         .with_filter(EnvFilter::try_new("tokio=trace,runtime=trace")?);
         Some(console_layer)
@@ -91,6 +94,7 @@ pub async fn run() -> anyhow::Result<()> {
         .with(streamer_layer)
         .with(fmt_layer)
         .init();
+    info!("Args: {:?}", args);
     info!("Loaded config: {:?}", config);
 
     let (discovery_tx, discovery_rx) = tokio::sync::mpsc::channel(2);


### PR DESCRIPTION
issue was found when running the `chatty-users` load test

before:

![image](https://github.com/dyc3/opentogethertube/assets/1808807/d892f7c3-31f9-445c-a62f-fa279df9f407)

after the load test, the balancer would become unresponsive

after:

![image](https://github.com/dyc3/opentogethertube/assets/1808807/b78d6370-8249-41ed-991a-e0f7a4f8ba5b)

after the load test, the balancer remains responsive, but still does not fully recover