### PR TITLE
fix: reject newlines in room title

### DIFF
--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -6,8 +6,6 @@ import { z } from "zod";
 // These strings are not allowed to be used as room names.
 const RESERVED_ROOM_NAMES = ["list", "create", "generate"];
 
-const NEWLINE_REGEX = /[\r\n]/;
-
 const CategorySchema = z.enum([
 	"sponsor",
 	"intro",
@@ -35,7 +33,7 @@ export const OttApiRequestRoomCreateSchema = z
 		title: z
 			.string()
 			.max(255, "too long, must be at most 255 characters")
-			.refine(title => !NEWLINE_REGEX.test(title), {
+			.refine(title => !title.includes("\n") && !title.includes("\r"), {
 				message: "title must not contain newlines",
 			})
 			.optional(),
@@ -110,7 +108,7 @@ export const RoomSettingsSchema = z
 		title: z
 			.string()
 			.max(254)
-			.refine(title => !NEWLINE_REGEX.test(title), {
+			.refine(title => !title.includes("\n") && !title.includes("\r"), {
 				message: "title must not contain newlines",
 			})
 			.optional(),

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -30,7 +30,13 @@ export const OttApiRequestRoomCreateSchema = z
 			.refine(name => !RESERVED_ROOM_NAMES.includes(name), {
 				message: "not allowed (reserved)",
 			}),
-		title: z.string().max(255, "too long, must be at most 255 characters").optional(),
+		title: z
+			.string()
+			.max(255, "too long, must be at most 255 characters")
+			.refine(title => !/[\r\n]/.test(title), {
+				message: "title must not contain newlines",
+			})
+			.optional(),
 		description: z.string().optional(),
 		isTemporary: z.boolean().optional().default(true),
 		visibility: z.nativeEnum(Visibility).default(Visibility.Public).optional(),
@@ -99,7 +105,13 @@ const GrantSchema = z.tuple([z.nativeEnum(Role), z.number()]);
 
 export const RoomSettingsSchema = z
 	.object({
-		title: z.string().max(254).optional(),
+		title: z
+			.string()
+			.max(254)
+			.refine(title => !/[\r\n]/.test(title), {
+				message: "title must not contain newlines",
+			})
+			.optional(),
 		description: z.string().optional(),
 		visibility: z.nativeEnum(Visibility).optional(),
 		queueMode: z.nativeEnum(QueueMode).optional(),

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 // These strings are not allowed to be used as room names.
 const RESERVED_ROOM_NAMES = ["list", "create", "generate"];
 
+const NEWLINE_REGEX = /[\r\n]/;
+
 const CategorySchema = z.enum([
 	"sponsor",
 	"intro",
@@ -33,7 +35,7 @@ export const OttApiRequestRoomCreateSchema = z
 		title: z
 			.string()
 			.max(255, "too long, must be at most 255 characters")
-			.refine(title => !/[\r\n]/.test(title), {
+			.refine(title => !NEWLINE_REGEX.test(title), {
 				message: "title must not contain newlines",
 			})
 			.optional(),
@@ -108,7 +110,7 @@ export const RoomSettingsSchema = z
 		title: z
 			.string()
 			.max(254)
-			.refine(title => !/[\r\n]/.test(title), {
+			.refine(title => !NEWLINE_REGEX.test(title), {
 				message: "title must not contain newlines",
 			})
 			.optional(),

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -239,6 +239,20 @@ describe("Room API", () => {
 					isTemporary: true,
 				},
 			],
+			[
+				{
+					name: "test2",
+					title: "Title with\nnewline",
+					isTemporary: true,
+				},
+			],
+			[
+				{
+					name: "test3",
+					title: "Title with\r\ncarriage return",
+					isTemporary: true,
+				},
+			],
 			[{ name: "test1", isTemporary: true, visibility: "invalid" }],
 		])("should fail to create room for validation errors: %s", async body => {
 			const resp = await request(app)
@@ -353,6 +367,16 @@ describe("Room API", () => {
 			[
 				{
 					title: "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+				},
+			],
+			[
+				{
+					title: "Title with\nnewline",
+				},
+			],
+			[
+				{
+					title: "Title with\r\ncarriage return newline",
 				},
 			],
 			[


### PR DESCRIPTION
Room titles with newlines break layout and display. The UI already prevents newlines in the title field, but the API accepts them. This adds validation at the schema level to reject titles containing `\n` or `\r`.

Adds a `.refine()` check to both `OttApiRequestRoomCreateSchema` and `RoomSettingsSchema` that returns a validation error if the title contains newlines. The room name field already has protection via `ROOM_NAME_REGEX` which only allows `[a-z0-9_-]`.

Test coverage includes both `\n` and `\r\n` variants for room creation and settings update endpoints.

Addresses the same issue as #1950.

Closes #555