### PR TITLE
client: Move dashjs to a new component, DashPlayer.vue, with caption support

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "@vimeo/player": "^2.20.1",
     "@vueuse/core": "^9.6.0",
     "axios": "1.7.4",
-    "dashjs": "4.7.1",
+    "dashjs": "5.0.3",
     "dayjs": "^1.10.4",
     "hls.js": "1.6.12",
     "load-script": "^1.0.0",

--- a/client/src/components/AddPreview.vue
+++ b/client/src/components/AddPreview.vue
@@ -143,6 +143,14 @@ const testVideos = import.meta.env.DEV
 				"https://dash.akamaized.net/dash264/TestCases/1a/sony/SNE_DASH_SD_CASE1A_REVISED.mpd",
 			],
 			["test dash 1", "https://dash.akamaized.net/envivio/EnvivioDash3/manifest.mpd"],
+			[
+				"test dash 2 w/ one caption",
+				"https://dash.akamaized.net/akamai/test/caption_test/ElephantsDream/elephants_dream_480p_heaac5_1_https.mpd",
+			],
+			[
+				"test dash 3 w/ multiple captions",
+				"https://livesim2.dashif.org/vod/testpic_2s/multi_subs.mpd",
+			],
 			["test peertube 0", "https://the.jokertv.eu/w/7C5YZTLVudL4FLN4JmVvnA"],
 	  ]
 	: [];

