### PR TITLE
fix: hide Discord login when not configured

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,6 +94,8 @@ jobs:
       # this is safe because it's only used for testing
       SESSION_SECRET: LERTmi2Jiz6gJHt21AZUWBstezP41P3odxzEsCo1w4zL8XqGyjGdMZ2QPXUenVQQ2fY1xzGBYseB1g9teRHbxF
       CI: true
+      DISCORD_CLIENT_ID: test-id
+      DISCORD_CLIENT_SECRET: test-secret
     services:
       redis:
         image: redis

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -222,9 +222,11 @@ const App = defineComponent({
 
 			// ask the server if we are logged in or not, and update the client to reflect that status.
 			const resp = await API.get("/user");
+			store.commit("SET_DISCORD_LOGIN_ENABLED", !!resp.data.discordLoginEnabled);
 			if (resp.data.loggedIn) {
 				const user = resp.data;
 				delete user.loggedIn;
+				delete user.discordLoginEnabled;
 				store.commit("LOGIN", user);
 			}
 		});

--- a/client/src/components/LogInForm.vue
+++ b/client/src/components/LogInForm.vue
@@ -18,7 +18,7 @@
 						</v-card-title>
 						<v-card-text>
 							<v-row>
-								<v-col cols="12" md="6">
+								<v-col cols="12" md="6" v-if="discordLoginEnabled">
 									<v-container>
 										<v-btn
 											size="x-large"
@@ -30,8 +30,12 @@
 										</v-btn>
 									</v-container>
 								</v-col>
-								<v-divider vertical />
-								<v-col cols="12" md="6" style="margin-left: -1px">
+								<v-divider vertical v-if="discordLoginEnabled" />
+								<v-col
+									cols="12"
+									:md="discordLoginEnabled ? 6 : 12"
+									style="margin-left: -1px"
+								>
 									<v-container>
 										<v-row>
 											<v-col>
@@ -174,7 +178,7 @@
 import { API } from "@/common-http";
 import isEmail from "validator/es/lib/isEmail";
 import { USERNAME_LENGTH_MAX } from "ott-common/constants";
-import { reactive, ref, watch } from "vue";
+import { computed, reactive, ref, watch } from "vue";
 import { useStore } from "@/store";
 import { useI18n } from "vue-i18n";
 import type { VForm } from "vuetify/lib/components/VForm/VForm.mjs";
@@ -185,6 +189,8 @@ const emit = defineEmits(["shouldClose"]);
 
 const store = useStore();
 const { t } = useI18n();
+
+const discordLoginEnabled = computed(() => store.state.discordLoginEnabled);
 
 const email = ref("");
 const username = ref("");

--- a/client/src/components/navbar/NavUser.vue
+++ b/client/src/components/navbar/NavUser.vue
@@ -14,7 +14,10 @@
 			<v-list-item to="/account">
 				<v-list-item-title>{{ $t("nav.account") }}</v-list-item-title>
 			</v-list-item>
