### PR TITLE
fix(server): Correctly handle absolute URLs in HLS manifests

### DIFF
--- a/server/services/hls.ts
+++ b/server/services/hls.ts
@@ -69,10 +69,9 @@ export default class HlsVideoAdapter extends ServiceAdapter {
 			},
 			{ attributes: { BANDWIDTH: Infinity } }
 		);
-		const newPath =
-			url.pathname?.split("/").slice(0, -1).join("/") + "/" + lowestBitratePlaylist.uri;
-		log.silly(`new playlist path ${newPath}`);
-		const respStreams = await axios.get("https://" + url.hostname + newPath);
+		const playlistUrl = URL.resolve(url.href, lowestBitratePlaylist.uri);
+		log.silly(`new playlist path ${playlistUrl}`);
+		const respStreams = await axios.get(playlistUrl);
 		const parser2 = new M3u8Parser();
 		parser2.push(respStreams.data);
 		parser2.end();


### PR DESCRIPTION
This fixes a bug in the HLS service where it would fail to parse manifests that use absolute URLs for their media playlists.

The existing code assumed that the uri property of a playlist in an HLS manifest was always a relative path. It would attempt to construct a new URL by concatenating the hostname of the manifest with a path derived from the manifest's path and the playlist's URI. This would fail if the URI was an absolute URL pointing to a different host.

The code has been updated to use URL.resolve() to determine the correct URL for the media playlist. This function correctly handles both relative and absolute URLs:

If the playlist URI is relative, it is resolved against the manifest's URL.
If the playlist URI is absolute, it is used as-is.