--- a/client/src/components/players/DashPlayer.vue
+++ b/client/src/components/players/DashPlayer.vue
@@ -1,0 +1,303 @@
+<template>
+	<div class="dash">
+		<video
+			id="dashplayer"
+			preload="auto"
+			crossorigin="anonymous"
+			:poster="thumbnail || ''"
+			@canplay="onReady"
+			@ready="onReady"
+			@playing="onPlaying"
+			@pause="onPaused"
+			@stalled="onBuffering"
+			@loadstart="onBuffering"
+			@progress="onProgress"
+			@error="onError"
+		></video>
+	</div>
+	<div id="dashplayer-ttml-rendering"></div>
+</template>
+
+<script lang="ts" setup>
+import { onMounted, ref, watch, onBeforeUnmount, toRefs } from "vue";
+import * as dashjs from "dashjs";
+import type { MediaPlayerWithCaptions, MediaPlayerWithPlaybackRate } from "../composables";
+import { useCaptions } from "../composables";
+
+interface Props {
+	videoUrl: string;
+	thumbnail?: string;
+}
+
+const props = defineProps<Props>();
+const { videoUrl, thumbnail } = toRefs(props);
+const videoElem = ref<HTMLVideoElement>();
+const ttlmCaption = ref<HTMLDivElement>();
+const captions = useCaptions();
+const dash = ref<dashjs.MediaPlayerClass | undefined>(undefined);
+
+const emit = defineEmits([
+	"apiready",
+	"ready",
+	"playing",
+	"paused",
+	"buffering",
+	"error",
+	"buffer-progress",
+	"buffer-spans",
+]);
+
+function play() {
+	if (!videoElem.value) {
+		console.error("video element not ready");
+		return;
+	}
+	return videoElem.value.play();
+}
+
+function pause() {
+	if (!videoElem.value) {
+		console.error("video element not ready");
+		return;
+	}
+	videoElem.value.pause();
+}
+
+function setVolume(volume: number) {
+	if (!videoElem.value) {
+		console.error("video element not ready");
+		return;
+	}
+	videoElem.value.volume = volume / 100;
+}
+
+function getPosition() {
+	if (!videoElem.value) {
+		console.error("video element not ready");
+		return 0;
+	}
+	return videoElem.value.currentTime;
+}
+
+function setPosition(position: number) {
+	if (!videoElem.value) {
+		console.error("video element not ready");
+		return;
+	}
+	videoElem.value.currentTime = position;
+}
+
+function isCaptionsSupported(): boolean {
+	return true;
+}
+
+function setCaptionsEnabled(enabled: boolean): void {
+	if (!dash.value) {
+		return;
+	}
+	if (enabled) {
+		setCaptionsTrack(captions.currentTrack.value || "");
+	} else {
+		dash.value.setTextTrack(-1);
+	}
+}
+
+function isCaptionsEnabled(): boolean {
+	if (!dash.value) {
+		return false;
+	}
+	return dash.value.getCurrentTextTrackIndex() !== -1;
+}
+
+function getCaptionsTracks(): string[] {
+	if (!dash.value) {
+		return [];
+	}
+	const captionsTracks = dash.value.getTracksFor("text").map(track => {
+		const label = track.labels["text"] || track.labels["lang"] || track.lang || "unknown";
+		if (track.roles && track.roles.length > 0 && track.roles[0]["value"]) {
+			return `${label} (${track.roles[0]["value"]})`;
+		}
+		return label;
+	});
+	console.log("DashPlayer: available captions tracks:", captionsTracks);
+	return captionsTracks;
+}
+
+function setCaptionsTrack(track: string): void {
+	if (!dash.value) {
+		console.error("dash.js player not ready");
+		return;
+	}
+	const trackIdx = captions.captionsTracks.value.findIndex(t => t === track);
+	if (trackIdx === -1) {
+		console.error("DashPlayer: captions track not found:", track);
+		return;
+	}
+	console.log("DashPlayer: setting captions track to", track, "at index", trackIdx);
+	dash.value.setTextTrack(trackIdx);
+}
+
+function getAvailablePlaybackRates(): number[] {
+	return [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2];
+}
+
+function getPlaybackRate(): number {
+	if (!videoElem.value) {
+		console.error("video element not ready");
+		return 1;
+	}
+	return videoElem.value.playbackRate;
+}
+
+async function setPlaybackRate(rate: number): Promise<void> {
+	if (!videoElem.value) {
+		console.error("video element not ready");
+		return;
+	}
+	videoElem.value.playbackRate = rate;
+}
+
+function loadVideoSource() {
+	console.log("DashPlayer: loading video source:", props.videoUrl);
+	if (!videoElem.value) {
+		console.error("video element not ready");
+		return;
+	}
+
+	dash.value?.destroy();
+	dash.value = undefined;
+
+	dash.value = dashjs.MediaPlayer().create();
+	dash.value.initialize(videoElem.value, props.videoUrl, false);
+	if (ttlmCaption.value) {
+		dash.value.attachTTMLRenderingDiv(ttlmCaption.value);
+	}
+
+	dash.value.on(dashjs.MediaPlayer.events.MANIFEST_LOADED, () => {
+		console.info("DashPlayer: dash.js manifest loaded");
+		emit("ready");
+	});
+	dash.value.on(dashjs.MediaPlayer.events.TEXT_TRACKS_ADDED, () => {
+		captions.captionsTracks.value = getCaptionsTracks();
+		captions.isCaptionsEnabled.value = isCaptionsEnabled();
+		if (dash.value?.getCurrentTextTrackIndex() !== -1) {
+			captions.currentTrack.value =
+				captions.captionsTracks.value[dash.value?.getCurrentTextTrackIndex() || 0];
+		} else {
+			captions.currentTrack.value = "";
+			console.log("DashPlayer: no text track selected");
+		}
+	});
+	dash.value.on(dashjs.MediaPlayer.events.ERROR, (event: unknown) => {
+		console.error("DashPlayer: dash.js error:", event);
+		emit("error");
+	});
+	dash.value.on(dashjs.MediaPlayer.events.PLAYBACK_ERROR, (event: unknown) => {
+		console.error("DashPlayer: dash.js playback error:", event);
+		emit("error");
+	});
+	dash.value.on(dashjs.MediaPlayer.events.STREAM_INITIALIZED, () => {
+		console.info("DashPlayer: dash.js stream initialized");
+	});
+	dash.value.on(dashjs.MediaPlayer.events.BUFFER_EMPTY, () => {
+		console.info("DashPlayer: dash.js buffer stalled");
+		emit("buffering");
+	});
+	dash.value.on(dashjs.MediaPlayer.events.BUFFER_LOADED, () => {
+		console.info("DashPlayer: dash.js buffer loaded");
+		emit("ready");
+	});
+
+	// this is needed to get the player to keep playing after the previous video has ended
+	videoElem.value.play();
+
+	emit("apiready");
+}
+
+onMounted(() => {
+	videoElem.value = document.getElementById("dashplayer") as HTMLVideoElement;
+	ttlmCaption.value = document.getElementById("dashplayer-ttml-rendering") as HTMLDivElement;
+
+	if (!videoElem.value) {
+		console.error("Dash player video element not found");
+		return;
+	}
+	loadVideoSource();
+});
+
+function onReady() {
+	emit("ready");
+}
+
+function onPlaying() {
+	emit("playing");
+}
+
+function onPaused() {
+	emit("paused");
+}
+
+function onBuffering() {
+	emit("buffering");
+}
+function onProgress() {
+	if (videoElem.value) {
+		const buffered = videoElem.value.buffered;
+		emit("buffer-spans", buffered);
+		const duration = videoElem.value.duration;
+		const bufferedPercentage =
+			buffered && buffered.length && duration > 0 ? buffered.end(0) / duration : 0;
+		emit("buffer-progress", bufferedPercentage);
+	}
+}
+function onError(err: Event) {
+	emit("error");
+	console.error("HlsPlayer: video element error:", err);
+}
+
+onBeforeUnmount(() => {
+	dash.value?.destroy();
+});
+
+watch(videoUrl, () => {
+	console.log("HlsPlayer: videoUrl changed");
+	loadVideoSource();
+});
+
+defineExpose({
+	play,
+	pause,
+	setVolume,
+	getPosition,
+	setPosition,
+	isCaptionsSupported,
+	setCaptionsEnabled,
+	isCaptionsEnabled,
+	getCaptionsTracks,
+	setCaptionsTrack,
+	getAvailablePlaybackRates,
+	getPlaybackRate,
+	setPlaybackRate,
+} satisfies MediaPlayerWithCaptions & MediaPlayerWithPlaybackRate);
+</script>
+
+<style lang="scss">
+.dash {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	max-width: 100%;
+	max-height: 100%;
+	width: 100%;
+	height: 100%;
+}
+
+.dash video {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	object-position: 50% 50%;
+}
+</style>

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -74,6 +74,21 @@
 				@buffer-progress="onBufferProgress"
 				@buffer-spans="onBufferSpans"
 			/>
