### PR TITLE
fix: hls caption not showing when re-selecting a previously disabled track

### DIFF
--- a/client/src/components/players/HlsPlayer.vue
+++ b/client/src/components/players/HlsPlayer.vue
@@ -95,7 +95,9 @@ function setCaptionsEnabled(enabled: boolean): void {
 	if (!hls) {
 		return;
 	}
-	if (!enabled) {
+	if (enabled) {
+		setCaptionsTrack(captions.currentTrack.value || "");
+	} else {
 		hls.subtitleTrack = -1;
 	}
 }


### PR DESCRIPTION
Without this fix, if a user just selects a previously disabled track, that track won't show up in the player.

https://github.com/dyc3/opentogethertube/blob/c5dc255ecdfe8f9c76a881bca2d470c32b20c85f/client/src/components/players/HlsPlayer.vue#L94-L101
My current logic doesn't account for the fact that "captions.currentTrack.value" isn't updated in this specific scenario.