### PR TITLE
dev: add vscode setting to disable sync button because its bad

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
 	"search.exclude": {
 		"**/coverage": true,
 		"**/dist": true
+	},
+	"git.showActionButton": {
+		"sync": false
 	}
 }


### PR DESCRIPTION
the sync button is really bad when using a rebase workflow