+			<DashPlayer
+				v-else-if="!!source && source.service == 'dash'"
+				ref="player"
+				:video-url="source.dash_url ?? source.id"
+				:thumbnail="source.thumbnail"
+				class="player"
+				@apiready="onApiReady"
+				@playing="onPlaying"
+				@paused="onPaused"
+				@ready="onReady"
+				@buffering="onBuffering"
+				@error="onError"
+				@buffer-progress="onBufferProgress"
+				@buffer-spans="onBufferSpans"
+			/>
 			<PlyrPlayer
 				v-else-if="!!source && ['direct', 'dash'].includes(source.service)"
 				ref="player"
@@ -150,6 +165,7 @@ const YoutubePlayer = defineAsyncComponent(() => import("./YoutubePlayer.vue"));
 const VimeoPlayer = defineAsyncComponent(() => import("./VimeoPlayer.vue"));
 const GoogleDrivePlayer = defineAsyncComponent(() => import("./GoogleDrivePlayer.vue"));
 const HlsPlayer = defineAsyncComponent(() => import("./HlsPlayer.vue"));
+const DashPlayer = defineAsyncComponent(() => import("./DashPlayer.vue"));
 const PlyrPlayer = defineAsyncComponent(() => import("./PlyrPlayer.vue"));
 const PeertubePlayer = defineAsyncComponent(() => import("./PeertubePlayer.vue"));
 

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -90,7 +90,7 @@
 				@buffer-spans="onBufferSpans"
 			/>
 			<PlyrPlayer
-				v-else-if="!!source && ['direct', 'dash'].includes(source.service)"
+				v-else-if="!!source && ['direct'].includes(source.service)"
 				ref="player"
 				:service="source.service"
 				:video-url="source.hls_url ?? source.id"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4385,6 +4385,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@svta/common-media-library@npm:^0.12.4":
+  version: 0.12.4
+  resolution: "@svta/common-media-library@npm:0.12.4"
+  checksum: 10c0/70830894d446d9d919deaa29492cfd3f1eee87b6065f6c505cdf9c36e6cee30b189438055d1c28b7e2f46e5b89d57072bdd5485ac42f45a8ac60d3c2603337df
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-arm64@npm:1.3.105":
   version: 1.3.105
   resolution: "@swc/core-darwin-arm64@npm:1.3.105"
