### PR TITLE
Fix(client): Fix incorrect logic for caption isEnabled

### DIFF
--- a/client/src/components/controls/VideoSettings.vue
+++ b/client/src/components/controls/VideoSettings.vue
@@ -160,8 +160,8 @@ const isCaptionsSupported = computed(
 
 const currentSubtitleDisplay = computed(() => {
 	const isEnabled =
-		isCaptionsSupported.value ||
-		captions.isCaptionsEnabled.value ||
+		isCaptionsSupported.value &&
+		captions.isCaptionsEnabled.value &&
 		captions.currentTrack.value !== null;
 	const track = captions.captionsTracks.value[captions.currentTrack.value || 0];
 	return isEnabled ? formatCaption(track) : "disabled";


### PR DESCRIPTION
This PR fixes the logic to determind if the current subtitle is enabled in the `VideoSettings.vue` component.