### PR TITLE
refactor(client): migrate from @mdi/font to @mdi/js for smaller bundle

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "cy:run": "cypress run --component"
   },
   "dependencies": {
-    "@mdi/font": "^3.9.97",
+    "@mdi/js": "^7.4.47",
     "@peertube/embed-api": "^0.0.6",
     "@vimeo/player": "^2.20.1",
     "@vueuse/core": "^9.6.0",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -34,11 +34,11 @@
 					href="https://github.com/dyc3/opentogethertube/issues/new/choose"
 					target="_blank"
 				>
-					<v-icon class="side-pad">mdi-bug</v-icon>
+					<v-icon class="side-pad" :icon="mdiBug" />
 					{{ $t("nav.bug") }}
 				</v-btn>
 				<v-btn variant="text" href="https://github.com/sponsors/dyc3" target="_blank">
-					<v-icon class="side-pad">mdi-heart</v-icon>
+					<v-icon class="side-pad" :icon="mdiHeart" />
 					{{ $t("nav.support") }}
 				</v-btn>
 			</v-toolbar-items>
@@ -47,7 +47,7 @@
 				<v-menu offset-y>
 					<template v-slot:activator="{ props }">
 						<v-btn variant="text" v-bind="props">
-							<v-icon class="side-pad">mdi-plus-box</v-icon>
+							<v-icon class="side-pad" :icon="mdiPlusBox" />
 							{{ $t("nav.create.title") }}
 						</v-btn>
 					</template>
@@ -84,13 +84,13 @@
 					target="_blank"
 				>
 					<template #prepend>
-						<v-icon>mdi-bug</v-icon>
+						<v-icon :icon="mdiBug" />
 					</template>
 					{{ $t("nav.bug") }}
 				</v-list-item>
 				<v-list-item href="https://github.com/sponsors/dyc3" target="_blank">
 					<template #prepend>
-						<v-icon>mdi-heart</v-icon>
+						<v-icon :icon="mdiHeart" />
 					</template>
 					{{ $t("nav.support") }}
 				</v-list-item>
@@ -138,6 +138,7 @@
 </template>
 
 <script lang="ts">
+import { mdiBug, mdiHeart, mdiPlusBox } from "@mdi/js";
 import { defineComponent, onMounted, ref, computed } from "vue";
 import { API } from "@/common-http";
 import CreateRoomForm from "@/components/CreateRoomForm.vue";
@@ -152,7 +153,7 @@ import logoUrl from "@/assets/logo.svg";
 import { useStore } from "@/store";
 import LocaleSelector from "@/components/navbar/LocaleSelector.vue";
 
-export const App = defineComponent({
+const App = defineComponent({
 	name: "app",
 	components: {
 		CreateRoomForm,
@@ -240,6 +241,9 @@ export const App = defineComponent({
 			createTempRoom,
 			logoUrl,
 			store,
+			mdiBug,
+			mdiHeart,
+			mdiPlusBox,
 		};
 	},
 });

--- a/client/src/components/AddPreview.vue
+++ b/client/src/components/AddPreview.vue
@@ -13,7 +13,7 @@
 					@keydown="onInputAddPreviewKeyDown"
 					@focus="onFocusHighlightText"
 					:loading="isLoadingAddPreview"
-					prepend-inner-icon="mdi-magnify"
+					:prepend-inner-icon="mdiMagnify"
 					base-color="primary"
 					color="primary"
 					persistent-clear
@@ -37,7 +37,7 @@
 				@click="addAllToQueue()"
 				:loading="isLoadingAddAll"
 				:disabled="isLoadingAddAll"
-				prepend-icon="mdi-plus"
+				:prepend-icon="mdiPlus"
 			>
 				{{ $t("add-preview.add-all") }}
 			</v-btn>
@@ -93,6 +93,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiMagnify, mdiPlus } from "@mdi/js";
 import { ref, computed, watch, Ref } from "vue";
 import { useRoute } from "vue-router";
 import { useStore } from "@/store";

--- a/client/src/components/Chat.vue
+++ b/client/src/components/Chat.vue
@@ -13,7 +13,7 @@
 				data-cy="chat-deactivate"
 				aria-label="close chat"
 			>
-				<v-icon>mdi-chevron-down</v-icon>
+				<v-icon :icon="mdiChevronDown" />
 			</v-btn>
 			<h4>{{ $t("chat.title") }}</h4>
 		</div>
@@ -37,7 +37,7 @@
 		</div>
 		<div v-if="!stickToBottom" class="to-bottom">
 			<v-btn size="x-small" icon @click="forceToBottom">
-				<v-icon>mdi-chevron-double-down</v-icon>
+				<v-icon :icon="mdiChevronDoubleDown" />
 			</v-btn>
 		</div>
 		<Transition name="input" @after-enter="enforceStickToBottom">
@@ -66,13 +66,14 @@
 				data-cy="chat-activate"
 				aria-label="open chat"
 			>
-				<v-icon>mdi-comment-outline</v-icon>
+				<v-icon :icon="mdiCommentOutline" />
 			</v-btn>
 		</div>
 	</div>
 </template>
 
 <script lang="ts" setup>
+import { mdiChevronDown, mdiChevronDoubleDown, mdiCommentOutline } from "@mdi/js";
 import { onUpdated, ref, type Ref, nextTick, onMounted, onUnmounted } from "vue";
 import type { ChatMessage } from "ott-common/models/types";
 import { useConnection } from "@/plugins/connection";

--- a/client/src/components/ClientSettingsDialog.vue
+++ b/client/src/components/ClientSettingsDialog.vue
@@ -48,8 +48,8 @@
 				<v-checkbox
 					:label="$t('client-settings.room-settings')"
 					v-model="showRoomSettings"
-					false-icon="mdi-chevron-up"
-					true-icon="mdi-chevron-down"
+					:false-icon="mdiChevronUp"
+					:true-icon="mdiChevronDown"
 				/>
 
 				<v-expand-transition>
@@ -75,6 +75,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiChevronUp, mdiChevronDown } from "@mdi/js";
 import { Ref, ref, watch } from "vue";
 import { useStore } from "@/store";
 import { SettingsState, RoomLayoutMode, Theme } from "@/stores/settings";

--- a/client/src/components/CreateRoomForm.vue
+++ b/client/src/components/CreateRoomForm.vue
@@ -16,8 +16,8 @@
 				<v-checkbox
 					v-model="showSettings"
 					:label="$t('room.tabs.settings')"
-					false-icon="mdi-chevron-up"
-					true-icon="mdi-chevron-down"
+					:false-icon="mdiChevronUp"
+					:true-icon="mdiChevronDown"
 				/>
 				<v-expand-transition>
 					<div v-if="showSettings">
@@ -78,6 +78,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiChevronUp, mdiChevronDown } from "@mdi/js";
 import { onMounted, reactive, Ref, ref, watch } from "vue";
 import { createRoomHelper } from "@/util/roomcreator";
 import { ROOM_NAME_REGEX } from "ott-common/constants";

--- a/client/src/components/ShareInvite.vue
+++ b/client/src/components/ShareInvite.vue
@@ -12,7 +12,7 @@
 					:class="copySuccess ? 'text-success' : ''"
 					ref="inviteLinkText"
 					:value="inviteLink"
-					append-icon="mdi-clipboard-outline"
+					:append-icon="mdiClipboardOutline"
 					:messages="copySuccess ? $t('share-invite.copied') : ''"
 					@focus="onFocusHighlightText"
 					@click:append="copyInviteLink"
@@ -24,6 +24,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiClipboardOutline } from "@mdi/js";
 import { ref, computed } from "vue";
 import { useStore } from "@/store";
 import { useCopyFromTextbox } from "./composables";

