### PR TITLE
Revert "(Deployment) Add SBOM and Provenance for Docker-compose build"

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,9 @@
+version: "3.7"
 services:
   opentogethertube:
     image: opentogethertube
     build:
       context: ../
-      sbom: true
-      provenance: mode=max
       dockerfile: deploy/monolith.Dockerfile
       target: docker-stage
       args:

--- a/docker/with-balancer.docker-compose.yml
+++ b/docker/with-balancer.docker-compose.yml
@@ -1,10 +1,9 @@
+version: "3.7"
 services:
   opentogethertube:
     image: opentogethertube
     build:
       context: ../
-      sbom: true
-      provenance: mode=max
       dockerfile: deploy/monolith.Dockerfile
       target: docker-stage
       args:


### PR DESCRIPTION
Reverts dyc3/opentogethertube#1905 because the docker build started failing

https://github.com/dyc3/opentogethertube/actions/runs/18349550350/job/52265797388

```
validating /home/runner/work/opentogethertube/opentogethertube/docker/docker-compose.yml: services.opentogethertube.build additional properties 'sbom', 'provenance' not allowed
```