@@ -7690,31 +7697,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcp-47-match@npm:^1.0.0, bcp-47-match@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "bcp-47-match@npm:1.0.3"
-  checksum: 10c0/f48377b5a0511ff77926ef9cb41befc6c006b562f83da80b3bdd32be45b07aeb9d0e315293407600eaa7211d8ab178c953043b17436b9ebaee22b882d573a31a
+"bcp-47-match@npm:^2.0.0, bcp-47-match@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "bcp-47-match@npm:2.0.3"
+  checksum: 10c0/ae5c202854df8a9ad4777dc3b49562578495a69164869f365a88c1a089837a9fbbce4c0c44f6f1a5e44c7841f47e91fe6fea00306ca49ce5ec95a7eb71f839c4
   languageName: node
   linkType: hard
 
-"bcp-47-normalize@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "bcp-47-normalize@npm:1.1.1"
+"bcp-47-normalize@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "bcp-47-normalize@npm:2.3.0"
   dependencies:
-    bcp-47: "npm:^1.0.0"
-    bcp-47-match: "npm:^1.0.0"
-  checksum: 10c0/3c6e873eb9b048892752c014db6276efa48636ed09b148e35b74725cafa8038fcef7816fdf9100ca88bbe6043ffb9b509d50c6a2b6be01687b5ddf7074197105
+    bcp-47: "npm:^2.0.0"
+    bcp-47-match: "npm:^2.0.0"
+  checksum: 10c0/c028251469dd31bb45871fe3bf3e6fb6b0989eb2e7d9fa709cdea0a38c3dff470f3ae164e88c7d685050a8253abfdcfe3a751d5a9f142ef3b0bcc498e9a5af90
   languageName: node
   linkType: hard
 
-"bcp-47@npm:^1.0.0":
-  version: 1.0.8
-  resolution: "bcp-47@npm:1.0.8"
+"bcp-47@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "bcp-47@npm:2.1.0"
   dependencies:
-    is-alphabetical: "npm:^1.0.0"
-    is-alphanumerical: "npm:^1.0.0"
-    is-decimal: "npm:^1.0.0"
-  checksum: 10c0/535f134503a57906cb1264fbfcae648768258131321ec9186883c4b83bf283aafc36a13e0f98dbd5aefa5b7022e4a9735724e465f9ea2518c550aa02ca284a9c
+    is-alphabetical: "npm:^2.0.0"
+    is-alphanumerical: "npm:^2.0.0"
+    is-decimal: "npm:^2.0.0"
+  checksum: 10c0/0b461b6d5bad215665e59bc57c4e1489312da541612558629e4f3d3538b16ce6c2709a4b62ec9ed6fca7a339740c27df6a454d5821a849b3df5ff7e697372885
   languageName: node
   linkType: hard
 
@@ -8398,10 +8405,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"codem-isoboxer@npm:0.3.9":
-  version: 0.3.9
-  resolution: "codem-isoboxer@npm:0.3.9"
-  checksum: 10c0/fcb4ed669a8aa4155b6a64bf640d43e6270783c2aaa1bd4298de9f36d0c10f31a77f3f6e84cc37428702f7a6ca16e5f13976907f60c4e871bddbcabcfd9470d9
+"codem-isoboxer@npm:0.3.10":
+  version: 0.3.10
+  resolution: "codem-isoboxer@npm:0.3.10"
+  checksum: 10c0/2df00af7ace2ba173d71ed95ed50774f486d2a54d3d979bb463f88cf8e551c83ff228ba625b7efdb9bfeddd22f3ad3ec717b5dc3e7176828eecf1b55dd8ee7e0
   languageName: node
   linkType: hard
 
@@ -9583,21 +9590,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dashjs@npm:4.7.1":
-  version: 4.7.1
-  resolution: "dashjs@npm:4.7.1"
+"dashjs@npm:5.0.3":
+  version: 5.0.3
+  resolution: "dashjs@npm:5.0.3"
   dependencies:
-    bcp-47-match: "npm:^1.0.3"
-    bcp-47-normalize: "npm:^1.1.1"
-    codem-isoboxer: "npm:0.3.9"
-    es6-promise: "npm:^4.2.8"
-    fast-deep-equal: "npm:2.0.1"
-    html-entities: "npm:^1.2.1"
-    imsc: "npm:^1.1.3"
-    localforage: "npm:^1.7.1"
+    "@svta/common-media-library": "npm:^0.12.4"
+    bcp-47-match: "npm:^2.0.3"
+    bcp-47-normalize: "npm:^2.3.0"
+    codem-isoboxer: "npm:0.3.10"
+    fast-deep-equal: "npm:3.1.3"
+    html-entities: "npm:^2.5.2"
+    imsc: "npm:^1.1.5"
+    localforage: "npm:^1.10.0"
     path-browserify: "npm:^1.0.1"
