### PR TITLE
fix(client): make restore-queue dialog usable after visual overhaul

### DIFF
--- a/client/src/components/RestoreQueue.vue
+++ b/client/src/components/RestoreQueue.vue
@@ -4,30 +4,45 @@
 			<div
 				v-if="(store.state.room.prevQueue?.length ?? 0) > 0"
 				class="restore flex flex-col gap-3 rounded-lg border bg-card p-4 sm:flex-row sm:items-center"
+				data-cy="restore-banner"
 			>
 				<span class="flex-1 text-foreground">{{ $t("video-queue.restore") }}</span>
 				<div class="flex gap-2">
-					<Button variant="default" @click="showDialog">{{ $t("common.show") }}</Button>
-					<Button variant="ghost" @click="discard">{{ $t("common.discard") }}</Button>
+					<Button variant="default" @click="showDialog" data-cy="restore-show">
+						{{ $t("common.show") }}
+					</Button>
+					<Button variant="ghost" @click="discard" data-cy="restore-banner-discard">
+						{{ $t("common.discard") }}
+					</Button>
 				</div>
 			</div>
 		</Transition>
 		<Dialog v-model:open="showRestorePreview">
-			<DialogContent class="max-w-xl sm:max-w-xl">
+			<DialogContent
+				class="grid-cols-[minmax(0,1fr)] max-w-xl sm:max-w-xl"
+				data-cy="restore-dialog"
+			>
 				<DialogHeader>
 					<DialogTitle>{{ $t("video-queue.restore-queue") }}</DialogTitle>
 				</DialogHeader>
-				<div class="flex flex-col gap-2">
-					<div class="text-muted-foreground">
-						{{ $t("video-queue.restore-queue-hint") }}
-					</div>
+				<div class="text-muted-foreground">
+					{{ $t("video-queue.restore-queue-hint") }}
+				</div>
+				<div
+					class="flex max-h-[50vh] flex-col gap-2 overflow-y-auto"
+					data-cy="restore-list"
+				>
 					<div v-for="video in store.state.room.prevQueue" :key="video.id">
 						<VideoQueueItem :item="video" :hide-all-buttons="true" />
 					</div>
 				</div>
 				<DialogFooter>
-					<Button variant="ghost" @click="discard">{{ $t("common.discard") }}</Button>
-					<Button variant="default" @click="restore">{{ $t("common.restore") }}</Button>
+					<Button variant="ghost" @click="discard" data-cy="restore-discard">
+						{{ $t("common.discard") }}
+					</Button>
+					<Button variant="default" @click="restore" data-cy="restore-confirm">
+						{{ $t("common.restore") }}
+					</Button>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/server/api/dev.ts
+++ b/server/api/dev.ts
@@ -2,6 +2,7 @@ import { getLogger } from "../logger.js";
 import express from "express";
 import { rateLimiter } from "../rate-limit.js";
 import roommanager from "../roommanager.js";
+import storage from "../storage.js";
 import { RoomRequestType } from "ott-common/models/messages.js";
 import usermanager from "../usermanager.js";
 import faker from "faker";
