### PR TITLE
(Deployment) Add SBOM and Provenance for Docker-compose build

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,10 @@
-version: "3.7"
 services:
   opentogethertube:
     image: opentogethertube
     build:
       context: ../
+      sbom: true
+      provenance: mode=max
       dockerfile: deploy/monolith.Dockerfile
       target: docker-stage
       args:

--- a/docker/with-balancer.docker-compose.yml
+++ b/docker/with-balancer.docker-compose.yml
@@ -1,9 +1,10 @@
-version: "3.7"
 services:
   opentogethertube:
     image: opentogethertube
     build:
       context: ../
+      sbom: true
+      provenance: mode=max
       dockerfile: deploy/monolith.Dockerfile
       target: docker-stage
       args:


### PR DESCRIPTION
As mentioned in #1864 I changed the Docker compose files for the builds to build with sbom and provenance mode max to provide the described benefits from it.

Closes #1864

Tested on my local device / server.