-    ua-parser-js: "npm:^1.0.2"
-  checksum: 10c0/188d4873bd0dbbe9a262f573cd4d26283488a4cd7a77c2e2de0a1998a555dfdb41107e20e63576b55669e25682af6d9b2c4a8ef57cdf921a365cd14e1a980ac0
+    ua-parser-js: "npm:^1.0.37"
+  checksum: 10c0/2e695c825e5621d0c36a603587fa2780afc074641da887e7b475c9b746b34a00ca817dfb6ceaf627e06fac8b7656d519b73ec3bc0c6f0b34b48235ad12e5033e
   languageName: node
   linkType: hard
 
@@ -10405,13 +10412,6 @@ __metadata:
     es5-ext: "npm:^0.10.35"
     es6-symbol: "npm:^3.1.1"
   checksum: 10c0/91f20b799dba28fb05bf623c31857fc1524a0f1c444903beccaf8929ad196c8c9ded233e5ac7214fc63a92b3f25b64b7f2737fcca8b1f92d2d96cf3ac902f5d8
-  languageName: node
-  linkType: hard
-
-"es6-promise@npm:^4.2.8":
-  version: 4.2.8
-  resolution: "es6-promise@npm:4.2.8"
-  checksum: 10c0/2373d9c5e9a93bdd9f9ed32ff5cb6dd3dd785368d1c21e9bbbfd07d16345b3774ae260f2bd24c8f836a6903f432b4151e7816a7fa8891ccb4e1a55a028ec42c3
   languageName: node
   linkType: hard
 
@@ -11409,14 +11409,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:2.0.1":
-  version: 2.0.1
-  resolution: "fast-deep-equal@npm:2.0.1"
-  checksum: 10c0/1602e0d6ed63493c865cc6b03f9070d6d3926e8cd086a123060b58f80a295f3f08b1ecfb479ae7c45b7fd45535202aea7cf5b49bc31bffb81c20b1502300be84
-  languageName: node
-  linkType: hard
-
-"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
+"fast-deep-equal@npm:3.1.3, fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
@@ -12557,10 +12550,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-entities@npm:^1.2.1":
-  version: 1.4.0
-  resolution: "html-entities@npm:1.4.0"
-  checksum: 10c0/eb2de616fb5948e681157805687672ea90e67c8a4f21a3215888ab422a984cab61fec96860708dca3bde0ae52577515683c8e28157ac8637220bb6a57a031b85
+"html-entities@npm:^2.5.2":
+  version: 2.6.0
+  resolution: "html-entities@npm:2.6.0"
+  checksum: 10c0/7c8b15d9ea0cd00dc9279f61bab002ba6ca8a7a0f3c36ed2db3530a67a9621c017830d1d2c1c65beb9b8e3436ea663e9cf8b230472e0e413359399413b27c8b7
   languageName: node
   linkType: hard
 
@@ -12838,12 +12831,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"imsc@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "imsc@npm:1.1.3"
+"imsc@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "imsc@npm:1.1.5"
   dependencies:
     sax: "npm:1.2.1"
-  checksum: 10c0/f8c78943ebdf8b0b38c32e55f1456a2ab31d14c34ec1b5777b5ad546346a2d28eaac72b3fa1510ef5df9f5c840319dbeb9018535ad51b6d2c056a9cc11f7d446
+  checksum: 10c0/e51014332569f9de1d2fda6eda407bf5c366f1b67fd268d37e24c191680b6f47597ff38ec2b47bc93a5d645991cfa222c29510bf6cbc4fb443db6856bb1ccbde
   languageName: node
   linkType: hard
 
@@ -12983,20 +12976,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-alphabetical@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "is-alphabetical@npm:1.0.4"
-  checksum: 10c0/1505b1de5a1fd74022c05fb21b0e683a8f5229366bac8dc4d34cf6935bcfd104d1125a5e6b083fb778847629f76e5bdac538de5367bdf2b927a1356164e23985
+"is-alphabetical@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-alphabetical@npm:2.0.1"
+  checksum: 10c0/932367456f17237533fd1fc9fe179df77957271020b83ea31da50e5cc472d35ef6b5fb8147453274ffd251134472ce24eb6f8d8398d96dee98237cdb81a6c9a7
   languageName: node
   linkType: hard
 
