### PR TITLE
fix: reject newlines in room title validation

### DIFF
--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -30,7 +30,11 @@ export const OttApiRequestRoomCreateSchema = z
 			.refine(name => !RESERVED_ROOM_NAMES.includes(name), {
 				message: "not allowed (reserved)",
 			}),
-		title: z.string().max(255, "too long, must be at most 255 characters").optional(),
+		title: z
+			.string()
+			.max(255, "too long, must be at most 255 characters")
+			.refine(s => !/[\n\r]/.test(s), { message: "must not contain newlines" })
+			.optional(),
 		description: z.string().optional(),
 		isTemporary: z.boolean().optional().default(true),
 		visibility: z.nativeEnum(Visibility).default(Visibility.Public).optional(),
@@ -79,7 +83,11 @@ const GrantSchema = z.tuple([z.nativeEnum(Role), z.number()]);
 
 export const RoomSettingsSchema = z
 	.object({
-		title: z.string().max(254).optional(),
+		title: z
+			.string()
+			.max(254)
+			.refine(s => !/[\n\r]/.test(s), { message: "must not contain newlines" })
+			.optional(),
 		description: z.string().optional(),
 		visibility: z.nativeEnum(Visibility).optional(),
 		queueMode: z.nativeEnum(QueueMode).optional(),

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -238,6 +238,8 @@ describe("Room API", () => {
 				},
 			],
 			[{ name: "test1", isTemporary: true, visibility: "invalid" }],
+			[{ name: "foo", title: "title\nwith newline", isTemporary: true }],
+			[{ name: "foo", title: "title\rwith carriage return", isTemporary: true }],
 		])("should fail to create room for validation errors: %s", async body => {
 			const resp = await request(app)
 				.post("/api/room/create")
@@ -356,6 +358,16 @@ describe("Room API", () => {
 			[
 				{
 					autoSkipSegmentCategories: ["invalid", "intro"],
+				},
+			],
+			[
+				{
+					title: "title\nwith newline",
+				},
+			],
+			[
+				{
+					title: "title\rwith carriage return",
 				},
 			],
 		])("should fail to modify room for validation errors: %s", async body => {


### PR DESCRIPTION
## Summary
- Add newline and carriage return validation to room title field in Zod schemas
- Applies to both room creation and room settings update
- The name field is already protected by ROOM_NAME_REGEX which only allows [a-z0-9_-]

## Changes
- common/models/zod-schemas.ts - Added .refine() to reject newlines in title for both create and patch schemas
- server/tests/unit/api/room.spec.ts - Added test cases for \n and \r in title for both POST and PATCH endpoints

Closes #555