### PR TITLE
server: refactor video highlighting, fix videos not getting highlighted in add previews

### DIFF
--- a/client/src/components/AddPreview.vue
+++ b/client/src/components/AddPreview.vue
@@ -236,6 +236,7 @@ async function requestAddPreviewExplicit() {
 	isLoadingAddPreview.value = true;
 	hasAddPreviewFailed.value = false;
 	videos.value = [];
+	highlightedAddPreviewItem.value = undefined;
 	await requestAddPreview();
 }
 async function addAllToQueue() {
@@ -261,16 +262,19 @@ function onInputAddPreviewChange() {
 	hasAddPreviewFailed.value = false;
 	if (!inputAddPreview.value || _.trim(inputAddPreview.value).length === 0) {
 		videos.value = [];
+		highlightedAddPreviewItem.value = undefined;
 		return;
 	}
 	if (!isAddPreviewInputUrl.value) {
 		videos.value = [];
+		highlightedAddPreviewItem.value = undefined;
 		// Don't send API requests for non URL inputs without the user's explicit input to do so.
 		// This is to help conserve youtube API quota.
 		return;
 	}
 	isLoadingAddPreview.value = true;
 	videos.value = [];
+	highlightedAddPreviewItem.value = undefined;
 	requestAddPreviewDebounced();
 }
 function onInputAddPreviewKeyDown(e) {

--- a/client/src/components/AddPreview.vue
+++ b/client/src/components/AddPreview.vue
@@ -157,9 +157,7 @@ watch(inputAddPreview, () => {
 	onInputAddPreviewChange();
 });
 
-const highlightedAddPreviewItem = computed(() => {
-	return _.find(videos.value, { highlight: true });
-});
+const highlightedAddPreviewItem = ref<Video | undefined>(undefined);
 const isAddPreviewInputUrl = computed(() => {
 	try {
 		return !!new URL(inputAddPreview.value).host;
@@ -184,6 +182,7 @@ async function requestAddPreview() {
 		hasAddPreviewFailed.value = false;
 		if (res.data.success) {
 			videos.value = res.data.result;
+			highlightedAddPreviewItem.value = res.data.highlighted;
 			console.log(`Got add preview with ${videos.value.length}`);
 		} else {
 			throw new Error(res.data.error.message);

--- a/client/tests/e2e/component/AddPreview.cy.ts
+++ b/client/tests/e2e/component/AddPreview.cy.ts
@@ -1,7 +1,7 @@
 import { defineComponent, h } from "vue";
 import { useStore } from "../../../src/store";
 import AddPreview from "../../../src/components/AddPreview.vue";
-import Norifier from "../../../src/components/Notifier.vue";
+import Notifier from "../../../src/components/Notifier.vue";
 
 let page = defineComponent({
 	setup() {
@@ -10,7 +10,7 @@ let page = defineComponent({
 		return {};
 	},
 	render() {
-		return h("div", {}, [h(AddPreview), h(Norifier)]);
+		return h("div", {}, [h(AddPreview), h(Notifier)]);
 	},
 });
 
@@ -83,7 +83,7 @@ describe("<AddPreview />", () => {
 				return {};
 			},
 			render() {
-				return h("div", {}, [h(AddPreview), h(Norifier)]);
+				return h("div", {}, [h(AddPreview), h(Notifier)]);
 			},
 		});
 		cy.mount(page);

--- a/common/models/rest-api.ts
+++ b/common/models/rest-api.ts
@@ -78,6 +78,7 @@ export type OttApiRequestRemoveFromQueue = z.infer<typeof OttApiRequestRemoveFro
 
 export type OttApiResponseAddPreview = {
 	result: Video[];
+	highlighted?: Video;
 };
 
 export type OttApiRequestVote = z.infer<typeof OttApiRequestVoteSchema>;

--- a/server/api/data.ts
+++ b/server/api/data.ts
@@ -33,7 +33,6 @@ const addPreview: RequestHandler<
 			req.query.input.trim(),
 			conf.get("add_preview.search.provider")
 		);
-		const videos = result.videos;
 
 		res.setHeader(
 			"Cache-Control",
@@ -42,9 +41,10 @@ const addPreview: RequestHandler<
 
 		res.json({
 			success: true,
-			result: videos,
+			result: result.videos,
+			highlighted: result.highlighted,
 		});
-		log.info(`Sent add preview response with ${videos.length} items`);
+		log.info(`Sent add preview response with ${result.videos.length} items`);
 	} catch (err) {
 		if (
 			err.name === "UnsupportedServiceException" ||

--- a/server/infoextractor.ts
+++ b/server/infoextractor.ts
@@ -382,7 +382,15 @@ export default {
 				const completeResults = await this.getManyVideoInfo(resolvedResults);
 				return new AddPreview(completeResults, cacheDuration);
 			} else {
-				return new AddPreview(fetchResults, cacheDuration);
+				const videos = fetchResults.videos;
+				const completeResults = await this.getManyVideoInfo(videos);
+				return new AddPreview(
+					{
+						videos: completeResults,
+						highlighted: fetchResults.highlighted,
+					},
+					cacheDuration
+				);
 			}
 		} else {
 			if (query.length < ADD_PREVIEW_SEARCH_MIN_LENGTH) {

--- a/server/infoextractor.ts
+++ b/server/infoextractor.ts
@@ -383,14 +383,16 @@ export default {
 				return new AddPreview(completeResults, cacheDuration);
 			} else {
 				const videos = fetchResults.videos;
-				const completeResults = await this.getManyVideoInfo(videos);
-				return new AddPreview(
-					{
-						videos: completeResults,
-						highlighted: fetchResults.highlighted,
-					},
-					cacheDuration
-				);
+				const completeResults: BulkVideoResult = {
+					videos: await this.getManyVideoInfo(videos),
+					highlighted: fetchResults.highlighted
+						? await this.getVideoInfo(
+								fetchResults.highlighted.service,
+								fetchResults.highlighted.id
+						  )
+						: undefined,
+				};
+				return new AddPreview(completeResults, cacheDuration);
 			}
 		} else {
 			if (query.length < ADD_PREVIEW_SEARCH_MIN_LENGTH) {

--- a/server/infoextractor.ts
+++ b/server/infoextractor.ts
@@ -424,11 +424,22 @@ export class AddPreview {
 	videos: Video[];
 	/** The number of seconds to allow downstream caches to cache the response. Affects caching HTTP headers. */
 	cacheDuration: number;
+	highlighted?: Video;
 
-	constructor(videos: Video[], cacheDuration: number) {
-		this.videos = videos;
+	constructor(videos: Video[] | BulkVideoResult, cacheDuration: number) {
+		if (Array.isArray(videos)) {
+			this.videos = videos;
+		} else {
+			this.videos = videos.videos;
+			this.highlighted = videos.highlighted;
+		}
 		this.cacheDuration = cacheDuration;
 	}
+}
+
+export interface BulkVideoResult {
+	videos: Video[];
+	highlighted?: Video;
 }
 
 const counterAddPreviewsRequested = new Counter({

--- a/server/serviceadapter.ts
+++ b/server/serviceadapter.ts
@@ -3,6 +3,7 @@
 import { Video, VideoId, VideoMetadata, VideoService } from "ott-common/models/video";
 import { IncompleteServiceAdapterException } from "./exceptions";
 import { getLogger } from "./logger";
+import { BulkVideoResult } from "./infoextractor";
 
 const log = getLogger("serviceadapter");
 export interface VideoRequest {
@@ -92,7 +93,7 @@ export class ServiceAdapter {
 	async resolveURL(
 		url: string,
 		properties?: (keyof VideoMetadata)[]
-	): Promise<(Video | { url: string })[]> {
+	): Promise<(Video | { url: string })[] | BulkVideoResult> {
 		throw new IncompleteServiceAdapterException(
 			`Service ${this.serviceId} does not implement method resolveURL`
 		);

--- a/server/services/youtube.ts
+++ b/server/services/youtube.ts
@@ -231,7 +231,7 @@ export default class YouTubeAdapter extends ServiceAdapter {
 		} else {
 			if (qPlaylist && !knownPrivateLists.includes(qPlaylist)) {
 				try {
-					return this.fetchVideoWithPlaylist(this.getVideoId(link), qPlaylist);
+					return await this.fetchVideoWithPlaylist(this.getVideoId(link), qPlaylist);
 				} catch {
 					log.debug("Falling back to fetching video without playlist");
 					return {

--- a/server/services/youtube.ts
+++ b/server/services/youtube.ts
@@ -16,6 +16,7 @@ import storage from "../storage";
 import { OttException } from "ott-common/exceptions";
 import { conf } from "../ott-config";
 import { parseIso8601Duration } from "./parsing/iso8601";
+import { BulkVideoResult } from "server/infoextractor";
 
 const log = getLogger("youtube");
 
@@ -203,7 +204,10 @@ export default class YouTubeAdapter extends ServiceAdapter {
 		}
 	}
 
-	async resolveURL(link: string, onlyProperties?: (keyof VideoMetadata)[]): Promise<Video[]> {
+	async resolveURL(
+		link: string,
+		onlyProperties?: (keyof VideoMetadata)[]
+	): Promise<Video[] | BulkVideoResult> {
 		log.debug(`resolveURL: ${link}, ${onlyProperties ? onlyProperties.toString() : ""}`);
 		const url = new URL(link);
 
@@ -215,7 +219,8 @@ export default class YouTubeAdapter extends ServiceAdapter {
 			url.pathname.startsWith("/user/") ||
 			url.pathname.startsWith("/@")
 		) {
-			return this.fetchChannelVideos(this.getChannelId(url));
+			const videos = await this.fetchChannelVideos(this.getChannelId(url));
+			return { videos };
 		} else if (url.pathname === "/playlist") {
 			if (qPlaylist) {
 				return this.fetchPlaylistVideos(qPlaylist);
@@ -225,7 +230,7 @@ export default class YouTubeAdapter extends ServiceAdapter {
 		} else {
 			if (qPlaylist && !knownPrivateLists.includes(qPlaylist)) {
 				try {
-					return await this.fetchVideoWithPlaylist(this.getVideoId(link), qPlaylist);
+					return this.fetchVideoWithPlaylist(this.getVideoId(link), qPlaylist);
 				} catch {
 					log.debug("Falling back to fetching video without playlist");
 					return [await this.fetchVideoInfo(this.getVideoId(link), onlyProperties)];
@@ -410,23 +415,22 @@ export default class YouTubeAdapter extends ServiceAdapter {
 		}
 	}
 
-	async fetchVideoWithPlaylist(videoId: string, playlistId: string): Promise<Video[]> {
+	async fetchVideoWithPlaylist(videoId: string, playlistId: string): Promise<BulkVideoResult> {
 		const playlist = await this.fetchPlaylistVideos(playlistId);
-		let highlighted = false;
-		playlist.forEach(video => {
-			if (video.id === videoId) {
-				highlighted = true;
-				video.highlight = true;
-			}
-		});
+		let highlighted = playlist.find(video => video.id === videoId);
 
 		if (!highlighted) {
-			const video = await this.fetchVideoInfo(videoId);
-			video.highlight = true;
-			playlist.unshift(video);
+			try {
+				highlighted = await this.fetchVideoInfo(videoId);
+			} catch (err) {
+				log.warn(`Failed to fetch highlighted video from playlist, skipping: ${err}`);
+			}
 		}
 
-		return playlist;
+		return {
+			videos: playlist,
+			highlighted,
+		};
 	}
 
 	async videoApiRequest(

--- a/server/services/youtube.ts
+++ b/server/services/youtube.ts
@@ -207,7 +207,7 @@ export default class YouTubeAdapter extends ServiceAdapter {
 	async resolveURL(
 		link: string,
 		onlyProperties?: (keyof VideoMetadata)[]
-	): Promise<Video[] | BulkVideoResult> {
+	): Promise<BulkVideoResult> {
 		log.debug(`resolveURL: ${link}, ${onlyProperties ? onlyProperties.toString() : ""}`);
 		const url = new URL(link);
 
@@ -223,7 +223,8 @@ export default class YouTubeAdapter extends ServiceAdapter {
 			return { videos };
 		} else if (url.pathname === "/playlist") {
 			if (qPlaylist) {
-				return this.fetchPlaylistVideos(qPlaylist);
+				const videos = await this.fetchPlaylistVideos(qPlaylist);
+				return { videos };
 			} else {
 				throw new BadApiArgumentException("input", "Link is missing playlist ID");
 			}
@@ -233,10 +234,14 @@ export default class YouTubeAdapter extends ServiceAdapter {
 					return this.fetchVideoWithPlaylist(this.getVideoId(link), qPlaylist);
 				} catch {
 					log.debug("Falling back to fetching video without playlist");
-					return [await this.fetchVideoInfo(this.getVideoId(link), onlyProperties)];
+					return {
+						videos: [await this.fetchVideoInfo(this.getVideoId(link), onlyProperties)],
+					};
 				}
 			} else {
-				return [await this.fetchVideoInfo(this.getVideoId(link), onlyProperties)];
+				return {
+					videos: [await this.fetchVideoInfo(this.getVideoId(link), onlyProperties)],
+				};
 			}
 		}
 	}

--- a/server/tests/unit/services/youtube.spec.ts
+++ b/server/tests/unit/services/youtube.spec.ts
@@ -321,7 +321,7 @@ describe("Youtube", () => {
 				expect(fetchSpy).toHaveBeenCalledTimes(1);
 				expect(fetchPlaylist).toHaveBeenCalledTimes(1);
 				expect(fetchVideo).toHaveBeenCalledTimes(1);
-				expect(videos).toEqual([
+				expect(videos.videos).toEqual([
 					{
 						service: "youtube",
 						id: "BTZ5KVRUy1Q",
@@ -375,7 +375,7 @@ describe("Youtube", () => {
 			async link => {
 				const fetchVideoWithPlaylist = vi.spyOn(adapter, "fetchVideoWithPlaylist");
 				const fetchVideo = vi.spyOn(adapter, "fetchVideoInfo");
-				const videos: Video[] = await adapter.resolveURL(link);
+				let videos = (await adapter.resolveURL(link)).videos;
 				expect(videos).toHaveLength(1);
 				expect(videos[0]).toEqual({
 					service: "youtube",
@@ -404,7 +404,7 @@ describe("Youtube", () => {
 			expect(fetchVideoWithPlaylist).toHaveBeenCalledTimes(0);
 			expect(fetchPlaylist).toHaveBeenCalledTimes(1);
 			expect(fetchVideo).toHaveBeenCalledTimes(0);
-			expect(videos).toEqual([
+			expect(videos.videos).toEqual([
 				{
 					service: "youtube",
 					id: "zgxj_0xPleg",

--- a/server/tests/unit/services/youtube.spec.ts
+++ b/server/tests/unit/services/youtube.spec.ts
@@ -119,7 +119,7 @@ async function mockYoutubeApi(
 			};
 		} catch (e) {
 			let content = fs.readFileSync(`${FIXTURE_DIRECTORY}/errors/${e.message}.json`, "utf8");
-			return JSON.parse(content);
+			throw JSON.parse(content);
 		}
 	} else if (path === "/channels") {
 		return {

--- a/server/tests/unit/services/youtube.spec.ts
+++ b/server/tests/unit/services/youtube.spec.ts
@@ -364,8 +364,8 @@ describe("Youtube", () => {
 		it("Recovers after not being able to fetch playlist information for a video", async () => {
 			const link = "https://youtube.com/watch?v=BTZ5KVRUy1Q&list=fakelistid";
 			const videos = await adapter.resolveURL(link);
-			expect(videos).toHaveLength(1);
-			expect(videos[0]).toEqual({
+			expect(videos.videos).toHaveLength(1);
+			expect(videos.videos[0]).toEqual({
 				service: "youtube",
 				id: "BTZ5KVRUy1Q",
 				title: "tmpIwT4T4",
@@ -380,9 +380,9 @@ describe("Youtube", () => {
 			async link => {
 				const fetchVideoWithPlaylist = vi.spyOn(adapter, "fetchVideoWithPlaylist");
 				const fetchVideo = vi.spyOn(adapter, "fetchVideoInfo");
-				let videos = (await adapter.resolveURL(link)).videos;
-				expect(videos).toHaveLength(1);
-				expect(videos[0]).toEqual({
+				const videos = await adapter.resolveURL(link);
+				expect(videos.videos).toHaveLength(1);
+				expect(videos.videos[0]).toEqual({
 					service: "youtube",
 					id: "BTZ5KVRUy1Q",
 					title: "tmpIwT4T4",

--- a/server/tests/unit/services/youtube.spec.ts
+++ b/server/tests/unit/services/youtube.spec.ts
@@ -255,8 +255,8 @@ describe("Youtube", () => {
 			].map(x => x.replace("%s", "BTZ5KVRUy1Q"))
 		)("Resolves single video URL: %s", async link => {
 			const videos = await adapter.resolveURL(link);
-			expect(videos).toHaveLength(1);
-			expect(videos[0]).toEqual({
+			expect(videos.videos).toHaveLength(1);
+			expect(videos.videos[0]).toEqual({
 				service: "youtube",
 				id: "BTZ5KVRUy1Q",
 				title: "tmpIwT4T4",
@@ -280,7 +280,7 @@ describe("Youtube", () => {
 			expect(fetchSpy).toHaveBeenCalledTimes(1);
 			expect(fetchPlaylist).toHaveBeenCalledTimes(1);
 			expect(fetchVideo).toHaveBeenCalledTimes(0);
-			expect(videos).toEqual([
+			expect(videos.videos).toEqual([
 				{
 					service: "youtube",
 					id: "zgxj_0xPleg",
@@ -289,7 +289,6 @@ describe("Youtube", () => {
 					thumbnail: "https://i.ytimg.com/vi/zgxj_0xPleg/mqdefault.jpg",
 					// length expected to be undefined because the youtube api doesn't return video length in playlist items
 					// feature requested here: https://issuetracker.google.com/issues/173420445
-					highlight: true,
 				},
 				{
 					service: "youtube",
@@ -299,6 +298,13 @@ describe("Youtube", () => {
 					thumbnail: "https://i.ytimg.com/vi/_3QMqssyBwQ/default.jpg",
 				},
 			]);
+			expect(videos.highlighted).toEqual({
+				service: "youtube",
+				id: "zgxj_0xPleg",
+				title: "Chris Chan: A Comprehensive History - Part 1",
+				description: "(1982-2000)",
+				thumbnail: "https://i.ytimg.com/vi/zgxj_0xPleg/mqdefault.jpg",
+			});
 			expect(apiGet).toHaveBeenCalledTimes(1);
 
 			fetchSpy.mockRestore();
@@ -321,16 +327,15 @@ describe("Youtube", () => {
 				expect(fetchSpy).toHaveBeenCalledTimes(1);
 				expect(fetchPlaylist).toHaveBeenCalledTimes(1);
 				expect(fetchVideo).toHaveBeenCalledTimes(1);
+				expect(videos.highlighted).toEqual({
+					service: "youtube",
+					id: "BTZ5KVRUy1Q",
+					title: "tmpIwT4T4",
+					description: "tmpIwT4T4",
+					thumbnail: "https://i.ytimg.com/vi/BTZ5KVRUy1Q/mqdefault.jpg",
+					length: 10,
+				});
 				expect(videos.videos).toEqual([
-					{
-						service: "youtube",
-						id: "BTZ5KVRUy1Q",
-						title: "tmpIwT4T4",
-						description: "tmpIwT4T4",
-						thumbnail: "https://i.ytimg.com/vi/BTZ5KVRUy1Q/mqdefault.jpg",
-						length: 10,
-						highlight: true,
-					},
 					{
 						service: "youtube",
 						id: "zgxj_0xPleg",


### PR DESCRIPTION
For better UX when copying links from youtube playlists, OTT is supposed to highlight the video that is in the link, while still fetching the playlist, if possible. This PR fixes that, and refactors the feature to make it a little more reliable.

fixes #1777