-"is-alphanumerical@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "is-alphanumerical@npm:1.0.4"
+"is-alphanumerical@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-alphanumerical@npm:2.0.1"
   dependencies:
-    is-alphabetical: "npm:^1.0.0"
-    is-decimal: "npm:^1.0.0"
-  checksum: 10c0/d623abae7130a7015c6bf33d99151d4e7005572fd170b86568ff4de5ae86ac7096608b87dd4a1d4dbbd497e392b6396930ba76c9297a69455909cebb68005905
+    is-alphabetical: "npm:^2.0.0"
+    is-decimal: "npm:^2.0.0"
+  checksum: 10c0/4b35c42b18e40d41378293f82a3ecd9de77049b476f748db5697c297f686e1e05b072a6aaae2d16f54d2a57f85b00cbbe755c75f6d583d1c77d6657bd0feb5a2
   languageName: node
   linkType: hard
 
@@ -13126,10 +13119,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-decimal@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "is-decimal@npm:1.0.4"
-  checksum: 10c0/a4ad53c4c5c4f5a12214e7053b10326711f6a71f0c63ba1314a77bd71df566b778e4ebd29f9fb6815f07a4dc50c3767fb19bd6fc9fa05e601410f1d64ffeac48
+"is-decimal@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-decimal@npm:2.0.1"
+  checksum: 10c0/8085dd66f7d82f9de818fba48b9e9c0429cb4291824e6c5f2622e96b9680b54a07a624cfc663b24148b8e853c62a1c987cfe8b0b5a13f5156991afaf6736e334
   languageName: node
   linkType: hard
 
@@ -14616,7 +14609,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"localforage@npm:^1.7.1":
+"localforage@npm:^1.10.0":
   version: 1.10.0
   resolution: "localforage@npm:1.10.0"
   dependencies:
@@ -16154,7 +16147,7 @@ __metadata:
     axios: "npm:1.7.4"
     cypress: "npm:13.7.1"
     cypress-real-events: "npm:^1.12.0"
-    dashjs: "npm:4.7.1"
+    dashjs: "npm:5.0.3"
     dayjs: "npm:^1.10.4"
     eslint: "npm:^8.57.0"
     eslint-plugin-cypress: "npm:^2.12.1"
@@ -21001,17 +20994,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^1.0.2":
-  version: 1.0.35
-  resolution: "ua-parser-js@npm:1.0.35"
-  checksum: 10c0/4641332fdf163ecdec4810cc2335932754f1b71527097f06005a658de256e22f5836a4a7860619c9e611d578e0451ff39dbff1a9b83c6615e3b0b3dd29588c30
-  languageName: node
-  linkType: hard
-
 "ua-parser-js@npm:^1.0.32":
   version: 1.0.37
   resolution: "ua-parser-js@npm:1.0.37"
   checksum: 10c0/dac8cf82a55b2e097bd2286954e01454c4cfcf23c9d9b56961ce94bda3cec5a38ca536e6e84c20a4000a9d4b4a4abcbd98ec634ccebe21be36595ea3069126e4
+  languageName: node
+  linkType: hard
+
+"ua-parser-js@npm:^1.0.37":
+  version: 1.0.41
+  resolution: "ua-parser-js@npm:1.0.41"
+  bin:
+    ua-parser-js: script/cli.js
+  checksum: 10c0/45dc1f7f3ce8248e0e64640d2e29c65c0ea1fc9cb105594de84af80e2a57bba4f718b9376098ca7a5b0ffe240f8995b0fa3714afa9d36861c41370a378f1a274
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR refactors DASH playback and introduces caption support:

- Dedicated DashPlayer.vue Component
  - DASH playback is now handled by a new DashPlayer component using dashjs.
  - DashPlayer supports captions (subtitles)
  - OmniPlayer now uses DashPlayer for DASH sources.
- Dependency Update
  - Upgrades dashjs to 5.0.3 and updates related dependencies.
- New DASH Test Streams with Captions
  - Adds two DASH test streams featuring single and multiple caption tracks to AddPreview.vue for easier testing.