--- a/client/src/components/ToastNotification.vue
+++ b/client/src/components/ToastNotification.vue
@@ -1,8 +1,6 @@
 <template>
 	<v-sheet :color="color" class="toast" elevation="12" aria-live="polite">
-		<v-icon class="toast-icon" v-if="!!icon">
-			{{ icon }}
-		</v-icon>
+		<v-icon class="toast-icon" v-if="!!icon" :icon="icon" />
 		<span class="toast-content">
 			<ProcessedText :text="toast.content" :show-add-queue-tooltip="false" />
 		</span>
@@ -18,13 +16,14 @@
 				icon
 				:aria-label="$t('common.close')"
 			>
-				<v-icon>mdi-close</v-icon>
+				<v-icon :icon="mdiClose" />
 			</v-btn>
 		</div>
 	</v-sheet>
 </template>
 
 <script lang="ts" setup>
+import { mdiClose, mdiCheckBold, mdiAlertCircle } from "@mdi/js";
 import { ref, toRefs, onMounted, onUnmounted, Ref, computed } from "vue";
 import { Toast, ToastStyle } from "@/models/toast";
 import { RoomRequestType } from "ott-common/models/messages";
@@ -66,9 +65,9 @@ const color = computed(() => {
 
 const icon = computed(() => {
 	if (toast.value.style === ToastStyle.Success) {
-		return "mdi-check-bold";
+		return mdiCheckBold;
 	} else if (toast.value.style === ToastStyle.Error) {
-		return "mdi-alert-circle";
+		return mdiAlertCircle;
 	}
 	return undefined;
 });

--- a/client/src/components/UserList.vue
+++ b/client/src/components/UserList.vue
@@ -3,7 +3,7 @@
 		<v-card-title>
 			{{ $t("room.users.title") }}
 			<v-btn icon size="x-small" @click="openEditName" aria-label="toggle edit name">
-				<v-icon>mdi-wrench</v-icon>
+				<v-icon :icon="mdiWrench" />
 			</v-btn>
 		</v-card-title>
 		<v-list-item v-if="showEditName">
@@ -64,8 +64,8 @@
 
 				<div v-if="user.id !== store.state.users.you.id">
 					<v-btn class="user-actions" variant="flat" depressed tile>
-						<v-icon size="small">mdi-wrench</v-icon>
-						<v-icon size="small" style="margin-left: 5px">mdi-chevron-down</v-icon>
+						<v-icon size="small" :icon="mdiWrench" />
+						<v-icon size="small" style="margin-left: 5px" :icon="mdiChevronDown" />
 						<v-menu right offset-y activator="parent">
 							<v-list>
 								<div class="user-promotion">
@@ -104,6 +104,16 @@
 </template>
 
 <script lang="ts" setup>
+import {
+	mdiWrench,
+	mdiChevronDown,
+	mdiStar,
+	mdiChevronUp,
+	mdiThumbUp,
+	mdiProgressDownload,
+	mdiCheckBold,
+	mdiExclamation,
+} from "@mdi/js";
 import { ref, inject } from "vue";
 import { API } from "@/common-http";
 import { ClientId, PlayerStatus, RoomUserInfo } from "ott-common/models/types";
@@ -199,18 +209,18 @@ function canSelfKickUser(user: RoomUserInfo): boolean {
 
 function getRoleIcon(role: Role) {
 	return {
-		[Role.Owner]: "mdi-star",
-		[Role.Administrator]: "mdi-star",
-		[Role.Moderator]: "mdi-chevron-up",
-		[Role.TrustedUser]: "mdi-thumb-up",
+		[Role.Owner]: mdiStar,
+		[Role.Administrator]: mdiStar,
+		[Role.Moderator]: mdiChevronUp,
+		[Role.TrustedUser]: mdiThumbUp,
 	}[role];
 }
 
 function getPlayerStatusIcon(status: PlayerStatus) {
 	return {
-		[PlayerStatus.buffering]: "mdi-progress-download",
-		[PlayerStatus.ready]: "mdi-check-bold",
-		[PlayerStatus.error]: "mdi-exclamation",
+		[PlayerStatus.buffering]: mdiProgressDownload,
+		[PlayerStatus.ready]: mdiCheckBold,
+		[PlayerStatus.error]: mdiExclamation,
 	}[status];
 }
 

--- a/client/src/components/VideoQueue.vue
+++ b/client/src/components/VideoQueue.vue
@@ -8,7 +8,7 @@
 							{{ $t("video-queue.no-videos") }}
 						</div>
 						<v-btn size="x-large" block @click="$emit('switchtab')">
-							<v-icon style="margin-right: 8px">mdi-plus</v-icon>
+							<v-icon style="margin-right: 8px" :icon="mdiPlus" />
 							{{ $t("video-queue.add-video") }}
 						</v-btn>
 					</div>
@@ -17,7 +17,7 @@
 		</div>
 		<div class="queue-controls" v-if="store.state.room.queue.length > 0">
 			<v-btn icon @click="roomapi.shuffle()">
-				<v-icon>mdi-shuffle-variant</v-icon>
+				<v-icon :icon="mdiShuffleVariant" />
 			</v-btn>
 			<v-dialog v-model="exportDialog" width="600">
 				<template v-slot:activator="{ props }">
@@ -63,6 +63,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiPlus, mdiShuffleVariant } from "@mdi/js";
 import { ref, computed } from "vue";
 import VideoQueueItem from "@/components/VideoQueueItem.vue";
 import { useStore } from "@/store";

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -15,7 +15,7 @@
 						granted('manage-queue.order')
 					"
 				>
-					<v-icon>mdi-format-align-justify</v-icon>
+					<v-icon :icon="mdiFormatAlignJustify" />
 				</span>
 				<span class="video-length">{{ videoLength }}</span>
 			</v-img>
@@ -43,7 +43,7 @@
 					data-cy="btn-vote"
 				>
 					<span>{{ votes }}</span>
-					<v-icon>mdi-thumb-up</v-icon>
+					<v-icon :icon="mdiThumbUp" />
 					<span class="vote-text">
 						{{ voted ? $t("common.unvote") : $t("common.vote") }}
 					</span>
@@ -56,7 +56,7 @@
 					:disabled="!granted('manage-queue.play-now')"
 					data-cy="btn-play-now"
 				>
-					<v-icon>mdi-play</v-icon>
+					<v-icon :icon="mdiPlay" />
 					<v-tooltip activator="parent" location="top">
 						<span>{{ $t("video.playnow-explanation") }}</span>
 					</v-tooltip>
@@ -69,9 +69,9 @@
 					v-if="isPreview && store.state.room.queueMode !== QueueMode.Dj"
 					data-cy="btn-add-to-queue"
 				>
-					<v-icon v-if="hasError">mdi-exclamation</v-icon>
-					<v-icon v-else-if="hasBeenAdded">mdi-check-bold</v-icon>
-					<v-icon v-else>mdi-plus</v-icon>
+					<v-icon v-if="hasError" :icon="mdiExclamation" />
+					<v-icon v-else-if="hasBeenAdded" :icon="mdiCheckBold" />
+					<v-icon v-else :icon="mdiPlus" />
 					<v-tooltip activator="parent" location="top">
 						<span>{{ $t("video.add-explanation") }}</span>
 					</v-tooltip>
@@ -85,13 +85,13 @@
 					@click="removeFromQueue"
 					data-cy="btn-remove-from-queue"
 				>
-					<v-icon v-if="hasError">mdi-exclamation</v-icon>
-					<v-icon v-else>mdi-trash-can</v-icon>
+					<v-icon v-if="hasError" :icon="mdiExclamation" />
+					<v-icon v-else :icon="mdiTrashCan" />
 				</v-btn>
 				<v-menu offset-y>
 					<template v-slot:activator="{ props: p }">
 						<v-btn icon variant="flat" v-bind="p" data-cy="btn-menu">
-							<v-icon>mdi-dots-vertical</v-icon>
+							<v-icon :icon="mdiDotsVertical" />
 						</v-btn>
 					</template>
 					<v-list>
@@ -102,7 +102,7 @@
 							:disabled="!granted('manage-queue.play-now')"
 							data-cy="menu-btn-play-now"
 						>
-							<v-icon>mdi-play</v-icon>
+							<v-icon :icon="mdiPlay" />
 							<span>{{ $t("video.playnow") }}</span>
 						</v-list-item>
 						<v-list-item
@@ -115,7 +115,7 @@
 							"
 							data-cy="menu-btn-move-to-top"
 						>
-							<v-icon>mdi-sort-descending</v-icon>
+							<v-icon :icon="mdiSortDescending" />
 							<span>{{ $t("video-queue-item.play-next") }}</span>
 						</v-list-item>
 						<v-list-item
@@ -124,7 +124,7 @@
 							v-if="!isPreview && store.state.room.queueMode !== QueueMode.Vote"
 							data-cy="menu-btn-move-to-bottom"
 						>
-							<v-icon>mdi-sort-ascending</v-icon>
+							<v-icon :icon="mdiSortAscending" />
 							<span>{{ $t("video-queue-item.play-last") }}</span>
 						</v-list-item>
 						<v-list-item
@@ -133,9 +133,9 @@
 							@click="addToQueue"
 							data-cy="menu-btn-add-to-queue"
 						>
-							<v-icon v-if="hasError">mdi-exclamation</v-icon>
-							<v-icon v-else-if="hasBeenAdded">mdi-check-bold</v-icon>
-							<v-icon v-else>mdi-plus</v-icon>
+							<v-icon v-if="hasError" :icon="mdiExclamation" />
+							<v-icon v-else-if="hasBeenAdded" :icon="mdiCheckBold" />
+							<v-icon v-else :icon="mdiPlus" />
 							<span>{{ $t("common.add") }}</span>
 						</v-list-item>
 						<v-list-item
@@ -144,7 +144,7 @@
 							v-if="!isPreview && store.state.room.queueMode === QueueMode.Dj"
 							data-cy="menu-btn-remove-from-queue"
 						>
-							<v-icon>mdi-trash-can</v-icon>
+							<v-icon :icon="mdiTrashCan" />
 							<span>{{ $t("common.remove") }}</span>
 						</v-list-item>
 					</v-list>
@@ -155,6 +155,18 @@
 </template>
 
 <script lang="ts" setup>
+import {
+	mdiFormatAlignJustify,
+	mdiThumbUp,
+	mdiPlay,
+	mdiExclamation,
+	mdiCheckBold,
+	mdiPlus,
+	mdiTrashCan,
+	mdiDotsVertical,
+	mdiSortDescending,
+	mdiSortAscending,
+} from "@mdi/js";
 import { ref, toRefs, computed, watchEffect } from "vue";
 import { API } from "@/common-http";
 import { secondsToTimestamp } from "@/util/timestamp";

--- a/client/src/components/controls/BasicControls.vue
+++ b/client/src/components/controls/BasicControls.vue
@@ -8,7 +8,7 @@
 			class="media-control"
 			:aria-label="$t('room.rewind')"
 		>
-			<v-icon>mdi-chevron-left</v-icon>
+			<v-icon :icon="mdiChevronLeft" />
 			<v-tooltip activator="parent" location="bottom">
 				<span>{{ $t("room.rewind") }}</span>
 			</v-tooltip>
@@ -21,7 +21,7 @@
 			class="media-control"
 			:aria-label="$t('room.play-pause')"
 		>
-			<v-icon :icon="store.state.room.isPlaying ? 'mdi-pause' : 'mdi-play'" />
+			<v-icon :icon="store.state.room.isPlaying ? mdiPause : mdiPlay" />
 			<v-tooltip activator="parent" location="bottom">
 				<span>{{ $t("room.play-pause") }}</span>
 			</v-tooltip>
@@ -34,7 +34,7 @@
 			class="media-control"
 			:aria-label="$t('room.skip')"
 		>
-			<v-icon>mdi-chevron-right</v-icon>
+			<v-icon :icon="mdiChevronRight" />
 			<v-tooltip activator="parent" location="bottom">
 				<span>{{ $t("room.skip") }}</span>
 			</v-tooltip>
@@ -49,7 +49,7 @@
 				store.state.room.enableVoteSkip ? $t('room.next-video-vote') : $t('room.next-video')
 			"
 		>
-			<v-icon>mdi-skip-forward</v-icon>
+			<v-icon :icon="mdiSkipForward" />
 			<v-tooltip activator="parent" location="bottom">
 				<span>
 					{{
@@ -64,6 +64,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiChevronLeft, mdiPlay, mdiPause, mdiChevronRight, mdiSkipForward } from "@mdi/js";
 import _ from "lodash";
 import { useStore } from "@/store";
 import { useConnection } from "@/plugins/connection";

--- a/client/src/components/controls/ClosedCaptionsSwitcher.vue
+++ b/client/src/components/controls/ClosedCaptionsSwitcher.vue
@@ -6,7 +6,7 @@
 		class="media-control"
 		aria-label="Closed Captions"
 	>
-		<v-icon>mdi-closed-caption</v-icon>
+		<v-icon :icon="mdiClosedCaption" />
 		<v-menu location="top" offset-y activator="parent" :disabled="!supported">
 			<v-list>
 				<v-list-item
@@ -47,6 +47,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiClosedCaption } from "@mdi/js";
 import { useCaptions } from "../composables";
 
 const captions = useCaptions();

--- a/client/src/components/controls/LayoutSwitcher.vue
+++ b/client/src/components/controls/LayoutSwitcher.vue
@@ -10,10 +10,9 @@
 		<v-icon
 			v-if="store.state.settings.roomLayout === 'theater'"
 			style="transform: scaleX(180%)"
-		>
-			mdi-square-outline
-		</v-icon>
-		<v-icon v-else style="transform: scaleX(130%)"> mdi-square-outline </v-icon>
+			:icon="mdiSquareOutline"
+		/>
+		<v-icon v-else style="transform: scaleX(130%)" :icon="mdiSquareOutline" />
 	</v-btn>
 	<v-btn
 		variant="text"
@@ -22,7 +21,7 @@
 		class="media-control"
 		:aria-label="$t('room.toggle-fullscreen')"
 	>
-		<v-icon>mdi-fullscreen-exit</v-icon>
+		<v-icon :icon="mdiFullscreenExit" />
 		<v-tooltip activator="parent" location="bottom">
 			<span>{{ $t("room.toggle-fullscreen") }}</span>
 		</v-tooltip>
@@ -30,6 +29,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiSquareOutline, mdiFullscreenExit } from "@mdi/js";
 import { computed, onMounted } from "vue";
 import { useStore } from "@/store";
 import { RoomLayoutMode } from "@/stores/settings";

--- a/client/src/components/navbar/NavCreateRoom.vue
+++ b/client/src/components/navbar/NavCreateRoom.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-list-item @click="$emit('createtemp')">
 		<template #prepend>
-			<v-icon>mdi-plus-box</v-icon>
+			<v-icon :icon="mdiPlusBox" />
 		</template>
 		<v-list-item-title>{{ $t("nav.create.temp") }}</v-list-item-title>
 		<v-list-item-subtitle class="text-muted">{{
@@ -10,7 +10,7 @@
 	</v-list-item>
 	<v-list-item @click="$emit('createperm')">
 		<template #prepend>
-			<v-icon>mdi-plus-box</v-icon>
+			<v-icon :icon="mdiPlusBox" />
 		</template>
 		<v-list-item-title>{{ $t("nav.create.perm") }}</v-list-item-title>
 		<v-list-item-subtitle class="text-muted">{{
@@ -20,5 +20,6 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiPlusBox } from "@mdi/js";
 defineEmits(["createtemp", "createperm"]);
 </script>

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -14,7 +14,7 @@
 							icon
 							@click="showBufferWarning = false"
 						>
-							<v-icon>mdi-close</v-icon>
+							<v-icon :icon="mdiClose" />
 						</v-btn>
 					</div>
 				</v-container>
@@ -132,6 +132,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiClose } from "@mdi/js";
 import { useStore } from "@/store";
 import { isInTimeRanges, secondsToTimestamp } from "@/util/timestamp";
 import { PlayerStatus } from "ott-common/models/types";

--- a/client/src/plugins/vuetify.ts
+++ b/client/src/plugins/vuetify.ts
@@ -1,9 +1,8 @@
 import "vuetify/styles";
-import "@mdi/font/css/materialdesignicons.css";
 import { createVuetify, type ThemeDefinition } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
-import { mdi } from "vuetify/iconsets/mdi";
+import { aliases, mdi } from "vuetify/iconsets/mdi-svg";
 
 const themeDark: ThemeDefinition = {
 	dark: true,
@@ -89,6 +88,7 @@ const vuetify = createVuetify({
 	directives,
 	icons: {
 		defaultSet: "mdi",
+		aliases,
 		sets: {
 			mdi,
 		},

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -130,7 +130,7 @@
 								href="https://github.com/sponsors/dyc3"
 								target="_blank"
 							>
-								<v-icon class="side-pad">mdi-heart</v-icon>
+								<v-icon class="side-pad" :icon="mdiHeart" />
 								{{ $t("landing.support.sponsor") }}
 							</v-btn>
 							<v-btn
@@ -141,7 +141,7 @@
 								href="https://github.com/dyc3/opentogethertube"
 								target="_blank"
 							>
-								<v-icon class="side-pad">mdi-xml</v-icon>
+								<v-icon class="side-pad" :icon="mdiXml" />
 								{{ $t("landing.support.contribute") }}
 							</v-btn>
 						</v-col>
@@ -179,6 +179,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiHeart, mdiXml } from "@mdi/js";
 import { computed } from "vue";
 import { createRoomHelper } from "@/util/roomcreator";
 import { useStore } from "@/store";

--- a/client/src/views/MyRooms.vue
+++ b/client/src/views/MyRooms.vue
@@ -40,7 +40,7 @@
 								color="error"
 								@click.stop.prevent="openDeleteDialog(room)"
 							>
-								<v-icon icon="mdi-delete" />
+								<v-icon :icon="mdiDelete" />
 							</v-btn>
 						</template>
 					</v-list-item>
@@ -72,6 +72,7 @@
 </template>
 
 <script lang="ts" setup>
+import { mdiDelete } from "@mdi/js";
 import { API } from "@/common-http";
 import { ref, onMounted } from "vue";
 import { createRoomHelper } from "@/util/roomcreator";

--- a/client/src/views/Room.vue
+++ b/client/src/views/Room.vue
@@ -41,7 +41,7 @@
 						</div>
 						<div class="playback-blocked-prompt" v-if="mediaPlaybackBlocked">
 							<v-btn
-								prepend-icon="mdi-play"
+								:prepend-icon="mdiPlay"
 								size="x-large"
 								color="warning"
 								@click="onClickUnblockPlayback"
@@ -73,7 +73,7 @@
 				<div class="under-video-tabs">
 					<v-tabs fixed-tabs v-model="queueTab" color="primary">
 						<v-tab>
-							<v-icon>mdi-format-list-bulleted</v-icon>
+							<v-icon :icon="mdiFormatListBulleted" />
 							<span class="tab-text">{{ $t("room.tabs.queue") }}</span>
 							<v-chip size="x-small">
 								{{
@@ -84,11 +84,11 @@
 							</v-chip>
 						</v-tab>
 						<v-tab>
-							<v-icon>mdi-plus</v-icon>
+							<v-icon :icon="mdiPlus" />
 							<span class="tab-text">{{ $t("common.add") }}</span>
 						</v-tab>
 						<v-tab>
-							<v-icon>mdi-wrench</v-icon>
+							<v-icon :icon="mdiWrench" />
 							<span class="tab-text">{{ $t("room.tabs.settings") }}</span>
 						</v-tab>
 					</v-tabs>
@@ -193,6 +193,7 @@
 </template>
 
 <script lang="ts">
+import { mdiPlay, mdiFormatListBulleted, mdiPlus, mdiWrench } from "@mdi/js";
 import {
 	defineComponent,
 	ref,
@@ -711,6 +712,12 @@ export default defineComponent({
 			mediaPlaybackBlocked,
 			onClickUnblockPlayback,
 			secondsToTimestamp,
+
+			// MDI Icons
+			mdiPlay,
+			mdiFormatListBulleted,
+			mdiPlus,
+			mdiWrench,
 		};
 	},
 });

--- a/client/src/views/RoomList.vue
+++ b/client/src/views/RoomList.vue
@@ -26,7 +26,7 @@
 						v-if="$vuetify.display.smAndUp"
 					>
 						<span class="subtitle-2 users">
-							{{ room.users }} <v-icon small>mdi-account-multiple</v-icon>
+							{{ room.users }} <v-icon small :icon="mdiAccountMultiple" />
 						</span>
 					</v-img>
 					<v-card-title>
@@ -57,6 +57,7 @@
 </template>
 
 <script lang="ts">
+import { mdiAccountMultiple } from "@mdi/js";
 import { API } from "@/common-http";
 import { defineComponent, ref, onMounted } from "vue";
 import { createRoomHelper } from "@/util/roomcreator";
@@ -87,6 +88,7 @@ const RoomListView = defineComponent({
 
 			createRoom,
 			placeholderUrl,
+			mdiAccountMultiple,
 		};
 	},
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3405,10 +3405,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdi/font@npm:^3.9.97":
-  version: 3.9.97
-  resolution: "@mdi/font@npm:3.9.97"
-  checksum: 10c0/1ddb0a49f870ad98018c35503db811d2bc469769d0510e79fa4022e131801178c072b92b8499b2af96e73a474ead968ef0a61675d7a3c565abc011c3402ad46b
+"@mdi/js@npm:^7.4.47":
+  version: 7.4.47
+  resolution: "@mdi/js@npm:7.4.47"
+  checksum: 10c0/4364d4dff943c630f9cdddba1a74d3713654e4da1b85bc7a307b2285447a57c41434a39a8520b39957df1028186a2e5944102fd1386d6c0c73e709335f5ccb3e
   languageName: node
   linkType: hard
 
@@ -16506,7 +16506,7 @@ __metadata:
   resolution: "ott-client@workspace:client"
   dependencies:
     "@cypress/vue": "npm:^5.0.3"
-    "@mdi/font": "npm:^3.9.97"
+    "@mdi/js": "npm:^7.4.47"
     "@peertube/embed-api": "npm:^0.0.6"
     "@types/video.js": "npm:^7.3.29"
     "@types/vimeo__player": "npm:^2.16.0"


### PR DESCRIPTION
This pr updates how material design icons are used throughout the client codebase to get smaller bundle