### PR TITLE
fix(client): "auto" is not supported to show if isAutoQualitySupported is false

### DIFF
--- a/client/src/components/controls/VideoQualitySwitcher.vue
+++ b/client/src/components/controls/VideoQualitySwitcher.vue
@@ -12,7 +12,7 @@
 				<v-list-item
 					link
 					@click="setVideosTrack(-1)"
-					v-if="qualities.isAutoQualitySupported"
+					v-if="qualities.isAutoQualitySupported.value"
 					:active="qualities.currentVideoTrack.value == -1"
 					color="primary"
 					variant="plain"

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -222,6 +222,7 @@ watch(player, v => {
 	} else {
 		captions.isCaptionsSupported.value = false;
 		qualities.isQualitySupported.value = false;
+		qualities.isAutoQualitySupported.value = false;
 		playbackRate.availablePlaybackRates.value = [1];
 	}
 });
@@ -277,6 +278,7 @@ async function onApiReady() {
 	}
 	if (implementsQualities(player.value)) {
 		qualities.videoTracks.value = player.value.getVideoTracks();
+		qualities.isAutoQualitySupported.value = player.value.isAutoQualitySupported();
 	}
 	if (implementsPlaybackRate(player.value)) {
 		playbackRate.availablePlaybackRates.value = player.value.getAvailablePlaybackRates();


### PR DESCRIPTION
We currently don't have a service that supports quality, but lacks support for auto quality.
I only noticed this issue while I was testing something for my ott instance.