### PR TITLE
chore: bump @types/node to 22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ There's 2 ways you can set up your dev environment: using docker via dev contain
 
 ### Prerequisites
 
-This project targets node 20 and up. I recommend using [nvm](https://github.com/nvm-sh/nvm) to manage your node versions.
+This project targets node 22 and up. I recommend using [nvm](https://github.com/nvm-sh/nvm) to manage your node versions.
 
 I also recommend using the github cli (note this is different from git) to make PRs.
 

--- a/common/package.json
+++ b/common/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.170",
-    "@types/node": "^18.13.0",
+    "@types/node": "^22.0.0",
     "eslint": "^8.57.0",
     "eslint-plugin-vitest": "0.3.22",
     "vitest": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@types/lodash": "^4.14.170",
-    "@types/node": "^16.11.7",
+    "@types/node": "^22.0.0",
     "@types/uuid": "^3.4.0",
     "@types/validator": "^13.1.3",
     "@typescript-eslint/eslint-plugin": "6.14.0",

--- a/packages/ott-vis-datasource/package.json
+++ b/packages/ott-vis-datasource/package.json
@@ -34,7 +34,7 @@
 		"@testing-library/react": "14.0.0",
 		"@types/jest": "^29.5.0",
 		"@types/lodash": "^4.14.194",
-		"@types/node": "^20.8.7",
+		"@types/node": "^22.0.0",
 		"@types/react-router-dom": "^5.2.0",
 		"@types/testing-library__jest-dom": "5.14.8",
 		"copy-webpack-plugin": "^11.0.0",

--- a/packages/ott-vis-panel/package.json
+++ b/packages/ott-vis-panel/package.json
@@ -33,7 +33,7 @@
 		"@types/d3": "7.4.3",
 		"@types/jest": "^29.5.0",
 		"@types/lodash": "^4.14.194",
-		"@types/node": "^20.8.7",
+		"@types/node": "^22.0.0",
 		"@types/testing-library__jest-dom": "5.14.8",
 		"copy-webpack-plugin": "^11.0.0",
 		"css-loader": "^6.7.3",

--- a/server/package.json
+++ b/server/package.json
@@ -64,7 +64,7 @@
     "@types/express-session": "^1.17.3",
     "@types/lodash": "^4.14.170",
     "@types/m3u8-parser": "^7.2.5",
-    "@types/node": "^18.13.0",
+    "@types/node": "^22.0.0",
     "@types/passport": "1.0.12",
     "@types/passport-http-bearer": "^1.0.36",
     "@types/sequelize": "^4.28.9",

--- a/server/roommanager.ts
+++ b/server/roommanager.ts
@@ -44,7 +44,7 @@ async function addRoom(room: Room) {
 	bus.emit("load", room.name);
 }
 
-let updaterInterval: NodeJS.Timer | null = null;
+let updaterInterval: ReturnType<typeof setInterval> | null = null;
 export async function start() {
 	log.info("Starting room manager");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5739,13 +5739,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.13.0":
-  version: 18.14.1
-  resolution: "@types/node@npm:18.14.1"
-  checksum: 10c0/0646a6888175361a693df828ed0632e53bbe9a72c528dfe3dba4179c9c29d641e0959a7a73eacaf4ee04d50d5e3a2274f7525bd7be41dd03e25c4a6938665107
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^22.0.0":
   version: 22.19.17
   resolution: "@types/node@npm:22.19.17"
@@ -16657,7 +16650,7 @@ __metadata:
   resolution: "ott-common@workspace:common"
   dependencies:
     "@types/lodash": "npm:^4.14.170"
-    "@types/node": "npm:^18.13.0"
+    "@types/node": "npm:^22.0.0"
     dayjs: "npm:^1.10.4"
     eslint: "npm:^8.57.0"
     eslint-plugin-vitest: "npm:0.3.22"
@@ -16684,7 +16677,7 @@ __metadata:
     "@types/express-session": "npm:^1.17.3"
     "@types/lodash": "npm:^4.14.170"
     "@types/m3u8-parser": "npm:^7.2.5"
-    "@types/node": "npm:^18.13.0"
+    "@types/node": "npm:^22.0.0"
     "@types/passport": "npm:1.0.12"
     "@types/passport-http-bearer": "npm:^1.0.36"
     "@types/sequelize": "npm:^4.28.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5739,13 +5739,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^16.11.7":
-  version: 16.18.38
-  resolution: "@types/node@npm:16.18.38"
-  checksum: 10c0/02631f1cfe0c111024e4bf0909c3bfc7476e65e03cb32dc48b2f71f000590b244d239b349b91a6b03667c33f31fbd3200c8fc5838623fcaadce3e92d60efee1a
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^18.13.0":
   version: 18.14.1
   resolution: "@types/node@npm:18.14.1"
@@ -5753,12 +5746,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.8.7":
-  version: 20.11.5
-  resolution: "@types/node@npm:20.11.5"
+"@types/node@npm:^22.0.0":
+  version: 22.19.17
+  resolution: "@types/node@npm:22.19.17"
   dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10c0/6d18cec852f5cfbed3ec42b5c01c026e7a3f9da540d6e3d6738d4cee9979fb308cf27b6df7ba40a6553e7bc82e678f0ef53ba6e6ad52e5b86bd97b7783c2a42c
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/b66c484c0a9f6d88b1ef360b0f487717234ee1a482cb2551ff73d9f3c43a42a777daf4c8a5eee970960728f8fe1f3877d3d8c6ffabcbca74cb401a59db700fa4
   languageName: node
   linkType: hard
 
@@ -16524,7 +16517,7 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:^2.4.13"
     "@types/lodash": "npm:^4.14.170"
-    "@types/node": "npm:^16.11.7"
+    "@types/node": "npm:^22.0.0"
     "@types/uuid": "npm:^3.4.0"
     "@types/validator": "npm:^13.1.3"
     "@typescript-eslint/eslint-plugin": "npm:6.14.0"
@@ -16769,7 +16762,7 @@ __metadata:
     "@testing-library/react": "npm:14.0.0"
     "@types/jest": "npm:^29.5.0"
     "@types/lodash": "npm:^4.14.194"
-    "@types/node": "npm:^20.8.7"
+    "@types/node": "npm:^22.0.0"
     "@types/react-router-dom": "npm:^5.2.0"
     "@types/testing-library__jest-dom": "npm:5.14.8"
     copy-webpack-plugin: "npm:^11.0.0"
@@ -16826,7 +16819,7 @@ __metadata:
     "@types/d3": "npm:7.4.3"
     "@types/jest": "npm:^29.5.0"
     "@types/lodash": "npm:^4.14.194"
-    "@types/node": "npm:^20.8.7"
+    "@types/node": "npm:^22.0.0"
     "@types/testing-library__jest-dom": "npm:5.14.8"
     copy-webpack-plugin: "npm:^11.0.0"
     css-loader: "npm:^6.7.3"
@@ -21513,10 +21506,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~5.26.4":
-  version: 5.26.5
-  resolution: "undici-types@npm:5.26.5"
-  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update documentation and dependencies to reflect the new minimum node version