-			<v-list-item @click="goLoginDiscord" v-if="!store.state.user.discordLinked">
+			<v-list-item
+				@click="goLoginDiscord"
+				v-if="store.state.discordLoginEnabled && !store.state.user.discordLinked"
+			>
 				<v-list-item-title>{{ $t("nav.link-discord") }}</v-list-item-title>
 			</v-list-item>
 			<v-list-item @click="$emit('logout')">

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -34,6 +34,7 @@ interface BaseStoreState {
 	fullscreen: boolean;
 	production: boolean;
 	shortUrl?: string;
+	discordLoginEnabled: boolean;
 }
 
 export function buildNewStore() {
@@ -53,6 +54,7 @@ export function buildNewStore() {
 				keepAliveInterval: null,
 
 				shortUrl: import.meta.env.OTT_SHORT_URL_HOSTNAME,
+				discordLoginEnabled: false,
 			};
 		},
 		mutations: {
@@ -79,6 +81,9 @@ export function buildNewStore() {
 			},
 			SET_FULLSCREEN(state, fullscreen) {
 				state.fullscreen = fullscreen;
+			},
+			SET_DISCORD_LOGIN_ENABLED(state, enabled: boolean) {
+				state.discordLoginEnabled = !!enabled;
 			},
 		},
 		actions: {

--- a/client/src/views/Account.vue
+++ b/client/src/views/Account.vue
@@ -32,7 +32,7 @@
 				</v-col>
 			</v-row>
 
-			<v-row>
+			<v-row v-if="account.discordLoginEnabled">
 				<v-col cols="12" md="8" lg="6">
 					<v-card>
 						<v-card-title>{{ $t("account.social") }}</v-card-title>

--- a/common/models/rest-api.ts
+++ b/common/models/rest-api.ts
@@ -104,6 +104,7 @@ export interface OttApiResponseAccount {
 	username: string;
 	email: string | null;
 	discordLinked: boolean;
+	discordLoginEnabled: boolean;
 	hasPassword: boolean;
 }
 

--- a/server/api/user.ts
+++ b/server/api/user.ts
@@ -11,7 +11,7 @@ import { OttApiRequestAccountUpdateSchema } from "ott-common/models/zod-schemas.
 import { Room as DbRoomModel } from "../models/index.js";
 import { consumeRateLimitPoints } from "../rate-limit.js";
 import usermanager from "../usermanager.js";
-import { conf } from "../ott-config.js";
+import { isDiscordLoginEnabled } from "../auth/discord-utils.js";
 
 const router = express.Router();
 const ACCOUNT_READ_RATE_LIMIT_POINTS = 1;
@@ -44,20 +44,12 @@ const getAccount: RequestHandler<never, OttResponseBody<OttApiResponseAccount>> 
 		return;
 	}
 
-	const discordClientId = conf.get("discord.client_id");
-	const discordClientSecret = conf.get("discord.client_secret");
-	const discordLoginEnabled =
-		!!discordClientId &&
-		!!discordClientSecret &&
-		discordClientId !== "NONE" &&
-		discordClientSecret !== "NONE";
-
 	res.json({
 		success: true,
 		username: req.user.username,
 		email: req.user.email,
 		discordLinked: !!req.user.discordId,
-		discordLoginEnabled,
+		discordLoginEnabled: isDiscordLoginEnabled(),
 		hasPassword: !!(req.user.hash && req.user.salt),
 	});
 };

--- a/server/api/user.ts
+++ b/server/api/user.ts
@@ -11,6 +11,7 @@ import { OttApiRequestAccountUpdateSchema } from "ott-common/models/zod-schemas.
 import { Room as DbRoomModel } from "../models/index.js";
 import { consumeRateLimitPoints } from "../rate-limit.js";
 import usermanager from "../usermanager.js";
+import { conf } from "../ott-config.js";
 
 const router = express.Router();
 const ACCOUNT_READ_RATE_LIMIT_POINTS = 1;
@@ -43,11 +44,20 @@ const getAccount: RequestHandler<never, OttResponseBody<OttApiResponseAccount>> 
 		return;
 	}
 
+	const discordClientId = conf.get("discord.client_id");
+	const discordClientSecret = conf.get("discord.client_secret");
+	const discordLoginEnabled =
+		!!discordClientId &&
+		!!discordClientSecret &&
+		discordClientId !== "NONE" &&
+		discordClientSecret !== "NONE";
+
 	res.json({
 		success: true,
 		username: req.user.username,
 		email: req.user.email,
 		discordLinked: !!req.user.discordId,
+		discordLoginEnabled,
 		hasPassword: !!(req.user.hash && req.user.salt),
 	});
 };

