### PR TITLE
fix(client): fix seek preview timestamp being positioned incorrectly for youtube videos.

### DIFF
--- a/client/src/components/controls/VideoProgressSlider.vue
+++ b/client/src/components/controls/VideoProgressSlider.vue
@@ -20,6 +20,7 @@
 		:class="{ hide: !seekPreviewVisible }"
 		:style="{
 			left: seekPreviewX + 'px',
+			top: seekPreviewY + 'px',
 		}"
 	>
 		<span>{{ seekPreviewTimestamp }}</span>
@@ -134,6 +135,7 @@ function getSliderProcesses(dotsPos: number[]) {
 const seekPreviewPercent: Ref<number | null> = ref(null);
 const seekPreviewTimestamp = ref("");
 const seekPreviewX = ref(0); // x position of the timestamp
+const seekPreviewY = ref(0); // y position of the timestamp
 const railHovered = ref(false);
 const seekPreviewVisible = computed(() => {
 	return railHovered.value;
@@ -147,6 +149,7 @@ function updateSeekPreview(e) {
 	railHovered.value = true;
 	const sliderRect = slider.getBoundingClientRect();
 	const sliderPos = e.clientX - sliderRect.left;
+	const sliderY = sliderRect.top;
 	seekPreviewPercent.value = sliderPos / sliderRect.width;
 	seekPreviewTimestamp.value = secondsToTimestamp(
 		seekPreviewPercent.value * (store.state.room.currentSource?.length ?? 0)
@@ -157,7 +160,8 @@ function updateSeekPreview(e) {
 	}
 	const baseX = sliderPos;
 	const seekPreviewRect = seekPreview.getBoundingClientRect();
-	seekPreviewX.value = baseX + 12 - seekPreviewRect.width / 2;
+	seekPreviewX.value = sliderRect.left + baseX - seekPreviewRect.width / 2;
+	seekPreviewY.value = sliderY - 14 - seekPreviewRect.height / 2;
 }
 
 function resetSeekPreview() {
@@ -188,8 +192,7 @@ onUpdated(() => {
 
 <style lang="scss" scoped>
 #seek-preview {
-	position: absolute;
-	top: -14px;
+	position: fixed;
 	background-color: rgba(0, 0, 0, 0.6);
 	color: white;
 	display: flex;


### PR DESCRIPTION
fixes #1834
