### PR TITLE
fix(server): Sequelize-cli now respects env files

### DIFF
--- a/server/config/config.mjs
+++ b/server/config/config.mjs
@@ -78,13 +78,13 @@ const conf = convict({
   },
 });
 try {
-  conf.load("../env/base.toml");
+  conf.loadFile("../env/base.toml");
 } catch {
   console.log("No base config found");
 }
 const env = process.env.NODE_ENV || "development";
 try {
-  conf.load(`../env/${env}.toml`);
+  conf.loadFile(`../env/${env}.toml`);
 } catch {
   console.log(`No ${env} config found`);
 }


### PR DESCRIPTION
This pr updates server/config/config.mjs for

1. TOML parsing
2. Fix typo? (Replaced the use of conf.load with conf.loadFile)