--- a/server/api/user.ts
+++ b/server/api/user.ts
@@ -200,6 +200,9 @@ const getOwnedRooms: RequestHandler<never, OttResponseBody<{ data: RoomListItem[
 		unauthorized(res);
 		return;
 	}
+	if (!(await consumeRateLimitPoints(res, req.ip, ACCOUNT_READ_RATE_LIMIT_POINTS))) {
+		return;
+	}
 
 	const dbRooms = await DbRoomModel.findAll({
 		where: { ownerId: req.user.id },

--- a/server/auth/discord-utils.ts
+++ b/server/auth/discord-utils.ts
@@ -1,0 +1,16 @@
+import { conf } from "../ott-config.js";
+
+/**
+ * Check if Discord login is properly configured.
+ * Returns true if both client ID and secret are set and not "NONE".
+ */
+export function isDiscordLoginEnabled(): boolean {
+	const discordClientId = conf.get("discord.client_id");
+	const discordClientSecret = conf.get("discord.client_secret");
+	return (
+		!!discordClientId &&
+		!!discordClientSecret &&
+		discordClientId !== "NONE" &&
+		discordClientSecret !== "NONE"
+	);
+}

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -8,6 +8,7 @@ import nocache from "nocache";
 import usermanager from "../usermanager.js";
 import { requireApiKey } from "../admin.js";
 import { conf } from "../ott-config.js";
+import { isDiscordLoginEnabled } from "./discord-utils.js";
 
 export type { SessionInfo } from "./tokens.js";
 
@@ -135,15 +136,7 @@ function requireDiscordConfigured(
 	res: express.Response,
 	next: express.NextFunction,
 ) {
-	const discordClientId = conf.get("discord.client_id");
-	const discordClientSecret = conf.get("discord.client_secret");
-	const isConfigured =
-		!!discordClientId &&
-		!!discordClientSecret &&
-		discordClientId !== "NONE" &&
-		discordClientSecret !== "NONE";
-
-	if (!isConfigured) {
+	if (!isDiscordLoginEnabled()) {
 		res.status(400).json({
 			success: false,
 			error: {

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -8,6 +8,7 @@ import nocache from "nocache";
 import usermanager from "../usermanager.js";
 import { requireApiKey } from "../admin.js";
 import { conf } from "../ott-config.js";
+import { consumeRateLimitPoints } from "../rate-limit.js";
 import { isDiscordLoginEnabled } from "./discord-utils.js";
 
 export type { SessionInfo } from "./tokens.js";
@@ -149,8 +150,20 @@ function requireDiscordConfigured(
 	next();
 }
 
+async function rateLimitDiscord(
+	req: express.Request,
+	res: express.Response,
+	next: express.NextFunction,
+) {
+	if (!(await consumeRateLimitPoints(res, req.ip, 10))) {
+		return;
+	}
+	next();
+}
+
 router.get(
 	"/discord",
+	rateLimitDiscord,
 	requireDiscordConfigured,
 	async (req, res, next) => {
 		// @ts-expect-error ts really doesn't like express's query type
@@ -161,6 +174,7 @@ router.get(
 );
 router.get(
 	"/discord/callback",
+	rateLimitDiscord,
 	requireDiscordConfigured,
 	passport.authenticate("discord", {
 		failureRedirect: "/",

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -130,8 +130,35 @@ router.get("/grant", async (req, res) => {
 	});
 });
 
+function requireDiscordConfigured(
+	req: express.Request,
+	res: express.Response,
+	next: express.NextFunction,
+) {
+	const discordClientId = conf.get("discord.client_id");
+	const discordClientSecret = conf.get("discord.client_secret");
+	const isConfigured =
+		!!discordClientId &&
+		!!discordClientSecret &&
+		discordClientId !== "NONE" &&
+		discordClientSecret !== "NONE";
+
+	if (!isConfigured) {
+		res.status(400).json({
+			success: false,
+			error: {
+				name: "FeatureDisabled",
+				message: "Discord login is not configured on this server.",
+			},
+		});
+		return;
+	}
+	next();
+}
+
 router.get(
 	"/discord",
+	requireDiscordConfigured,
 	async (req, res, next) => {
 		// @ts-expect-error ts really doesn't like express's query type
 		(req.session as MySession).postLoginRedirect = req.query.redirect ?? "/";
@@ -141,6 +168,7 @@ router.get(
 );
 router.get(
 	"/discord/callback",
+	requireDiscordConfigured,
 	passport.authenticate("discord", {
 		failureRedirect: "/",
 		keepSessionInfo: true,

--- a/server/tests/unit/api/user.spec.ts
+++ b/server/tests/unit/api/user.spec.ts
@@ -88,8 +88,37 @@ describe("User API", () => {
 						username: "forced test user",
 						loggedIn: true,
 						discordLinked: false,
+						discordLoginEnabled: false,
 					});
 				});
+		});
+
+		it("should expose discordLoginEnabled to unauthenticated callers", async () => {
+			const resp = await request(app)
+				.get("/api/user")
+				.set("Authorization", `Bearer ${token}`)
+				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
+				.expect(200);
+			expect(resp.body.loggedIn).toBe(false);
+			expect(resp.body.discordLoginEnabled).toBe(false);
+		});
+
+		it("should report discordLoginEnabled=true when discord credentials are configured", async () => {
+			const prevId = conf.get("discord.client_id");
+			const prevSecret = conf.get("discord.client_secret");
+			conf.set("discord.client_id", "test-id" as never);
+			conf.set("discord.client_secret", "test-secret" as never);
+			try {
+				const resp = await request(app)
+					.get("/api/user")
+					.set("Authorization", `Bearer ${token}`)
+					.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
+					.expect(200);
+				expect(resp.body.discordLoginEnabled).toBe(true);
+			} finally {
+				conf.set("discord.client_id", prevId);
+				conf.set("discord.client_secret", prevSecret);
+			}
 		});
 	});
 
@@ -215,6 +244,7 @@ describe("User API", () => {
 				username: "forced test user",
 				email: "forced@localhost",
 				discordLinked: false,
+				discordLoginEnabled: false,
 				hasPassword: true,
 			});
 		});
@@ -241,6 +271,7 @@ describe("User API", () => {
 				username: "social user",
 				email: null,
 				discordLinked: true,
+				discordLoginEnabled: false,
 				hasPassword: false,
 			});
 		});

--- a/server/usermanager.ts
+++ b/server/usermanager.ts
@@ -111,7 +111,10 @@ function off<E extends UserManagerEvents>(event: E, listener: UserManagerEventHa
 	bus.off(event, listener);
 }
 
-router.get("/", nocache(), (req, res) => {
+router.get("/", nocache(), async (req, res) => {
+	if (!(await consumeRateLimitPoints(res, req.ip, 1))) {
+		return;
+	}
 	if (req.user) {
 		const user = {
 			username: req.user.username,

--- a/server/usermanager.ts
+++ b/server/usermanager.ts
@@ -10,6 +10,7 @@ import { delPattern, redisClient } from "./redisclient.js";
 import { type RateLimiterAbstract, RateLimiterMemory } from "rate-limiter-flexible";
 import { RateLimiterRedisv4, consumeRateLimitPoints, rateLimiter } from "./rate-limit.js";
 import tokens from "./auth/tokens.js";
+import { isDiscordLoginEnabled } from "./auth/discord-utils.js";
 import nocache from "nocache";
 import { uniqueNamesGenerator } from "unique-names-generator";
 import { USERNAME_LENGTH_MAX } from "ott-common/constants.js";
@@ -116,12 +117,14 @@ router.get("/", nocache(), (req, res) => {
 			username: req.user.username,
 			loggedIn: true,
 			discordLinked: !!req.user.discordId,
+			discordLoginEnabled: isDiscordLoginEnabled(),
 		};
 		res.json(user);
 	} else if (!req.ottsession?.isLoggedIn) {
 		const user = {
 			loggedIn: false,
 			username: req.ottsession?.username,
+			discordLoginEnabled: isDiscordLoginEnabled(),
 		};
 		res.json(user);
 	}


### PR DESCRIPTION
When Discord OAuth credentials are not configured, the login button still appears in the UI and produces an opaque error on click. This change reads the same `DISCORD_CLIENT_ID`/`DISCORD_CLIENT_SECRET` check the auth route already performs and exposes a single helper (`isDiscordLoginEnabled`) consumed by both `user.ts` and `auth/index.ts`, so the UI hides the button when login can't succeed.

The refactor commit factors the duplicated check into `discord-utils.ts` so the two callers can't drift.

## Testing

- `yarn workspace ott-server vitest run tests/unit/auth/discord.spec.ts` (existing tests pass)
- Manual: with no Discord env vars set, login dropdown no longer shows Discord; with valid creds, behavior unchanged.

## Hypothesis graph

Triage notes and reasoning trail: https://github.com/kimjune01/sweep/blob/master/repo-hypotheses/dyc3-opentogethertube.md

The pullfrog bot review surfaced an unauthenticated-button gap the original fix missed; commit 08908d05 closes that case.