@@ -78,6 +79,24 @@ router.post("/room/:name/force-disconnect", (req, res) => {
 	const client = clientmanager.getClientByToken(req.token!, req.params.name);
 	client.kick(1000);
 	res.json({ success: true });
+});
+
+router.post("/room/:name/seed-prev-queue", async (req, res) => {
+	// Writes a fake previous queue straight to storage so tests can exercise the
+	// restore-queue prompt deterministically. The room must already exist and be
+	// unloaded, so reopening it loads this prevQueue from the database.
+	const count = Number(req.body.count ?? 1);
+	const prevQueue = Array.from({ length: count }, (_, i) => ({
+		service: "direct" as const,
+		id: `fake-video-${i}`,
+		title: `Fake Video ${i + 1}`,
+		description: `Fake video ${i + 1} for testing the restore queue dialog`,
+		length: 100,
+		thumbnail: "",
+		mime: "video/mp4",
+	}));
+	const ok = await storage.updateRoom({ name: req.params.name, prevQueue });
+	res.json({ success: ok });
 });
 
 router.post("/set-admin-api-key", (req, res) => {

--- a/tests/e2e/integration/restore-queue.spec.ts
+++ b/tests/e2e/integration/restore-queue.spec.ts
@@ -1,0 +1,68 @@
+import { v4 as uuid } from "uuid";
+import { beforeEach, describe, expect, it } from "../support/fixtures";
+
+describe("Restore queue", () => {
+	beforeEach(async ({ context, ott }) => {
+		await context.clearCookies();
+		await ott.ensureToken();
+		await ott.resetRateLimit();
+		await ott.request({
+			method: "POST",
+			url: "/api/dev/set-admin-api-key",
+			body: { newkey: ott.apiKey },
+		});
+	});
+
+	it("should restore the previous queue while keeping the dialog usable", async ({
+		page,
+		ott,
+	}) => {
+		page.on("pageerror", () => {
+			// Restored fake videos have no real source; ignore the resulting player errors.
+		});
+
+		const roomName = uuid().substring(0, 20);
+
+		// Create a permanent room, unload it so nothing shadows storage, then seed a
+		// previous queue directly into storage. Reopening the room loads this
+		// prevQueue from the database, which is what powers the restore prompt.
+		await ott.request({
+			method: "POST",
+			url: "/api/room/create",
+			body: { name: roomName, isTemporary: false },
+		});
+		await ott.request({
+			method: "DELETE",
+			url: `/api/room/${roomName}`,
+			headers: { apikey: ott.apiKey },
+		});
+		await ott.request({
+			method: "POST",
+			url: `/api/dev/room/${roomName}/seed-prev-queue`,
+			body: { count: 4 },
+		});
+
+		// Use a short viewport so the dialog's scroll cap is what keeps the action
+		// buttons reachable. Without the cap, a 4-item list pushes them off-screen.
+		await page.setViewportSize({ width: 1280, height: 500 });
+		await page.goto(`/room/${roomName}`);
+		await expect(page.locator("#connectStatus")).toHaveText("Connected");
+
+		// The restore prompt should appear and open a dialog listing the previous items.
+		await expect(page.locator("[data-cy=restore-banner]")).toBeVisible();
+		await page.locator("[data-cy=restore-show]").click();
+		await expect(page.locator("[data-cy=restore-dialog]")).toBeVisible();
+		await expect(page.locator("[data-cy=restore-dialog] .video")).toHaveCount(4);
+
+		// The action buttons must stay fully within the viewport regardless of how
+		// long the previous queue is. This guards the UI regression being fixed.
+		await expect(page.locator("[data-cy=restore-confirm]")).toBeInViewport({ ratio: 1 });
+		await expect(page.locator("[data-cy=restore-discard]")).toBeInViewport({ ratio: 1 });
+
+		// Restoring enqueues the previous videos and dismisses the prompt.
+		await page.locator("[data-cy=restore-confirm]").click();
+		await expect(page.locator("[data-cy=restore-banner]")).toHaveCount(0);
+		// One video becomes the current source; the remaining three stay queued.
+		await expect(page.locator(".video-queue .video")).toHaveCount(3);
+	});
+});


### PR DESCRIPTION
fixes #2038

The restore-queue prompt renders VideoQueueItem inside a grid-based
DialogContent. The item-list grid track defaulted to min-width: auto, so
it grew to the item's intrinsic width (~873px) and overflowed the dialog
(long descriptions made it worse), leaving the prompt unusable.

- Cap the grid track with grid-cols-[minmax(0,1fr)] so items shrink and
  descriptions truncate instead of widening the dialog.
- Pin the title/hint/footer and scroll only the video-item list
  (max-h-[50vh] overflow-y-auto) so a long previous queue keeps the
  Restore/Discard buttons reachable.
- Add data-cy hooks to the banner, dialog, and buttons.

Add an e2e test covering the full restore flow (seed a previous queue,
unload, reopen, restore) and asserting the action buttons stay in the
viewport. Backed by a new dev-only add-fake-videos endpoint to seed a
previous queue deterministically without external video sources.

