### PR TITLE
Subtitle rendering via ASS.js for Directly player and custom-manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 /ts-out
 /target
 .eslintcache
+bun.lock
 
 # Playwright test artifacts
 /test-results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ OpenTogetherTube is a real-time video synchronization web application. It uses a
 
 ## Build & Development Commands
 
+> **Note:** yarn is prefered. But if that doesn't work in your sandbox, use bun instead.
+
 **Build:**
 
 ```bash
@@ -62,7 +64,7 @@ yarn test:e2e:ui       # Open Playwright UI (interactive)
 yarn test:component    # Run component tests
 
 # Rust tests
-cargo test
+cargo test                # requires ipv6
 cargo test -p ott-balancer
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,6 @@ OpenTogetherTube is a real-time video synchronization web application. It uses a
 
 ## Build & Development Commands
 
-> **Note:** yarn is prefered. But if that doesn't work in your sandbox, use bun instead.
-
 **Build:**
 
 ```bash

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
 		"@tanstack/vue-table": "^8.21.3",
 		"@vimeo/player": "^2.20.1",
 		"@vueuse/core": "^14.3.0",
+		"assjs": "^0.1.7",
 		"axios": "1.13.5",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -186,7 +186,42 @@
 						{{ $t("video-queue-item.edit.title") }}
 					</DialogTitle>
 				</DialogHeader>
-				<Field>
+				<Field v-if="isManifestItem">
+					<FieldLabel for="edit-default-subtitle-track">
+						{{ $t("video-queue-item.edit.default-subtitle-track") }}
+					</FieldLabel>
+					<Spinner v-if="isLoadingManifest" class="size-4" />
+					<FieldDescription v-else-if="manifestError">
+						{{ $t("video-queue-item.edit.manifest-load-failed") }}
+					</FieldDescription>
+					<Select v-else v-model="editedDefaultTrack">
+						<SelectTrigger
+							id="edit-default-subtitle-track"
+							data-cy="edit-default-subtitle-track"
+						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem :value="TRACK_MANIFEST_DEFAULT">
+								{{ $t("video-queue-item.edit.manifest-default") }}
+							</SelectItem>
+							<SelectItem :value="TRACK_NONE">
+								{{ $t("video-queue-item.edit.no-subtitles") }}
+							</SelectItem>
+							<SelectItem
+								v-for="track in manifestTracks"
+								:key="track.url"
+								:value="track.url"
+							>
+								{{ formatTrackLabel(track) }}
+							</SelectItem>
+						</SelectContent>
+					</Select>
+					<FieldDescription v-if="!manifestError">
+						{{ $t("video-queue-item.edit.default-subtitle-track-hint") }}
+					</FieldDescription>
+				</Field>
+				<Field v-else>
 					<FieldLabel for="edit-subtitle-url">
 						{{ $t("video-queue-item.edit.subtitle-url") }}
 					</FieldLabel>
@@ -233,6 +268,13 @@ import {
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -253,6 +295,7 @@ import { API } from "@/common-http";
 import { secondsToTimestamp } from "@/util/timestamp";
 import { ToastStyle } from "@/models/toast";
 import type { QueueItem, VideoAdd } from "ott-common/models/video";
+import type { CustomMediaManifest, CustomMediaTextTrack } from "ott-common/models/zod-schemas";
 import { QueueMode } from "ott-common/models/types";
 import { useStore } from "@/store";
 import toast from "@/util/toast";
@@ -291,6 +334,60 @@ const hasError = ref(false);
 const voted = ref(false);
 const showEditDialog = ref(false);
 const editedSubtitleUrl = props.isPreview ? ref("") : ref(item.value.subtitleUrl);
+
+// Sentinel values for the default subtitle track select. `null`/absent on the queue
+// item means "use the manifest's default flag", `""` means "no subtitles".
+const TRACK_MANIFEST_DEFAULT = "\0manifest-default";
+const TRACK_NONE = "\0none";
+const isManifestItem = computed(() => item.value.mime === "application/json");
+const editedDefaultTrack = ref(TRACK_MANIFEST_DEFAULT);
+const manifestTracks = ref<CustomMediaTextTrack[]>([]);
+const manifestError = ref(false);
+const isLoadingManifest = ref(false);
+
+function trackToSelectValue(track: string | null | undefined): string {
+	if (track === null || track === undefined) {
+		return TRACK_MANIFEST_DEFAULT;
+	}
+	if (track === "") {
+		return TRACK_NONE;
+	}
+	return track;
+}
+
+function selectValueToTrack(value: string): string | null {
+	if (value === TRACK_MANIFEST_DEFAULT) {
+		return null;
+	}
+	if (value === TRACK_NONE) {
+		return "";
+	}
+	return value;
+}
+
+function formatTrackLabel(track: CustomMediaTextTrack): string {
+	const name = track.name ?? track.srclang;
+	const format = track.contentType === "text/x-ass" ? "ASS" : "VTT";
+	return `${name} [${track.srclang}] (${format})`;
+}
+
+async function loadManifestTracks() {
+	isLoadingManifest.value = true;
+	manifestError.value = false;
+	try {
+		const response = await fetch(item.value.src_url ?? item.value.id);
+		if (!response.ok) {
+			throw new Error(`failed to fetch manifest: ${response.status}`);
+		}
+		const manifest = (await response.json()) as CustomMediaManifest;
+		manifestTracks.value = manifest.textTracks ?? [];
+	} catch (e) {
+		console.error("VideoQueueItem: failed to load manifest tracks:", e);
+		manifestError.value = true;
+		manifestTracks.value = [];
+	}
+	isLoadingManifest.value = false;
+}
 const videoLength = computed(() => secondsToTimestamp(item.value?.length ?? 0));
 const videoStartAt = computed(() => secondsToTimestamp(item.value?.startAt ?? 0));
 const thumbnailSource = computed(() => {
@@ -320,27 +417,38 @@ function updateHasBeenAdded() {
 }
 
 function getPostData(): VideoAdd {
-	const data = {
+	const data: VideoAdd = {
 		service: item.value.service,
 		id: item.value.id,
-		// Use `item.value.subtitleUrl` for preview since editedSubtitleUrl might have been edited but not saved
+		// Use `item.value.*` for preview since the edited refs might not be saved yet
 		subtitleUrl:
 			(props.isPreview ? item.value.subtitleUrl : editedSubtitleUrl.value) ?? undefined,
+		defaultSubtitleTrack: props.isPreview
+			? item.value.defaultSubtitleTrack
+			: selectValueToTrack(editedDefaultTrack.value),
 	};
 	return data;
 }
 
-// Ensure that the editedSubtitleUrl is reflected to the current subtitle URL after a failed update request
+// Ensure that the edited values reflect the current item state when the dialog opens
 watch(showEditDialog, open => {
-	if (!props.isPreview && open) {
+	if (!open) {
+		return;
+	}
+	if (!props.isPreview) {
 		editedSubtitleUrl.value = item.value.subtitleUrl ?? "";
+	}
+	editedDefaultTrack.value = trackToSelectValue(item.value.defaultSubtitleTrack);
+	if (isManifestItem.value) {
+		loadManifestTracks();
 	}
 });
 
 async function saveEdit() {
 	if (props.isPreview) {
-		// Update the subtitle URL for playNow()
+		// Update the subtitle settings for playNow()
 		item.value.subtitleUrl = editedSubtitleUrl.value ?? undefined;
+		item.value.defaultSubtitleTrack = selectValueToTrack(editedDefaultTrack.value);
 		showEditDialog.value = false;
 	} else {
 		isLoadingEdit.value = true;

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -329,7 +329,7 @@ const hasError = ref(false);
 const voted = ref(false);
 const showEditDialog = ref(false);
 const editedDefaultTrack = ref<string | null>(
-	props.isPreview ? null : item.value.defaultSubtitleTrack ?? null,
+	props.isPreview ? null : item.value.subtitleUrl ?? null,
 );
 function setExternalSubtitleUrl(value: string): void {
 	editedDefaultTrack.value = normalizeSubtitleTrack(value);
@@ -376,21 +376,21 @@ function getPostData(): VideoAdd {
 	const data: VideoAdd = {
 		service: item.value.service,
 		id: item.value.id,
-		defaultSubtitleTrack:
-			(props.isPreview ? item.value.defaultSubtitleTrack : editedDefaultTrack.value) ?? null,
+		subtitleUrl:
+			(props.isPreview ? item.value.subtitleUrl : editedDefaultTrack.value) ?? null,
 	};
 	return data;
 }
 
 watch(showEditDialog, open => {
 	if (open && !props.isPreview) {
-		editedDefaultTrack.value = item.value.defaultSubtitleTrack ?? null;
+		editedDefaultTrack.value = item.value.subtitleUrl ?? null;
 	}
 });
 
 async function saveEdit() {
 	if (props.isPreview) {
-		item.value.defaultSubtitleTrack = editedDefaultTrack.value;
+		item.value.subtitleUrl = editedDefaultTrack.value;
 		showEditDialog.value = false;
 	} else {
 		isLoadingEdit.value = true;

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -220,7 +220,7 @@
 					</FieldLabel>
 					<Input
 						id="edit-subtitle-url"
-						v-model="editedSubtitleUrl"
+						v-model="externalSubtitleUrl"
 						class="font-mono"
 						:disabled="!['direct', 'googledrive'].includes(item.service)"
 						data-cy="edit-subtitle-url"
@@ -326,25 +326,28 @@ const thumbnailHasError = ref(false);
 const hasError = ref(false);
 const voted = ref(false);
 const showEditDialog = ref(false);
-// External subtitle URL input (non-manifest items) and the manifest track selector
-// both feed the same `defaultSubtitleTrack` field; only one is shown at a time.
-const editedSubtitleUrl = props.isPreview ? ref("") : ref(item.value.defaultSubtitleTrack ?? "");
+// The single source of truth for the edited default subtitle track. `null` is the
+// canonical "no subtitles" value (also what the manifest <Select>'s None item uses).
+// The manifest selector binds to it directly; the external subtitle URL input binds
+// via `externalSubtitleUrl`, which maps the input's empty string to/from `null`.
+// Only one of those widgets is shown at a time.
+const editedDefaultTrack = ref<string | null>(
+	props.isPreview ? null : item.value.defaultSubtitleTrack ?? null,
+);
+const externalSubtitleUrl = computed<string>({
+	get: () => editedDefaultTrack.value ?? "",
+	set: value => {
+		editedDefaultTrack.value = value || null;
+	},
+});
 
 const isManifestItem = computed(() => item.value.mime === "application/json");
-const editedDefaultTrack = ref<string | null>(null);
 const manifestTracks = computed<CustomMediaTextTrack[]>(() => item.value.textTracks ?? []);
 
 function formatTrackLabel(track: CustomMediaTextTrack): string {
 	const name = track.name ?? track.srclang;
 	const format = track.contentType === "text/x-ass" ? "ASS" : "VTT";
 	return `${name} [${track.srclang}] (${format})`;
-}
-
-// Resolve the edited `defaultSubtitleTrack` from whichever widget applies to this
-// item: the manifest track selector, or the external subtitle URL input (where an
-// empty string means "no subtitles").
-function getEditedDefaultSubtitleTrack(): string | null {
-	return isManifestItem.value ? editedDefaultTrack.value : editedSubtitleUrl.value || null;
 }
 
 const videoLength = computed(() => secondsToTimestamp(item.value?.length ?? 0));
@@ -379,29 +382,25 @@ function getPostData(): VideoAdd {
 	const data: VideoAdd = {
 		service: item.value.service,
 		id: item.value.id,
-		// Use `item.value.*` for preview since the edited refs might not be saved yet
-		defaultSubtitleTrack: props.isPreview
-			? item.value.defaultSubtitleTrack
-			: getEditedDefaultSubtitleTrack(),
+		// `null` is the canonical "no subtitles". Use `item.value.*` for preview since
+		// the edited fields might not be saved yet; `?? null` normalizes undefined.
+		defaultSubtitleTrack:
+			(props.isPreview ? item.value.defaultSubtitleTrack : editedDefaultTrack.value) ?? null,
 	};
 	return data;
 }
 
 // Ensure that the edited values reflect the current item state when the dialog opens
 watch(showEditDialog, open => {
-	if (!open) {
-		return;
+	if (open && !props.isPreview) {
+		editedDefaultTrack.value = item.value.defaultSubtitleTrack ?? null;
 	}
-	if (!props.isPreview) {
-		editedSubtitleUrl.value = item.value.defaultSubtitleTrack ?? "";
-	}
-	editedDefaultTrack.value = item.value.defaultSubtitleTrack ?? null;
 });
 
 async function saveEdit() {
 	if (props.isPreview) {
-		// Update the subtitle settings for playNow().
-		item.value.defaultSubtitleTrack = getEditedDefaultSubtitleTrack();
+		// Update the subtitle settings for playNow(); `null` is the canonical "no subtitles".
+		item.value.defaultSubtitleTrack = editedDefaultTrack.value;
 		showEditDialog.value = false;
 	} else {
 		isLoadingEdit.value = true;

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -326,7 +326,9 @@ const thumbnailHasError = ref(false);
 const hasError = ref(false);
 const voted = ref(false);
 const showEditDialog = ref(false);
-const editedSubtitleUrl = props.isPreview ? ref("") : ref(item.value.subtitleUrl);
+// External subtitle URL input (non-manifest items) and the manifest track selector
+// both feed the same `defaultSubtitleTrack` field; only one is shown at a time.
+const editedSubtitleUrl = props.isPreview ? ref("") : ref(item.value.defaultSubtitleTrack ?? "");
 
 const isManifestItem = computed(() => item.value.mime === "application/json");
 const editedDefaultTrack = ref<string | null>(null);
@@ -336,6 +338,13 @@ function formatTrackLabel(track: CustomMediaTextTrack): string {
 	const name = track.name ?? track.srclang;
 	const format = track.contentType === "text/x-ass" ? "ASS" : "VTT";
 	return `${name} [${track.srclang}] (${format})`;
+}
+
+// Resolve the edited `defaultSubtitleTrack` from whichever widget applies to this
+// item: the manifest track selector, or the external subtitle URL input (where an
+// empty string means "no subtitles").
+function getEditedDefaultSubtitleTrack(): string | null {
+	return isManifestItem.value ? editedDefaultTrack.value : editedSubtitleUrl.value || null;
 }
 
 const videoLength = computed(() => secondsToTimestamp(item.value?.length ?? 0));
@@ -371,11 +380,9 @@ function getPostData(): VideoAdd {
 		service: item.value.service,
 		id: item.value.id,
 		// Use `item.value.*` for preview since the edited refs might not be saved yet
-		subtitleUrl:
-			(props.isPreview ? item.value.subtitleUrl : editedSubtitleUrl.value) ?? undefined,
 		defaultSubtitleTrack: props.isPreview
 			? item.value.defaultSubtitleTrack
-			: editedDefaultTrack.value,
+			: getEditedDefaultSubtitleTrack(),
 	};
 	return data;
 }
@@ -386,7 +393,7 @@ watch(showEditDialog, open => {
 		return;
 	}
 	if (!props.isPreview) {
-		editedSubtitleUrl.value = item.value.subtitleUrl ?? "";
+		editedSubtitleUrl.value = item.value.defaultSubtitleTrack ?? "";
 	}
 	editedDefaultTrack.value = item.value.defaultSubtitleTrack ?? null;
 });
@@ -394,8 +401,7 @@ watch(showEditDialog, open => {
 async function saveEdit() {
 	if (props.isPreview) {
 		// Update the subtitle settings for playNow().
-		item.value.subtitleUrl = editedSubtitleUrl.value ?? undefined;
-		item.value.defaultSubtitleTrack = editedDefaultTrack.value;
+		item.value.defaultSubtitleTrack = getEditedDefaultSubtitleTrack();
 		showEditDialog.value = false;
 	} else {
 		isLoadingEdit.value = true;

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -220,7 +220,8 @@
 					</FieldLabel>
 					<Input
 						id="edit-subtitle-url"
-						v-model="externalSubtitleUrl"
+						:model-value="editedDefaultTrack ?? ''"
+						@update:model-value="setExternalSubtitleUrl(String($event))"
 						class="font-mono"
 						:disabled="!['direct', 'googledrive'].includes(item.service)"
 						data-cy="edit-subtitle-url"
@@ -289,6 +290,7 @@ import { secondsToTimestamp } from "@/util/timestamp";
 import { ToastStyle } from "@/models/toast";
 import type { QueueItem, VideoAdd } from "ott-common/models/video";
 import type { CustomMediaTextTrack } from "ott-common/models/zod-schemas";
+import { normalizeSubtitleTrack } from "ott-common/subtitle";
 import { QueueMode } from "ott-common/models/types";
 import { useStore } from "@/store";
 import toast from "@/util/toast";
@@ -326,20 +328,12 @@ const thumbnailHasError = ref(false);
 const hasError = ref(false);
 const voted = ref(false);
 const showEditDialog = ref(false);
-// The single source of truth for the edited default subtitle track. `null` is the
-// canonical "no subtitles" value (also what the manifest <Select>'s None item uses).
-// The manifest selector binds to it directly; the external subtitle URL input binds
-// via `externalSubtitleUrl`, which maps the input's empty string to/from `null`.
-// Only one of those widgets is shown at a time.
 const editedDefaultTrack = ref<string | null>(
 	props.isPreview ? null : item.value.defaultSubtitleTrack ?? null,
 );
-const externalSubtitleUrl = computed<string>({
-	get: () => editedDefaultTrack.value ?? "",
-	set: value => {
-		editedDefaultTrack.value = value || null;
-	},
-});
+function setExternalSubtitleUrl(value: string): void {
+	editedDefaultTrack.value = normalizeSubtitleTrack(value);
+}
 
 const isManifestItem = computed(() => item.value.mime === "application/json");
 const manifestTracks = computed<CustomMediaTextTrack[]>(() => item.value.textTracks ?? []);
@@ -382,15 +376,12 @@ function getPostData(): VideoAdd {
 	const data: VideoAdd = {
 		service: item.value.service,
 		id: item.value.id,
-		// `null` is the canonical "no subtitles". Use `item.value.*` for preview since
-		// the edited fields might not be saved yet; `?? null` normalizes undefined.
 		defaultSubtitleTrack:
 			(props.isPreview ? item.value.defaultSubtitleTrack : editedDefaultTrack.value) ?? null,
 	};
 	return data;
 }
 
-// Ensure that the edited values reflect the current item state when the dialog opens
 watch(showEditDialog, open => {
 	if (open && !props.isPreview) {
 		editedDefaultTrack.value = item.value.defaultSubtitleTrack ?? null;
@@ -399,7 +390,6 @@ watch(showEditDialog, open => {
 
 async function saveEdit() {
 	if (props.isPreview) {
-		// Update the subtitle settings for playNow(); `null` is the canonical "no subtitles".
 		item.value.defaultSubtitleTrack = editedDefaultTrack.value;
 		showEditDialog.value = false;
 	} else {

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -190,11 +190,7 @@
 					<FieldLabel for="edit-default-subtitle-track">
 						{{ $t("video-queue-item.edit.default-subtitle-track") }}
 					</FieldLabel>
-					<Spinner v-if="isLoadingManifest" class="size-4" />
-					<FieldDescription v-else-if="manifestError">
-						{{ $t("video-queue-item.edit.manifest-load-failed") }}
-					</FieldDescription>
-					<Select v-else v-model="editedDefaultTrack">
+					<Select v-model="editedDefaultTrack">
 						<SelectTrigger
 							id="edit-default-subtitle-track"
 							data-cy="edit-default-subtitle-track"
@@ -202,10 +198,7 @@
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
-							<SelectItem :value="TRACK_MANIFEST_DEFAULT">
-								{{ $t("video-queue-item.edit.manifest-default") }}
-							</SelectItem>
-							<SelectItem :value="TRACK_NONE">
+							<SelectItem :value="null">
 								{{ $t("video-queue-item.edit.no-subtitles") }}
 							</SelectItem>
 							<SelectItem
@@ -217,7 +210,7 @@
 							</SelectItem>
 						</SelectContent>
 					</Select>
-					<FieldDescription v-if="!manifestError">
+					<FieldDescription>
 						{{ $t("video-queue-item.edit.default-subtitle-track-hint") }}
 					</FieldDescription>
 				</Field>
@@ -295,7 +288,7 @@ import { API } from "@/common-http";
 import { secondsToTimestamp } from "@/util/timestamp";
 import { ToastStyle } from "@/models/toast";
 import type { QueueItem, VideoAdd } from "ott-common/models/video";
-import type { CustomMediaManifest, CustomMediaTextTrack } from "ott-common/models/zod-schemas";
+import type { CustomMediaTextTrack } from "ott-common/models/zod-schemas";
 import { QueueMode } from "ott-common/models/types";
 import { useStore } from "@/store";
 import toast from "@/util/toast";
@@ -335,35 +328,9 @@ const voted = ref(false);
 const showEditDialog = ref(false);
 const editedSubtitleUrl = props.isPreview ? ref("") : ref(item.value.subtitleUrl);
 
-// Sentinel values for the default subtitle track select. `null`/absent on the queue
-// item means "use the manifest's default flag", `""` means "no subtitles".
-const TRACK_MANIFEST_DEFAULT = "\0manifest-default";
-const TRACK_NONE = "\0none";
 const isManifestItem = computed(() => item.value.mime === "application/json");
-const editedDefaultTrack = ref(TRACK_MANIFEST_DEFAULT);
-const manifestTracks = ref<CustomMediaTextTrack[]>([]);
-const manifestError = ref(false);
-const isLoadingManifest = ref(false);
-
-function trackToSelectValue(track: string | null | undefined): string {
-	if (track === null || track === undefined) {
-		return TRACK_MANIFEST_DEFAULT;
-	}
-	if (track === "") {
-		return TRACK_NONE;
-	}
-	return track;
-}
-
-function selectValueToTrack(value: string): string | null {
-	if (value === TRACK_MANIFEST_DEFAULT) {
-		return null;
-	}
-	if (value === TRACK_NONE) {
-		return "";
-	}
-	return value;
-}
+const editedDefaultTrack = ref<string | null>(null);
+const manifestTracks = computed<CustomMediaTextTrack[]>(() => item.value.textTracks ?? []);
 
 function formatTrackLabel(track: CustomMediaTextTrack): string {
 	const name = track.name ?? track.srclang;
@@ -371,23 +338,6 @@ function formatTrackLabel(track: CustomMediaTextTrack): string {
 	return `${name} [${track.srclang}] (${format})`;
 }
 
-async function loadManifestTracks() {
-	isLoadingManifest.value = true;
-	manifestError.value = false;
-	try {
-		const response = await fetch(item.value.src_url ?? item.value.id);
-		if (!response.ok) {
-			throw new Error(`failed to fetch manifest: ${response.status}`);
-		}
-		const manifest = (await response.json()) as CustomMediaManifest;
-		manifestTracks.value = manifest.textTracks ?? [];
-	} catch (e) {
-		console.error("VideoQueueItem: failed to load manifest tracks:", e);
-		manifestError.value = true;
-		manifestTracks.value = [];
-	}
-	isLoadingManifest.value = false;
-}
 const videoLength = computed(() => secondsToTimestamp(item.value?.length ?? 0));
 const videoStartAt = computed(() => secondsToTimestamp(item.value?.startAt ?? 0));
 const thumbnailSource = computed(() => {
@@ -425,7 +375,7 @@ function getPostData(): VideoAdd {
 			(props.isPreview ? item.value.subtitleUrl : editedSubtitleUrl.value) ?? undefined,
 		defaultSubtitleTrack: props.isPreview
 			? item.value.defaultSubtitleTrack
-			: selectValueToTrack(editedDefaultTrack.value),
+			: editedDefaultTrack.value,
 	};
 	return data;
 }
@@ -438,17 +388,14 @@ watch(showEditDialog, open => {
 	if (!props.isPreview) {
 		editedSubtitleUrl.value = item.value.subtitleUrl ?? "";
 	}
-	editedDefaultTrack.value = trackToSelectValue(item.value.defaultSubtitleTrack);
-	if (isManifestItem.value) {
-		loadManifestTracks();
-	}
+	editedDefaultTrack.value = item.value.defaultSubtitleTrack ?? null;
 });
 
 async function saveEdit() {
 	if (props.isPreview) {
-		// Update the subtitle settings for playNow()
+		// Update the subtitle settings for playNow().
 		item.value.subtitleUrl = editedSubtitleUrl.value ?? undefined;
-		item.value.defaultSubtitleTrack = selectValueToTrack(editedDefaultTrack.value);
+		item.value.defaultSubtitleTrack = editedDefaultTrack.value;
 		showEditDialog.value = false;
 	} else {
 		isLoadingEdit.value = true;

--- a/client/src/components/VideoQueueItem.vue
+++ b/client/src/components/VideoQueueItem.vue
@@ -328,9 +328,7 @@ const thumbnailHasError = ref(false);
 const hasError = ref(false);
 const voted = ref(false);
 const showEditDialog = ref(false);
-const editedDefaultTrack = ref<string | null>(
-	props.isPreview ? null : item.value.subtitleUrl ?? null,
-);
+const editedDefaultTrack = ref<string | null>(item.value.subtitleUrl ?? null);
 function setExternalSubtitleUrl(value: string): void {
 	editedDefaultTrack.value = normalizeSubtitleTrack(value);
 }

--- a/client/src/components/composables/ass-overlay.ts
+++ b/client/src/components/composables/ass-overlay.ts
@@ -5,20 +5,13 @@ import ASS from "assjs";
  * Manages an assjs subtitle overlay rendered on top of an HTML5 video element.
  *
  * assjs derives its reference resolution (`layoutRes`) exactly once, in its
- * constructor, from the ASS file's `LayoutResX/Y` and then falls back to
- * `video.videoWidth`/`videoHeight`, and finally to the element's *displayed*
- * pixel size (`clientWidth`/`clientHeight`). It only ever recomputes the
- * subtitle box afterwards (via its own ResizeObserver on the video element) —
- * it never revisits `layoutRes`.
- *
- * That means if the overlay is constructed before the video's metadata has
- * loaded (so `videoWidth` is still 0), assjs scales the subtitles against the
- * player's current display size — whose aspect ratio is usually wrong — and
- * nothing ever corrects it. This is why subtitles looked mis-scaled right after
- * queuing a video but were fine after a reload: a reload serves the video from
- * cache, so it reports its dimensions before the (small, fast) ASS fetch
- * completes. We avoid the race entirely by waiting for the intrinsic dimensions
- * to be known before constructing the instance.
+ * constructor — from the ASS file's `LayoutResX/Y`, else `video.videoWidth/Height`,
+ * else the element's *displayed* pixel size — and never revisits it (it only
+ * recomputes the subtitle box afterwards via its own ResizeObserver). So
+ * constructing before the video's metadata has loaded (while `videoWidth` is 0)
+ * locks the subtitles to the element's display aspect ratio, with nothing to
+ * correct it later. We avoid the race by waiting for the intrinsic dimensions to be
+ * known before constructing the instance.
  *
  * Overlapping loads are disambiguated by a monotonic `loadSeq`: each load claims
  * an id and applies its result only if still the latest, so a slow earlier fetch
@@ -38,9 +31,8 @@ export function useAssOverlay(
 	let cancelWait: (() => void) | null = null;
 
 	/**
-	 * Resolve once the video's intrinsic dimensions are known. assjs reads them in
-	 * its constructor to size its coordinate system, so constructing before they're
-	 * available bakes in a scale based on the element's display size instead.
+	 * Resolve once the video's intrinsic dimensions are known (see the module note
+	 * above on why assjs must be constructed only after that).
 	 */
 	function waitForDimensions(video: HTMLVideoElement): Promise<void> {
 		if (video.videoWidth > 0 && video.videoHeight > 0) {

--- a/client/src/components/composables/ass-overlay.ts
+++ b/client/src/components/composables/ass-overlay.ts
@@ -4,14 +4,21 @@ import ASS from "assjs";
 /**
  * Manages an assjs subtitle overlay rendered on top of an HTML5 video element.
  *
- * assjs only recomputes its subtitle box when the video element's box size
- * changes (via its own internal ResizeObserver). It does NOT recompute when the
- * video's intrinsic resolution becomes known (metadata load) or changes (quality
- * switch). Since the video element here is always sized 100%x100%, constructing
- * the instance before metadata is available leaves the box positioned as if the
- * video filled the whole container (no letterboxing). We fix this by forcing a
- * recompute on the video element's "resize" event, which fires exactly when the
- * intrinsic dimensions first appear and whenever they change.
+ * assjs derives its reference resolution (`layoutRes`) exactly once, in its
+ * constructor, from the ASS file's `LayoutResX/Y` and then falls back to
+ * `video.videoWidth`/`videoHeight`, and finally to the element's *displayed*
+ * pixel size (`clientWidth`/`clientHeight`). It only ever recomputes the
+ * subtitle box afterwards (via its own ResizeObserver on the video element) —
+ * it never revisits `layoutRes`.
+ *
+ * That means if the overlay is constructed before the video's metadata has
+ * loaded (so `videoWidth` is still 0), assjs scales the subtitles against the
+ * player's current display size — whose aspect ratio is usually wrong — and
+ * nothing ever corrects it. This is why subtitles looked mis-scaled right after
+ * queuing a video but were fine after a reload: a reload serves the video from
+ * cache, so it reports its dimensions before the (small, fast) ASS fetch
+ * completes. We avoid the race entirely by waiting for the intrinsic dimensions
+ * to be known before constructing the instance.
  *
  * Overlapping loads are disambiguated by a monotonic `loadSeq`: each load claims
  * an id and applies its result only if still the latest, so a slow earlier fetch
@@ -27,49 +34,45 @@ export function useAssOverlay(
 	// Monotonic load id, bumped per load() and on teardown.
 	let loadSeq = 0;
 	const visible = ref(false);
-	let containerObserver: ResizeObserver | null = null;
+	// Cleanup for a pending waitForDimensions() listener, so teardown can cancel it.
+	let cancelWait: (() => void) | null = null;
 
 	/**
-	 * Force assjs to recompute its subtitle box. assjs has no public resize() —
-	 * the resize logic lives in a private `#resize` only invoked by its internal
-	 * ResizeObserver and by the `resampling` setter. That setter early-returns
-	 * when the value is unchanged (`if (r === this.#resampling) return;`), so we
-	 * toggle to another valid mode and back: each write actually changes the
-	 * value, triggering an internal recompute, and the final mode is unchanged.
+	 * Resolve once the video's intrinsic dimensions are known. assjs reads them in
+	 * its constructor to size its coordinate system, so constructing before they're
+	 * available bakes in a scale based on the element's display size instead.
 	 */
-	function recompute(): void {
-		if (!instance) {
-			throw new Error("useAssOverlay: recompute() called with no active overlay");
+	function waitForDimensions(video: HTMLVideoElement): Promise<void> {
+		if (video.videoWidth > 0 && video.videoHeight > 0) {
+			return Promise.resolve();
 		}
-		const mode = instance.resampling;
-		instance.resampling = mode === "video_height" ? "video_width" : "video_height";
-		instance.resampling = mode;
-	}
-
-	function attachResize(video: HTMLVideoElement, box: HTMLElement): void {
-		video.addEventListener("resize", recompute);
-		// loadedmetadata fires when intrinsic dimensions become known; it may arrive
-		// before the ASS fetch completes, so we re-run recompute here too.
-		video.addEventListener("loadedmetadata", recompute);
-		containerObserver = new ResizeObserver(() => {
-			if (instance) recompute();
+		return new Promise<void>(resolve => {
+			const cleanup = (): void => {
+				video.removeEventListener("loadedmetadata", onReady);
+				video.removeEventListener("resize", onReady);
+				cancelWait = null;
+			};
+			const onReady = (): void => {
+				if (video.videoWidth > 0 && video.videoHeight > 0) {
+					cleanup();
+					resolve();
+				}
+			};
+			// loadedmetadata fires when intrinsic dimensions first become known;
+			// resize covers a source/quality switch that changes them.
+			video.addEventListener("loadedmetadata", onReady);
+			video.addEventListener("resize", onReady);
+			// Let teardown abort the wait; the seq check in fetchAndCreate then bails.
+			cancelWait = () => {
+				cleanup();
+				resolve();
+			};
 		});
-		containerObserver.observe(box);
-	}
-
-	function detachResize(video: HTMLVideoElement): void {
-		video.removeEventListener("resize", recompute);
-		video.removeEventListener("loadedmetadata", recompute);
-		containerObserver?.disconnect();
-		containerObserver = null;
 	}
 
 	function destroy(): void {
 		loadSeq++; // invalidate any in-flight load
-
-		if (videoElement.value) {
-			detachResize(videoElement.value);
-		}
+		cancelWait?.();
 		instance?.destroy();
 		instance = null;
 		currentUrl = null;
@@ -93,12 +96,15 @@ export function useAssOverlay(
 				console.warn("useAssOverlay: discarding stale ASS load for", url);
 				return;
 			}
+			// Don't build the overlay until the video resolution is known, or assjs
+			// will lock its subtitle scale to the element's display size.
+			await waitForDimensions(video);
+			if (seq !== loadSeq) {
+				console.warn("useAssOverlay: discarding stale ASS load for", url);
+				return;
+			}
 			instance = new ASS(content, video, { container: box });
 			visible.value = true;
-			attachResize(video, box);
-			// Defer recompute to the next animation frame so the browser has
-			// finished layout before assjs reads the video's bounding rect.
-			requestAnimationFrame(recompute);
 		} catch (e) {
 			if (seq !== loadSeq) {
 				console.info("useAssOverlay: ignoring superseded ASS load failure for", url);

--- a/client/src/components/composables/ass-overlay.ts
+++ b/client/src/components/composables/ass-overlay.ts
@@ -1,5 +1,16 @@
 import { onBeforeUnmount, type Ref, ref } from "vue";
 import ASS from "assjs";
+import { i18n } from "@/i18n";
+import toast from "@/util/toast";
+import { ToastStyle } from "@/models/toast";
+
+function notifySubtitleLoadFailed(): void {
+	toast.add({
+		style: ToastStyle.Error,
+		content: i18n.global.t("room.subtitle-load-failed"),
+		duration: 6000,
+	});
+}
 
 export function useAssOverlay(
 	videoElement: Ref<HTMLVideoElement | undefined>,
@@ -82,6 +93,14 @@ export function useAssOverlay(
 				return false;
 			}
 			console.error("useAssOverlay: failed to load ASS subtitles:", url, e);
+			if (e instanceof TypeError) {
+				console.error(
+					"useAssOverlay: could not load subtitles from url. This could be a CORS issue. see docs/custom-media-format.md",
+					url,
+					e,
+				);
+			}
+			notifySubtitleLoadFailed();
 			currentUrl = null;
 			return false;
 		}

--- a/client/src/components/composables/ass-overlay.ts
+++ b/client/src/components/composables/ass-overlay.ts
@@ -1,0 +1,154 @@
+import { onBeforeUnmount, type Ref, ref } from "vue";
+import ASS from "assjs";
+
+/**
+ * Manages an assjs subtitle overlay rendered on top of an HTML5 video element.
+ *
+ * assjs only recomputes its subtitle box when the video element's box size
+ * changes (via its own internal ResizeObserver). It does NOT recompute when the
+ * video's intrinsic resolution becomes known (metadata load) or changes (quality
+ * switch). Since the video element here is always sized 100%x100%, constructing
+ * the instance before metadata is available leaves the box positioned as if the
+ * video filled the whole container (no letterboxing). We fix this by forcing a
+ * recompute on the video element's "resize" event, which fires exactly when the
+ * intrinsic dimensions first appear and whenever they change.
+ *
+ * Overlapping loads are disambiguated by a monotonic `loadSeq`: each load claims
+ * an id and applies its result only if still the latest, so a slow earlier fetch
+ * can't clobber a newer one even when both target the same url.
+ */
+export function useAssOverlay(
+	videoElement: Ref<HTMLVideoElement | undefined>,
+	container: Ref<HTMLElement | undefined>,
+) {
+	let instance: ASS | null = null;
+	// The active or in-flight track; drives the fast path/dedupe. Null when none.
+	let currentUrl: string | null = null;
+	// Monotonic load id, bumped per load() and on teardown.
+	let loadSeq = 0;
+	const visible = ref(false);
+	let containerObserver: ResizeObserver | null = null;
+
+	/**
+	 * Force assjs to recompute its subtitle box. assjs has no public resize() —
+	 * the resize logic lives in a private `#resize` only invoked by its internal
+	 * ResizeObserver and by the `resampling` setter. That setter early-returns
+	 * when the value is unchanged (`if (r === this.#resampling) return;`), so we
+	 * toggle to another valid mode and back: each write actually changes the
+	 * value, triggering an internal recompute, and the final mode is unchanged.
+	 */
+	function recompute(): void {
+		if (!instance) {
+			throw new Error("useAssOverlay: recompute() called with no active overlay");
+		}
+		const mode = instance.resampling;
+		instance.resampling = mode === "video_height" ? "video_width" : "video_height";
+		instance.resampling = mode;
+	}
+
+	function attachResize(video: HTMLVideoElement, box: HTMLElement): void {
+		video.addEventListener("resize", recompute);
+		// loadedmetadata fires when intrinsic dimensions become known; it may arrive
+		// before the ASS fetch completes, so we re-run recompute here too.
+		video.addEventListener("loadedmetadata", recompute);
+		containerObserver = new ResizeObserver(() => {
+			if (instance) recompute();
+		});
+		containerObserver.observe(box);
+	}
+
+	function detachResize(video: HTMLVideoElement): void {
+		video.removeEventListener("resize", recompute);
+		video.removeEventListener("loadedmetadata", recompute);
+		containerObserver?.disconnect();
+		containerObserver = null;
+	}
+
+	function destroy(): void {
+		loadSeq++; // invalidate any in-flight load
+
+		if (videoElement.value) {
+			detachResize(videoElement.value);
+		}
+		instance?.destroy();
+		instance = null;
+		currentUrl = null;
+		visible.value = false;
+	}
+
+	async function fetchAndCreate(
+		url: string,
+		video: HTMLVideoElement,
+		box: HTMLElement,
+	): Promise<void> {
+		const seq = ++loadSeq; // claim an id before the first await
+		currentUrl = url;
+		try {
+			const response = await fetch(url);
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}`);
+			}
+			const content = await response.text();
+			if (seq !== loadSeq) {
+				console.warn("useAssOverlay: discarding stale ASS load for", url);
+				return;
+			}
+			instance = new ASS(content, video, { container: box });
+			visible.value = true;
+			attachResize(video, box);
+			// Defer recompute to the next animation frame so the browser has
+			// finished layout before assjs reads the video's bounding rect.
+			requestAnimationFrame(recompute);
+		} catch (e) {
+			if (seq !== loadSeq) {
+				console.info("useAssOverlay: ignoring superseded ASS load failure for", url);
+				return;
+			}
+			console.error("useAssOverlay: failed to load ASS subtitles:", e);
+			currentUrl = null; // free the slot so this track can be retried
+		}
+	}
+
+	/**
+	 * Load and display the ASS track at `url`. If it's already the active (or
+	 * in-flight) track this is a no-op beyond ensuring visibility; switching to a
+	 * different url tears down the current overlay and supersedes any in-flight
+	 * load via the `loadSeq` token.
+	 */
+	function load(url: string): Promise<void> {
+		const video = videoElement.value;
+		const box = container.value;
+		if (!video || !box) {
+			throw new Error("useAssOverlay.load() called before the video element was mounted");
+		}
+		if (currentUrl === url) {
+			if (instance) {
+				console.info("useAssOverlay: track already active, ensuring visible:", url);
+				show();
+			} else {
+				console.info("useAssOverlay: track already loading:", url);
+			}
+			return Promise.resolve();
+		}
+		destroy();
+		return fetchAndCreate(url, video, box);
+	}
+
+	function show(): void {
+		if (!instance) {
+			console.warn("useAssOverlay: show() called with no active overlay");
+			return;
+		}
+		instance.show();
+		visible.value = true;
+	}
+
+	function hide(): void {
+		instance?.hide();
+		visible.value = false;
+	}
+
+	onBeforeUnmount(destroy);
+
+	return { load, show, hide, destroy, visible };
+}

--- a/client/src/components/composables/ass-overlay.ts
+++ b/client/src/components/composables/ass-overlay.ts
@@ -1,39 +1,16 @@
 import { onBeforeUnmount, type Ref, ref } from "vue";
 import ASS from "assjs";
 
-/**
- * Manages an assjs subtitle overlay rendered on top of an HTML5 video element.
- *
- * assjs derives its reference resolution (`layoutRes`) exactly once, in its
- * constructor — from the ASS file's `LayoutResX/Y`, else `video.videoWidth/Height`,
- * else the element's *displayed* pixel size — and never revisits it (it only
- * recomputes the subtitle box afterwards via its own ResizeObserver). So
- * constructing before the video's metadata has loaded (while `videoWidth` is 0)
- * locks the subtitles to the element's display aspect ratio, with nothing to
- * correct it later. We avoid the race by waiting for the intrinsic dimensions to be
- * known before constructing the instance.
- *
- * Overlapping loads are disambiguated by a monotonic `loadSeq`: each load claims
- * an id and applies its result only if still the latest, so a slow earlier fetch
- * can't clobber a newer one even when both target the same url.
- */
 export function useAssOverlay(
 	videoElement: Ref<HTMLVideoElement | undefined>,
 	container: Ref<HTMLElement | undefined>,
 ) {
 	let instance: ASS | null = null;
-	// The active or in-flight track; drives the fast path/dedupe. Null when none.
 	let currentUrl: string | null = null;
-	// Monotonic load id, bumped per load() and on teardown.
 	let loadSeq = 0;
 	const visible = ref(false);
-	// Cleanup for a pending waitForDimensions() listener, so teardown can cancel it.
 	let cancelWait: (() => void) | null = null;
 
-	/**
-	 * Resolve once the video's intrinsic dimensions are known (see the module note
-	 * above on why assjs must be constructed only after that).
-	 */
 	function waitForDimensions(video: HTMLVideoElement): Promise<void> {
 		if (video.videoWidth > 0 && video.videoHeight > 0) {
 			return Promise.resolve();
@@ -50,11 +27,8 @@ export function useAssOverlay(
 					resolve();
 				}
 			};
-			// loadedmetadata fires when intrinsic dimensions first become known;
-			// resize covers a source/quality switch that changes them.
 			video.addEventListener("loadedmetadata", onReady);
 			video.addEventListener("resize", onReady);
-			// Let teardown abort the wait; the seq check in fetchAndCreate then bails.
 			cancelWait = () => {
 				cleanup();
 				resolve();
@@ -63,7 +37,7 @@ export function useAssOverlay(
 	}
 
 	function destroy(): void {
-		loadSeq++; // invalidate any in-flight load
+		loadSeq++;
 		cancelWait?.();
 		instance?.destroy();
 		instance = null;
@@ -71,12 +45,13 @@ export function useAssOverlay(
 		visible.value = false;
 	}
 
+	// Returns whether the overlay is now active; failures are logged and reported as false, not thrown.
 	async function fetchAndCreate(
 		url: string,
 		video: HTMLVideoElement,
 		box: HTMLElement,
-	): Promise<void> {
-		const seq = ++loadSeq; // claim an id before the first await
+	): Promise<boolean> {
+		const seq = ++loadSeq;
 		currentUrl = url;
 		try {
 			const response = await fetch(url);
@@ -85,48 +60,45 @@ export function useAssOverlay(
 			}
 			const content = await response.text();
 			if (seq !== loadSeq) {
-				console.warn("useAssOverlay: discarding stale ASS load for", url);
-				return;
+				console.debug("useAssOverlay: ASS load superseded after fetch, ignoring:", url);
+				return false;
 			}
-			// Don't build the overlay until the video resolution is known, or assjs
-			// will lock its subtitle scale to the element's display size.
 			await waitForDimensions(video);
 			if (seq !== loadSeq) {
-				console.warn("useAssOverlay: discarding stale ASS load for", url);
-				return;
+				console.debug(
+					"useAssOverlay: ASS load superseded while awaiting video dimensions, ignoring:",
+					url,
+				);
+				return false;
 			}
+			// assjs attaches a ResizeObserver to the video element, so subtitles keep rendering
+			// at the correct position when the video's dimensions change.
 			instance = new ASS(content, video, { container: box });
 			visible.value = true;
+			return true;
 		} catch (e) {
 			if (seq !== loadSeq) {
-				console.info("useAssOverlay: ignoring superseded ASS load failure for", url);
-				return;
+				console.debug("useAssOverlay: superseded ASS load failed, ignoring:", url, e);
+				return false;
 			}
-			console.error("useAssOverlay: failed to load ASS subtitles:", e);
-			currentUrl = null; // free the slot so this track can be retried
+			console.error("useAssOverlay: failed to load ASS subtitles:", url, e);
+			currentUrl = null;
+			return false;
 		}
 	}
 
-	/**
-	 * Load and display the ASS track at `url`. If it's already the active (or
-	 * in-flight) track this is a no-op beyond ensuring visibility; switching to a
-	 * different url tears down the current overlay and supersedes any in-flight
-	 * load via the `loadSeq` token.
-	 */
-	function load(url: string): Promise<void> {
+	function load(url: string): Promise<boolean> {
 		const video = videoElement.value;
 		const box = container.value;
 		if (!video || !box) {
-			throw new Error("useAssOverlay.load() called before the video element was mounted");
+			console.error("useAssOverlay: load() called before the video element was mounted");
+			return Promise.resolve(false);
 		}
 		if (currentUrl === url) {
 			if (instance) {
-				console.info("useAssOverlay: track already active, ensuring visible:", url);
 				show();
-			} else {
-				console.info("useAssOverlay: track already loading:", url);
 			}
-			return Promise.resolve();
+			return Promise.resolve(true);
 		}
 		destroy();
 		return fetchAndCreate(url, video, box);

--- a/client/src/components/composables/ass-overlay.ts
+++ b/client/src/components/composables/ass-overlay.ts
@@ -1,21 +1,23 @@
 import { onBeforeUnmount, type Ref, ref } from "vue";
+import { useI18n } from "vue-i18n";
 import ASS from "assjs";
-import { i18n } from "@/i18n";
 import toast from "@/util/toast";
 import { ToastStyle } from "@/models/toast";
-
-function notifySubtitleLoadFailed(): void {
-	toast.add({
-		style: ToastStyle.Error,
-		content: i18n.global.t("room.subtitle-load-failed"),
-		duration: 6000,
-	});
-}
 
 export function useAssOverlay(
 	videoElement: Ref<HTMLVideoElement | undefined>,
 	container: Ref<HTMLElement | undefined>,
 ) {
+	// The app-level i18n instance from "@/i18n" has no `.t`; only useI18n() provides it.
+	const { t } = useI18n();
+
+	function notifySubtitleLoadFailed(): void {
+		toast.add({
+			style: ToastStyle.Error,
+			content: t("room.subtitle-load-failed"),
+			duration: 6000,
+		});
+	}
 	let instance: ASS | null = null;
 	let currentUrl: string | null = null;
 	let loadSeq = 0;

--- a/client/src/components/composables/index.ts
+++ b/client/src/components/composables/index.ts
@@ -1,3 +1,4 @@
+export * from "./ass-overlay";
 export * from "./copy-from-textbox";
 export * from "./media-audio-boost";
 export * from "./media-player";

--- a/client/src/components/controls/VideoSettings.vue
+++ b/client/src/components/controls/VideoSettings.vue
@@ -257,8 +257,6 @@ function selectSubtitleTrack(track: number): void {
 .menu-scroll {
 	display: flex;
 	flex-direction: column;
-	/* Cap the list height so a large number of tracks doesn't overflow the
-	   viewport. The list scrolls instead, keeping the back-header in view. */
 	max-height: min(50vh, 320px);
 	overflow-y: auto;
 	overscroll-behavior: contain;

--- a/client/src/components/controls/VideoSettings.vue
+++ b/client/src/components/controls/VideoSettings.vue
@@ -60,26 +60,28 @@
 						<span>{{ $t("room.quality") }}</span>
 					</button>
 
-					<button
-						v-if="qualities.isAutoQualitySupported.value"
-						type="button"
-						class="menu-item"
-						:class="{ 'menu-item-active': isAutoQualityActive }"
-						@click="selectQuality(-1)"
-					>
-						{{ autoQualityDisplay }}
-					</button>
+					<div class="menu-scroll">
+						<button
+							v-if="qualities.isAutoQualitySupported.value"
+							type="button"
+							class="menu-item"
+							:class="{ 'menu-item-active': isAutoQualityActive }"
+							@click="selectQuality(-1)"
+						>
+							{{ autoQualityDisplay }}
+						</button>
 
-					<button
-						v-for="(quality, idx) in qualities.videoTracks.value"
-						:key="idx"
-						type="button"
-						class="menu-item"
-						:class="{ 'menu-item-active': idx === qualities.currentVideoTrack.value }"
-						@click="selectQuality(idx)"
-					>
-						{{ formatQuality(quality) }}
-					</button>
+						<button
+							v-for="(quality, idx) in qualities.videoTracks.value"
+							:key="idx"
+							type="button"
+							class="menu-item"
+							:class="{ 'menu-item-active': idx === qualities.currentVideoTrack.value }"
+							@click="selectQuality(idx)"
+						>
+							{{ formatQuality(quality) }}
+						</button>
+					</div>
 				</div>
 
 				<!-- Subtitle submenu -->
@@ -93,21 +95,23 @@
 						<span>{{ $t("room.subtitles") }}</span>
 					</button>
 
-					<button
-						v-for="(track, idx) in captions.captionsTracks.value"
-						:key="idx"
-						type="button"
-						class="menu-item"
-						:class="{ 'menu-item-active': isSubtitleTrackActive(idx) }"
-						@click="selectSubtitleTrack(idx)"
-					>
-						<span class="menu-item-content">{{ formatCaption(track) }}</span>
-						<Icon
-							v-if="track.kind === 'captions'"
-							:icon="mdiClosedCaption"
-							class="size-5 shrink-0"
-						/>
-					</button>
+					<div class="menu-scroll">
+						<button
+							v-for="(track, idx) in captions.captionsTracks.value"
+							:key="idx"
+							type="button"
+							class="menu-item"
+							:class="{ 'menu-item-active': isSubtitleTrackActive(idx) }"
+							@click="selectSubtitleTrack(idx)"
+						>
+							<span class="menu-item-content">{{ formatCaption(track) }}</span>
+							<Icon
+								v-if="track.kind === 'captions'"
+								:icon="mdiClosedCaption"
+								class="size-5 shrink-0"
+							/>
+						</button>
+					</div>
 				</div>
 			</Transition>
 		</PopoverContent>
@@ -248,6 +252,16 @@ function selectSubtitleTrack(track: number): void {
 	min-height: fit-content;
 	display: flex;
 	flex-direction: column;
+}
+
+.menu-scroll {
+	display: flex;
+	flex-direction: column;
+	/* Cap the list height so a large number of tracks doesn't overflow the
+	   viewport. The list scrolls instead, keeping the back-header in view. */
+	max-height: min(50vh, 320px);
+	overflow-y: auto;
+	overscroll-behavior: contain;
 }
 
 .menu-item {

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -54,11 +54,11 @@ interface Props {
 	 * URL of an external subtitle file. `null`/`undefined` means no subtitles are
 	 * shown by default.
 	 */
-	defaultTrack?: string | null;
+	defaultSubtitleTrack?: string | null;
 }
 
 const props = defineProps<Props>();
-const { videoUrl, videoMime, thumbnail, defaultTrack } = toRefs(props);
+const { videoUrl, videoMime, thumbnail, defaultSubtitleTrack } = toRefs(props);
 const videoElem = ref<HTMLVideoElement | undefined>();
 const captions = useCaptions();
 const audioBoost = useMediaAudioBoost(videoElem);
@@ -68,24 +68,24 @@ const assContainer = ref<HTMLDivElement | undefined>();
 
 /**
  * The available text tracks, unified across source types. Manifest items declare
- * their tracks; for other items the single `defaultTrack` external subtitle (if
- * any) is the only track.
+ * their tracks; for other items the single `defaultSubtitleTrack` external subtitle
+ * (if any) is the only track.
  */
 const textTracks = computed<CustomMediaTextTrack[]>(() => {
 	if (videoMime.value === "application/json") {
 		return manifest.value?.textTracks ?? [];
 	}
-	if (defaultTrack.value) {
+	if (defaultSubtitleTrack.value) {
 		// Infer the subtitle format of the external (non-manifest) track from its
 		// URL so external `.vtt`/`.ass` files go through the same rendering paths as
 		// the tracks declared by a manifest.
-		const path = defaultTrack.value.split("?")[0].split("#")[0];
+		const path = defaultSubtitleTrack.value.split("?")[0].split("#")[0];
 		const ext = path.split(".").pop()?.toLowerCase();
 		const contentType: CustomMediaTextTrack["contentType"] =
 			ext === "ass" || ext === "ssa" ? "text/x-ass" : "text/vtt";
 		return [
 			{
-				url: defaultTrack.value,
+				url: defaultSubtitleTrack.value,
 				contentType,
 				srclang: "und",
 				default: true,
@@ -156,27 +156,26 @@ function isCaptionsSupported(): boolean {
 	return true;
 }
 
-function textTrack(idx: number) {
+function textTrackAt(idx: number) {
 	return textTracks.value[idx];
 }
 
 /**
- * Maps a text track index to its index in the native videoElem.textTracks list,
- * which only contains the VTT tracks. Returns -1 for non-VTT tracks.
+ * Resolves the native TextTrack backing a VTT track url. Only VTT tracks are
+ * rendered as <track> elements, so ASS (and unknown) urls return undefined.
+ * Keying off the <track src> avoids mapping unified indices onto the VTT-only
+ * native list.
  */
-function nativeTrackIndex(idx: number): number {
-	const tracks = textTracks.value;
-	if (tracks[idx]?.contentType !== "text/vtt") {
-		return -1;
-	}
-	return tracks.slice(0, idx).filter(t => t.contentType === "text/vtt").length;
+function nativeTrackFor(url: string): TextTrack | undefined {
+	const el = videoElem.value?.querySelector<HTMLTrackElement>(`track[src="${CSS.escape(url)}"]`);
+	return el?.track ?? undefined;
 }
 
 /**
  * Activate the ASS overlay for the given text track index, if it exists.
  */
 function activateAssTrack(idx: number): Promise<void> {
-	const track = textTrack(idx);
+	const track = textTrackAt(idx);
 	if (!track) {
 		return Promise.resolve();
 	}
@@ -196,7 +195,7 @@ function setCaptionsEnabled(enabled: boolean): void {
 		}
 		return;
 	}
-	const track = textTrack(captions.currentTrack.value);
+	const track = textTrackAt(captions.currentTrack.value);
 	if (!track) {
 		console.warn("DirectPlayer: invalid captions track index:", captions.currentTrack.value);
 		return;
@@ -209,8 +208,10 @@ function setCaptionsEnabled(enabled: boolean): void {
 		}
 		return;
 	}
-	const nativeIdx = nativeTrackIndex(captions.currentTrack.value);
-	videoElem.value.textTracks[nativeIdx].mode = enabled ? "showing" : "hidden";
+	const native = nativeTrackFor(track.url);
+	if (native) {
+		native.mode = enabled ? "showing" : "hidden";
+	}
 }
 
 function isCaptionsEnabled(): boolean {
@@ -241,14 +242,15 @@ function setCaptionsTrack(track: number): void {
 		return;
 	}
 	console.log("DirectPlayer: setCaptionsTrack:", track);
-	const selected = textTrack(track);
+	const selected = textTrackAt(track);
 	if (!selected) {
 		console.warn("DirectPlayer: invalid captions track index:", track);
 		return;
 	}
-	const nativeIdx = nativeTrackIndex(track);
-	for (let i = 0; i < videoElem.value.textTracks.length; i++) {
-		videoElem.value.textTracks[i].mode = i === nativeIdx ? "showing" : "hidden";
+	const selectedNative =
+		selected.contentType === "text/vtt" ? nativeTrackFor(selected.url) : undefined;
+	for (const native of Array.from(videoElem.value.textTracks)) {
+		native.mode = native === selectedNative ? "showing" : "hidden";
 	}
 	if (selected.contentType === "text/x-ass") {
 		activateAssTrack(track);
@@ -381,19 +383,22 @@ async function loadVideoSource() {
 	// track's mode to "showing" below.
 	captions.captionsTracks.value = getCaptionsTracks();
 	let defaultTrackIdx = -1;
-	if (defaultTrack.value) {
-		defaultTrackIdx = textTracks.value.findIndex(t => t.url === defaultTrack.value);
+	if (defaultSubtitleTrack.value) {
+		defaultTrackIdx = textTracks.value.findIndex(t => t.url === defaultSubtitleTrack.value);
 	}
 	captions.currentTrack.value = defaultTrackIdx;
 	captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
 	if (defaultTrackIdx !== -1) {
-		if (textTrack(defaultTrackIdx)?.contentType === "text/x-ass") {
+		if (textTrackAt(defaultTrackIdx)?.contentType === "text/x-ass") {
 			// Fire-and-forget: the overlay builds itself once the video's
 			// dimensions are known, so it must not block load()/play() below.
 			activateAssTrack(defaultTrackIdx);
 		} else {
 			await nextTick();
-			videoElem.value.textTracks[nativeTrackIndex(defaultTrackIdx)].mode = "showing";
+			const native = nativeTrackFor(textTrackAt(defaultTrackIdx).url);
+			if (native) {
+				native.mode = "showing";
+			}
 		}
 	}
 
@@ -455,8 +460,8 @@ onMounted(() => {
 	loadVideoSource();
 });
 
-watch([videoUrl, defaultTrack], () => {
-	console.log("DirectPlayer: videoUrl or defaultTrack changed");
+watch([videoUrl, defaultSubtitleTrack], () => {
+	console.log("DirectPlayer: videoUrl or defaultSubtitleTrack changed");
 	loadVideoSource();
 });
 

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -67,17 +67,6 @@ const manifest = ref<CustomMediaManifest | null>(null);
 const assContainer = ref<HTMLDivElement | undefined>();
 
 /**
- * Infer the subtitle format of an external (non-manifest) track from its URL so
- * external `.vtt`/`.ass` files go through the same rendering paths as the tracks
- * declared by a manifest.
- */
-function inferSubtitleContentType(url: string): CustomMediaTextTrack["contentType"] {
-	const path = url.split("?")[0].split("#")[0];
-	const ext = path.split(".").pop()?.toLowerCase();
-	return ext === "ass" || ext === "ssa" ? "text/x-ass" : "text/vtt";
-}
-
-/**
  * The available text tracks, unified across source types. Manifest items declare
  * their tracks; for other items the single `defaultTrack` external subtitle (if
  * any) is the only track.
@@ -87,10 +76,17 @@ const textTracks = computed<CustomMediaTextTrack[]>(() => {
 		return manifest.value?.textTracks ?? [];
 	}
 	if (defaultTrack.value) {
+		// Infer the subtitle format of the external (non-manifest) track from its
+		// URL so external `.vtt`/`.ass` files go through the same rendering paths as
+		// the tracks declared by a manifest.
+		const path = defaultTrack.value.split("?")[0].split("#")[0];
+		const ext = path.split(".").pop()?.toLowerCase();
+		const contentType: CustomMediaTextTrack["contentType"] =
+			ext === "ass" || ext === "ssa" ? "text/x-ass" : "text/vtt";
 		return [
 			{
 				url: defaultTrack.value,
-				contentType: inferSubtitleContentType(defaultTrack.value),
+				contentType,
 				srclang: "und",
 				default: true,
 			},

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -42,18 +42,13 @@ import type {
 	MediaPlayerWithQuality,
 } from "../composables";
 import { useAssOverlay, useCaptions, useMediaAudioBoost, useQualities } from "../composables";
+import { externalSubtitleAsTextTrack } from "ott-common/subtitle";
 
 interface Props {
 	service: string;
 	videoUrl: string;
 	videoMime: string;
 	thumbnail?: string;
-	/**
-	 * URL of the subtitle track to select by default for all viewers. For manifest
-	 * items it must be one of the manifest's text tracks; for other items it is the
-	 * URL of an external subtitle file. `null`/`undefined` means no subtitles are
-	 * shown by default.
-	 */
 	defaultSubtitleTrack?: string | null;
 }
 
@@ -66,31 +61,13 @@ const qualities = useQualities();
 const manifest = ref<CustomMediaManifest | null>(null);
 const assContainer = ref<HTMLDivElement | undefined>();
 
-/**
- * The available text tracks, unified across source types. Manifest items declare
- * their tracks; for other items the single `defaultSubtitleTrack` external subtitle
- * (if any) is the only track.
- */
+// Note: this list includes ASS tracks, which have no <track> DOM element (see nativeTrackFor).
 const textTracks = computed<CustomMediaTextTrack[]>(() => {
 	if (videoMime.value === "application/json") {
 		return manifest.value?.textTracks ?? [];
 	}
 	if (defaultSubtitleTrack.value) {
-		// Infer the subtitle format of the external (non-manifest) track from its
-		// URL so external `.vtt`/`.ass` files go through the same rendering paths as
-		// the tracks declared by a manifest.
-		const path = defaultSubtitleTrack.value.split("?")[0].split("#")[0];
-		const ext = path.split(".").pop()?.toLowerCase();
-		const contentType: CustomMediaTextTrack["contentType"] =
-			ext === "ass" || ext === "ssa" ? "text/x-ass" : "text/vtt";
-		return [
-			{
-				url: defaultSubtitleTrack.value,
-				contentType,
-				srclang: "und",
-				default: true,
-			},
-		];
+		return [externalSubtitleAsTextTrack(defaultSubtitleTrack.value)];
 	}
 	return [];
 });
@@ -160,26 +137,27 @@ function textTrackAt(idx: number) {
 	return textTracks.value[idx];
 }
 
-/**
- * Resolves the native TextTrack backing a VTT track url. Only VTT tracks are
- * rendered as <track> elements, so ASS (and unknown) urls return undefined.
- * Keying off the <track src> avoids mapping unified indices onto the VTT-only
- * native list.
- */
+// captions.currentTrack indexes the logical `textTracks` list (which includes ASS tracks),
+// but `videoElem.textTracks` only contains the VTT <track> DOM elements. Those two index
+// spaces diverge whenever an ASS track is present, so native tracks are resolved by URL
+// rather than by index.
 function nativeTrackFor(url: string): TextTrack | undefined {
 	const el = videoElem.value?.querySelector<HTMLTrackElement>(`track[src="${CSS.escape(url)}"]`);
 	return el?.track ?? undefined;
 }
 
-/**
- * Activate the ASS overlay for the given text track index, if it exists.
- */
-function activateAssTrack(idx: number): Promise<void> {
+async function activateAssTrack(idx: number): Promise<void> {
 	const track = textTrackAt(idx);
 	if (!track) {
-		return Promise.resolve();
+		return;
 	}
-	return assOverlay.load(track.url);
+	const shown = await assOverlay.load(track.url);
+	// Guard against a newer selection: only reflect "no captions" if this track is still
+	// the current one, so a rapid switch isn't clobbered.
+	if (!shown && captions.currentTrack.value === idx) {
+		captions.currentTrack.value = -1;
+		captions.isCaptionsEnabled.value = false;
+	}
 }
 
 function setCaptionsEnabled(enabled: boolean): void {
@@ -376,11 +354,6 @@ async function loadVideoSource() {
 		qualities.currentVideoTrack.value = -1;
 	}
 
-	// The default subtitle track (set via the Edit Video dialog) selects which track
-	// to show by default, the same way for manifest tracks and external subtitle
-	// files. A URL selects that track; `null`/`undefined` means no subtitles. Newly
-	// inserted <track> elements start "disabled", so we explicitly set the chosen
-	// track's mode to "showing" below.
 	captions.captionsTracks.value = getCaptionsTracks();
 	let defaultTrackIdx = -1;
 	if (defaultSubtitleTrack.value) {
@@ -390,14 +363,15 @@ async function loadVideoSource() {
 	captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
 	if (defaultTrackIdx !== -1) {
 		if (textTrackAt(defaultTrackIdx)?.contentType === "text/x-ass") {
-			// Fire-and-forget: the overlay builds itself once the video's
-			// dimensions are known, so it must not block load()/play() below.
 			activateAssTrack(defaultTrackIdx);
 		} else {
 			await nextTick();
-			const native = nativeTrackFor(textTrackAt(defaultTrackIdx).url);
+			const url = textTrackAt(defaultTrackIdx).url;
+			const native = nativeTrackFor(url);
 			if (native) {
 				native.mode = "showing";
+			} else {
+				console.warn("DirectPlayer: default subtitle track element not found:", url);
 			}
 		}
 	}

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onMounted, ref, toRefs, watch } from "vue";
+import { computed, onMounted, ref, toRefs, watch } from "vue";
 import type { CaptionTrack, VideoTrack } from "@/models/media-tracks";
 import type {
 	CustomMediaManifest,
@@ -61,7 +61,6 @@ const qualities = useQualities();
 const manifest = ref<CustomMediaManifest | null>(null);
 const assContainer = ref<HTMLDivElement | undefined>();
 
-// Note: this list includes ASS tracks, which have no <track> DOM element (see nativeTrackFor).
 const textTracks = computed<CustomMediaTextTrack[]>(() => {
 	if (videoMime.value === "application/json") {
 		return manifest.value?.textTracks ?? [];
@@ -75,6 +74,8 @@ const vttTracks = computed(() =>
 	textTracks.value.filter(track => track.contentType === "text/vtt")
 );
 const assOverlay = useAssOverlay(videoElem, assContainer);
+// -1 = none. Whether the selected track is shown is gated separately by captions.isCaptionsEnabled.
+const selectedTrack = ref(-1);
 
 const emit = defineEmits<{
 	"apiready": [];
@@ -133,79 +134,48 @@ function isCaptionsSupported(): boolean {
 	return true;
 }
 
-function textTrackAt(idx: number) {
-	return textTracks.value[idx];
+function clearRendering(): void {
+	if (videoElem.value) {
+		for (const native of Array.from(videoElem.value.textTracks)) {
+			native.mode = "hidden";
+		}
+	}
+	assOverlay.destroy();
 }
 
-// captions.currentTrack indexes the logical `textTracks` list (which includes ASS tracks),
-// but `videoElem.textTracks` only contains the VTT <track> DOM elements. Those two index
-// spaces diverge whenever an ASS track is present, so native tracks are resolved by URL
-// rather than by index.
-function nativeTrackFor(url: string): TextTrack | undefined {
-	const el = videoElem.value?.querySelector<HTMLTrackElement>(`track[src="${CSS.escape(url)}"]`);
-	return el?.track ?? undefined;
-}
-
-async function activateAssTrack(idx: number): Promise<void> {
-	const track = textTrackAt(idx);
+function applyCaptions(): void {
+	clearRendering();
+	if (!captions.isCaptionsEnabled.value) {
+		return;
+	}
+	const track = textTracks.value[selectedTrack.value];
 	if (!track) {
 		return;
 	}
-	const shown = await assOverlay.load(track.url);
-	// Guard against a newer selection: only reflect "no captions" if this track is still
-	// the current one, so a rapid switch isn't clobbered.
-	if (!shown && captions.currentTrack.value === idx) {
-		captions.currentTrack.value = -1;
-		captions.isCaptionsEnabled.value = false;
+	switch (track.contentType) {
+		case "text/x-ass":
+			assOverlay.load(track.url);
+			break;
+		case "text/vtt": {
+			const el = videoElem.value?.querySelector<HTMLTrackElement>(
+				`track[src="${CSS.escape(track.url)}"]`
+			);
+			if (el?.track) {
+				el.track.mode = "showing";
+			} else {
+				console.warn("DirectPlayer: subtitle track element not found:", track.url);
+			}
+			break;
+		}
+		default:
+			console.warn("DirectPlayer: unsupported subtitle content type:", track.contentType);
 	}
 }
 
-function setCaptionsEnabled(enabled: boolean): void {
-	if (!videoElem.value || captions.currentTrack.value === null) {
-		return;
-	}
-	if (textTracks.value.length === 0) {
-		return;
-	}
-	if (captions.currentTrack.value === -1) {
-		if (enabled) {
-			setCaptionsTrack(0);
-		}
-		return;
-	}
-	const track = textTrackAt(captions.currentTrack.value);
-	if (!track) {
-		console.warn("DirectPlayer: invalid captions track index:", captions.currentTrack.value);
-		return;
-	}
-	if (track.contentType === "text/x-ass") {
-		if (enabled) {
-			activateAssTrack(captions.currentTrack.value);
-		} else {
-			assOverlay.hide();
-		}
-		return;
-	}
-	const native = nativeTrackFor(track.url);
-	if (native) {
-		native.mode = enabled ? "showing" : "hidden";
-	}
-}
-
-function isCaptionsEnabled(): boolean {
-	if (!videoElem.value) {
-		return false;
-	}
-	if (assOverlay.visible.value) {
-		return true;
-	}
-	return Array.from(videoElem.value.textTracks).find(t => t.mode === "showing") !== undefined;
-}
+// flush: "post" ensures the <track> DOM elements are present before we look them up by URL.
+watch([selectedTrack, captions.isCaptionsEnabled], applyCaptions, { flush: "post" });
 
 function getCaptionsTracks(): CaptionTrack[] {
-	if (!videoElem.value) {
-		return [];
-	}
 	return textTracks.value.map(track => ({
 		kind: "subtitles",
 		label: track.name ?? undefined,
@@ -215,26 +185,7 @@ function getCaptionsTracks(): CaptionTrack[] {
 }
 
 function setCaptionsTrack(track: number): void {
-	if (!videoElem.value) {
-		console.error("player not ready");
-		return;
-	}
-	console.log("DirectPlayer: setCaptionsTrack:", track);
-	const selected = textTrackAt(track);
-	if (!selected) {
-		console.warn("DirectPlayer: invalid captions track index:", track);
-		return;
-	}
-	const selectedNative =
-		selected.contentType === "text/vtt" ? nativeTrackFor(selected.url) : undefined;
-	for (const native of Array.from(videoElem.value.textTracks)) {
-		native.mode = native === selectedNative ? "showing" : "hidden";
-	}
-	if (selected.contentType === "text/x-ass") {
-		activateAssTrack(track);
-	} else {
-		assOverlay.hide();
-	}
+	selectedTrack.value = track;
 	captions.currentTrack.value = track;
 }
 
@@ -315,11 +266,10 @@ async function loadVideoSource() {
 		console.error("player not ready");
 		return;
 	}
-	// Fix for captions from previous video still showing after source change
-	for (let i = 0; i < videoElem.value.textTracks.length; i++) {
-		videoElem.value.textTracks[i].mode = "hidden";
-	}
-	assOverlay.destroy();
+	// Reset to "no track" so captions from the previous video stop showing, and so the seed below
+	// always represents a change (re-rendering even if the new default lands on the same index).
+	clearRendering();
+	selectedTrack.value = -1;
 	audioBoost.resetFailedSetup();
 	manifest.value = null;
 
@@ -355,33 +305,18 @@ async function loadVideoSource() {
 	}
 
 	captions.captionsTracks.value = getCaptionsTracks();
-	let defaultTrackIdx = -1;
-	if (defaultSubtitleTrack.value) {
-		defaultTrackIdx = textTracks.value.findIndex(t => t.url === defaultSubtitleTrack.value);
-	}
-	captions.currentTrack.value = defaultTrackIdx;
-	captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
-	if (defaultTrackIdx !== -1) {
-		if (textTrackAt(defaultTrackIdx)?.contentType === "text/x-ass") {
-			activateAssTrack(defaultTrackIdx);
-		} else {
-			await nextTick();
-			const url = textTrackAt(defaultTrackIdx).url;
-			const native = nativeTrackFor(url);
-			if (native) {
-				native.mode = "showing";
-			} else {
-				console.warn("DirectPlayer: default subtitle track element not found:", url);
-			}
-		}
-	}
+	const defaultTrackIdx = defaultSubtitleTrack.value
+		? textTracks.value.findIndex(t => t.url === defaultSubtitleTrack.value)
+		: -1;
+	const hasDefault = defaultTrackIdx >= 0;
+	setCaptionsTrack(hasDefault ? defaultTrackIdx : 0);
+	captions.isCaptionsEnabled.value = hasDefault;
 
 	videoElem.value.poster = thumbnail.value ?? "";
 	videoElem.value.load();
 	// this is needed to get the player to keep playing after the previous video has ended
 	videoElem.value.play();
 
-	console.log("DirectPlayer: current subtitle track:", captions.currentTrack.value);
 	console.log("DirectPlayer: current video track:", qualities.currentVideoTrack.value);
 
 	emit("apiready");
@@ -446,8 +381,10 @@ defineExpose({
 	getPosition,
 	setPosition,
 	isCaptionsSupported,
-	setCaptionsEnabled,
-	isCaptionsEnabled,
+	setCaptionsEnabled: (enabled: boolean) => {
+		captions.isCaptionsEnabled.value = enabled;
+	},
+	isCaptionsEnabled: () => captions.isCaptionsEnabled.value,
 	getCaptionsTracks,
 	setCaptionsTrack,
 	isQualitySupported,

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -22,7 +22,6 @@
 				:src="track.url"
 				:srclang="track.srclang"
 				:label="track.name"
-				:default="track.default"
 			/>
 			<track
 				v-if="subtitleUrl && videoMime !== 'application/json'"
@@ -55,7 +54,7 @@ interface Props {
 	subtitleUrl?: string;
 	/**
 	 * URL of the manifest text track to select by default for all viewers.
-	 * `""` means no subtitles by default, `null`/`undefined` means use the manifest's default flag.
+	 * `null`/`undefined` means no subtitles are shown by default.
 	 */
 	defaultTrack?: string | null;
 }
@@ -384,25 +383,18 @@ async function loadVideoSource() {
 		qualities.currentVideoTrack.value = 0;
 
 		captions.captionsTracks.value = getCaptionsTracks();
-		if ((manifest.value.textTracks ?? []).length > 0) {
+if ((manifest.value.textTracks ?? []).length > 0) {
 			// Wait for all text tracks to be inserted
 			await nextTick();
 		}
-		// The browser adds newly inserted <track> elements in "disabled" mode initially,
-		// the default attribute causes them to become "showing" asynchronously.
-		// To reflect this in the UI correctly, now the default track index is read directly
-		// from the manifest data, and we explicitly set its mode to "showing"
-		// A per-queue-item override (set via the Edit Video dialog) takes precedence over the
-		// manifest's own default flag. `""` means "no subtitles", a URL selects that track,
-		// `null`/`undefined` falls back to the manifest's default flag.
-		let defaultTrackIdx: number;
-		if (defaultTrack.value === "") {
-			defaultTrackIdx = -1;
-		} else if (defaultTrack.value) {
+		// The per-queue-item default subtitle track (set via the Edit Video dialog) selects
+		// which track to show by default. A URL selects that manifest track; `null`/`undefined`
+		// means no subtitles. Newly inserted <track> elements start "disabled", so we
+		// explicitly set the chosen track's mode to "showing" below.
+		let defaultTrackIdx = -1;
+		if (defaultTrack.value) {
 			defaultTrackIdx =
 				manifest.value.textTracks?.findIndex(t => t.url === defaultTrack.value) ?? -1;
-		} else {
-			defaultTrackIdx = manifest.value.textTracks?.findIndex(t => t.default) ?? -1;
 		}
 		captions.currentTrack.value = defaultTrackIdx;
 		captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -49,6 +49,7 @@ interface Props {
 	videoUrl: string;
 	videoMime: string;
 	thumbnail?: string;
+	/** URL of the subtitle track to show by default. Fed from the queue item's `subtitleUrl`. */
 	defaultSubtitleTrack?: string | null;
 }
 

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -16,7 +16,7 @@
 			@error="onError"
 		>
 			<track
-				v-for="track in manifest?.textTracks ?? []"
+				v-for="track in vttTracks"
 				:key="track.url"
 				kind="subtitles"
 				:src="track.url"
@@ -31,11 +31,12 @@
 				default
 			/>
 		</video>
+		<div ref="assContainer" class="ass-container"></div>
 	</div>
 </template>
 
 <script lang="ts" setup>
-import { nextTick, onMounted, ref, toRefs, watch } from "vue";
+import { computed, nextTick, onMounted, ref, toRefs, watch } from "vue";
 import type { CaptionTrack, VideoTrack } from "@/models/media-tracks";
 import type { CustomMediaManifest } from "ott-common/models/zod-schemas.js";
 import type {
@@ -44,7 +45,7 @@ import type {
 	MediaPlayerWithPlaybackRate,
 	MediaPlayerWithQuality,
 } from "../composables";
-import { useCaptions, useMediaAudioBoost, useQualities } from "../composables";
+import { useAssOverlay, useCaptions, useMediaAudioBoost, useQualities } from "../composables";
 
 interface Props {
 	service: string;
@@ -61,6 +62,18 @@ const captions = useCaptions();
 const audioBoost = useMediaAudioBoost(videoElem);
 const qualities = useQualities();
 const manifest = ref<CustomMediaManifest | null>(null);
+const assContainer = ref<HTMLDivElement | undefined>();
+const vttTracks = computed(() => {
+	const tracks = manifest.value?.textTracks ?? [];
+	const vtt: typeof tracks = [];
+	for (const track of tracks) {
+		if (track.contentType === "text/vtt") {
+			vtt.push(track);
+		}
+	}
+	return vtt;
+});
+const assOverlay = useAssOverlay(videoElem, assContainer);
 
 const emit = defineEmits<{
 	"apiready": [];
@@ -119,6 +132,33 @@ function isCaptionsSupported(): boolean {
 	return true;
 }
 
+function manifestTrack(idx: number) {
+	return manifest.value?.textTracks?.[idx];
+}
+
+/**
+ * Maps a manifest text track index to its index in the native videoElem.textTracks list,
+ * which only contains the VTT tracks. Returns -1 for non-VTT tracks.
+ */
+function nativeTrackIndex(manifestIdx: number): number {
+	const tracks = manifest.value?.textTracks ?? [];
+	if (tracks[manifestIdx]?.contentType !== "text/vtt") {
+		return -1;
+	}
+	return tracks.slice(0, manifestIdx).filter(t => t.contentType === "text/vtt").length;
+}
+
+/**
+ * Activate the ASS overlay for the given manifest track index, if it exists.
+ */
+function activateAssTrack(manifestIdx: number): Promise<void> {
+	const track = manifestTrack(manifestIdx);
+	if (!track) {
+		return Promise.resolve();
+	}
+	return assOverlay.load(track.url);
+}
+
 function setCaptionsEnabled(enabled: boolean): void {
 	if (!videoElem.value || captions.currentTrack.value === null) {
 		return;
@@ -132,9 +172,29 @@ function setCaptionsEnabled(enabled: boolean): void {
 	}
 	if (captions.currentTrack.value === -1) {
 		if (enabled) {
-			videoElem.value.textTracks[0].mode = "showing";
-			captions.currentTrack.value = 0;
+			setCaptionsTrack(0);
 		}
+		return;
+	}
+	if (videoMime.value === "application/json" && manifest.value) {
+		const track = manifestTrack(captions.currentTrack.value);
+		if (!track) {
+			console.warn(
+				"DirectPlayer: invalid captions track index:",
+				captions.currentTrack.value
+			);
+			return;
+		}
+		if (track.contentType === "text/x-ass") {
+			if (enabled) {
+				activateAssTrack(captions.currentTrack.value);
+			} else {
+				assOverlay.hide();
+			}
+			return;
+		}
+		const nativeIdx = nativeTrackIndex(captions.currentTrack.value);
+		videoElem.value.textTracks[nativeIdx].mode = enabled ? "showing" : "hidden";
 		return;
 	}
 	if (captions.currentTrack.value >= videoElem.value.textTracks.length) {
@@ -147,6 +207,9 @@ function setCaptionsEnabled(enabled: boolean): void {
 function isCaptionsEnabled(): boolean {
 	if (!videoElem.value) {
 		return false;
+	}
+	if (assOverlay.visible.value) {
+		return true;
 	}
 	return Array.from(videoElem.value.textTracks).find(t => t.mode === "showing") !== undefined;
 }
@@ -181,6 +244,24 @@ function setCaptionsTrack(track: number): void {
 		return;
 	}
 	console.log("DirectPlayer: setCaptionsTrack:", track);
+	if (videoMime.value === "application/json" && manifest.value) {
+		const selected = manifestTrack(track);
+		if (!selected) {
+			console.warn("DirectPlayer: invalid captions track index:", track);
+			return;
+		}
+		const nativeIdx = nativeTrackIndex(track);
+		for (let i = 0; i < videoElem.value.textTracks.length; i++) {
+			videoElem.value.textTracks[i].mode = i === nativeIdx ? "showing" : "hidden";
+		}
+		if (selected.contentType === "text/x-ass") {
+			activateAssTrack(track);
+		} else {
+			assOverlay.hide();
+		}
+		captions.currentTrack.value = track;
+		return;
+	}
 	for (let i = 0; i < videoElem.value.textTracks.length; i++) {
 		videoElem.value.textTracks[i].mode = i === track ? "showing" : "hidden";
 	}
@@ -268,6 +349,7 @@ async function loadVideoSource() {
 	for (let i = 0; i < videoElem.value.textTracks.length; i++) {
 		videoElem.value.textTracks[i].mode = "hidden";
 	}
+	assOverlay.destroy();
 	audioBoost.resetFailedSetup();
 	manifest.value = null;
 
@@ -304,6 +386,14 @@ async function loadVideoSource() {
 		const defaultTrackIdx = manifest.value.textTracks?.findIndex(t => t.default) ?? -1;
 		captions.currentTrack.value = defaultTrackIdx;
 		captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
+		if (defaultTrackIdx !== -1) {
+			if (manifestTrack(defaultTrackIdx)?.contentType === "text/x-ass") {
+				await activateAssTrack(defaultTrackIdx);
+			} else {
+				await nextTick();
+				videoElem.value.textTracks[nativeTrackIndex(defaultTrackIdx)].mode = "showing";
+			}
+		}
 	} else {
 		videoElem.value.src = videoUrl.value;
 
@@ -417,6 +507,15 @@ defineExpose({
 	max-height: 100%;
 	width: 100%;
 	height: 100%;
+	position: relative;
+}
+
+.direct .ass-container {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: 1;
+	overflow: hidden;
 }
 
 .direct video {

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -53,10 +53,15 @@ interface Props {
 	videoMime: string;
 	thumbnail?: string;
 	subtitleUrl?: string;
+	/**
+	 * URL of the manifest text track to select by default for all viewers.
+	 * `""` means no subtitles by default, `null`/`undefined` means use the manifest's default flag.
+	 */
+	defaultTrack?: string | null;
 }
 
 const props = defineProps<Props>();
-const { videoUrl, videoMime, thumbnail, subtitleUrl } = toRefs(props);
+const { videoUrl, videoMime, thumbnail, subtitleUrl, defaultTrack } = toRefs(props);
 const videoElem = ref<HTMLVideoElement | undefined>();
 const captions = useCaptions();
 const audioBoost = useMediaAudioBoost(videoElem);
@@ -383,7 +388,22 @@ async function loadVideoSource() {
 			// Wait for all text tracks to be inserted
 			await nextTick();
 		}
-		const defaultTrackIdx = manifest.value.textTracks?.findIndex(t => t.default) ?? -1;
+		// The browser adds newly inserted <track> elements in "disabled" mode initially,
+		// the default attribute causes them to become "showing" asynchronously.
+		// To reflect this in the UI correctly, now the default track index is read directly
+		// from the manifest data, and we explicitly set its mode to "showing"
+		// A per-queue-item override (set via the Edit Video dialog) takes precedence over the
+		// manifest's own default flag. `""` means "no subtitles", a URL selects that track,
+		// `null`/`undefined` falls back to the manifest's default flag.
+		let defaultTrackIdx: number;
+		if (defaultTrack.value === "") {
+			defaultTrackIdx = -1;
+		} else if (defaultTrack.value) {
+			defaultTrackIdx =
+				manifest.value.textTracks?.findIndex(t => t.url === defaultTrack.value) ?? -1;
+		} else {
+			defaultTrackIdx = manifest.value.textTracks?.findIndex(t => t.default) ?? -1;
+		}
 		captions.currentTrack.value = defaultTrackIdx;
 		captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
 		if (defaultTrackIdx !== -1) {

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -42,7 +42,13 @@ import type {
 	MediaPlayerWithQuality,
 } from "../composables";
 import { useAssOverlay, useCaptions, useMediaAudioBoost, useQualities } from "../composables";
-import { externalSubtitleAsTextTrack } from "ott-common/subtitle";
+import {
+	externalSubtitleAsTextTrackOrNull,
+	inferSubtitleContentTypeOrNull,
+} from "ott-common/subtitle";
+import { useI18n } from "vue-i18n";
+import toast from "@/util/toast";
+import { ToastStyle } from "@/models/toast";
 
 interface Props {
 	service: string;
@@ -55,6 +61,7 @@ interface Props {
 
 const props = defineProps<Props>();
 const { videoUrl, videoMime, thumbnail, defaultSubtitleTrack } = toRefs(props);
+const { t } = useI18n();
 const videoElem = ref<HTMLVideoElement | undefined>();
 const captions = useCaptions();
 const audioBoost = useMediaAudioBoost(videoElem);
@@ -67,11 +74,31 @@ const textTracks = computed<CustomMediaTextTrack[]>(() => {
 		return manifest.value?.textTracks ?? [];
 	}
 	if (defaultSubtitleTrack.value) {
-		return [externalSubtitleAsTextTrack(defaultSubtitleTrack.value)];
+		const track = externalSubtitleAsTextTrackOrNull(defaultSubtitleTrack.value);
+		return track ? [track] : [];
 	}
 	return [];
 });
+
+// The server rejects unsupported subtitle urls on the write path, so this may be overkill — but
+// dropping the track silently here would be annoying for a user to troubleshoot. Manifest videos
+// are excluded: their tracks declare contentType explicitly, so the url extension is irrelevant.
+watch(
+	[defaultSubtitleTrack, videoMime],
+	([url, mime]) => {
+		if (url && mime !== "application/json" && inferSubtitleContentTypeOrNull(url) === null) {
+			console.warn("DirectPlayer: unsupported subtitle url, ignoring:", url);
+			toast.add({
+				style: ToastStyle.Error,
+				content: t("room.subtitle-unsupported"),
+				duration: 6000,
+			});
+		}
+	},
+	{ immediate: true },
+);
 const vttTracks = computed(() =>
+	// biome-ignore lint/nursery/noVueRefAsOperand: false positive, `track` is a callback parameter, not a ref
 	textTracks.value.filter(track => track.contentType === "text/vtt")
 );
 const assOverlay = useAssOverlay(videoElem, assContainer);

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -23,12 +23,6 @@
 				:srclang="track.srclang"
 				:label="track.name"
 			/>
-			<track
-				v-if="subtitleUrl && videoMime !== 'application/json'"
-				:src="subtitleUrl"
-				kind="subtitles"
-				default
-			/>
 		</video>
 		<div ref="assContainer" class="ass-container"></div>
 	</div>
@@ -37,7 +31,10 @@
 <script lang="ts" setup>
 import { computed, nextTick, onMounted, ref, toRefs, watch } from "vue";
 import type { CaptionTrack, VideoTrack } from "@/models/media-tracks";
-import type { CustomMediaManifest } from "ott-common/models/zod-schemas.js";
+import type {
+	CustomMediaManifest,
+	CustomMediaTextTrack,
+} from "ott-common/models/zod-schemas.js";
 import type {
 	MediaPlayerWithAudioBoost,
 	MediaPlayerWithCaptions,
@@ -51,32 +48,59 @@ interface Props {
 	videoUrl: string;
 	videoMime: string;
 	thumbnail?: string;
-	subtitleUrl?: string;
 	/**
-	 * URL of the manifest text track to select by default for all viewers.
-	 * `null`/`undefined` means no subtitles are shown by default.
+	 * URL of the subtitle track to select by default for all viewers. For manifest
+	 * items it must be one of the manifest's text tracks; for other items it is the
+	 * URL of an external subtitle file. `null`/`undefined` means no subtitles are
+	 * shown by default.
 	 */
 	defaultTrack?: string | null;
 }
 
 const props = defineProps<Props>();
-const { videoUrl, videoMime, thumbnail, subtitleUrl, defaultTrack } = toRefs(props);
+const { videoUrl, videoMime, thumbnail, defaultTrack } = toRefs(props);
 const videoElem = ref<HTMLVideoElement | undefined>();
 const captions = useCaptions();
 const audioBoost = useMediaAudioBoost(videoElem);
 const qualities = useQualities();
 const manifest = ref<CustomMediaManifest | null>(null);
 const assContainer = ref<HTMLDivElement | undefined>();
-const vttTracks = computed(() => {
-	const tracks = manifest.value?.textTracks ?? [];
-	const vtt: typeof tracks = [];
-	for (const track of tracks) {
-		if (track.contentType === "text/vtt") {
-			vtt.push(track);
-		}
+
+/**
+ * Infer the subtitle format of an external (non-manifest) track from its URL so
+ * external `.vtt`/`.ass` files go through the same rendering paths as the tracks
+ * declared by a manifest.
+ */
+function inferSubtitleContentType(url: string): CustomMediaTextTrack["contentType"] {
+	const path = url.split("?")[0].split("#")[0];
+	const ext = path.split(".").pop()?.toLowerCase();
+	return ext === "ass" || ext === "ssa" ? "text/x-ass" : "text/vtt";
+}
+
+/**
+ * The available text tracks, unified across source types. Manifest items declare
+ * their tracks; for other items the single `defaultTrack` external subtitle (if
+ * any) is the only track.
+ */
+const textTracks = computed<CustomMediaTextTrack[]>(() => {
+	if (videoMime.value === "application/json") {
+		return manifest.value?.textTracks ?? [];
 	}
-	return vtt;
+	if (defaultTrack.value) {
+		return [
+			{
+				url: defaultTrack.value,
+				contentType: inferSubtitleContentType(defaultTrack.value),
+				srclang: "und",
+				default: true,
+			},
+		];
+	}
+	return [];
 });
+const vttTracks = computed(() =>
+	textTracks.value.filter(track => track.contentType === "text/vtt")
+);
 const assOverlay = useAssOverlay(videoElem, assContainer);
 
 const emit = defineEmits<{
@@ -136,27 +160,27 @@ function isCaptionsSupported(): boolean {
 	return true;
 }
 
-function manifestTrack(idx: number) {
-	return manifest.value?.textTracks?.[idx];
+function textTrack(idx: number) {
+	return textTracks.value[idx];
 }
 
 /**
- * Maps a manifest text track index to its index in the native videoElem.textTracks list,
+ * Maps a text track index to its index in the native videoElem.textTracks list,
  * which only contains the VTT tracks. Returns -1 for non-VTT tracks.
  */
-function nativeTrackIndex(manifestIdx: number): number {
-	const tracks = manifest.value?.textTracks ?? [];
-	if (tracks[manifestIdx]?.contentType !== "text/vtt") {
+function nativeTrackIndex(idx: number): number {
+	const tracks = textTracks.value;
+	if (tracks[idx]?.contentType !== "text/vtt") {
 		return -1;
 	}
-	return tracks.slice(0, manifestIdx).filter(t => t.contentType === "text/vtt").length;
+	return tracks.slice(0, idx).filter(t => t.contentType === "text/vtt").length;
 }
 
 /**
- * Activate the ASS overlay for the given manifest track index, if it exists.
+ * Activate the ASS overlay for the given text track index, if it exists.
  */
-function activateAssTrack(manifestIdx: number): Promise<void> {
-	const track = manifestTrack(manifestIdx);
+function activateAssTrack(idx: number): Promise<void> {
+	const track = textTrack(idx);
 	if (!track) {
 		return Promise.resolve();
 	}
@@ -167,11 +191,7 @@ function setCaptionsEnabled(enabled: boolean): void {
 	if (!videoElem.value || captions.currentTrack.value === null) {
 		return;
 	}
-	if (
-		videoMime.value !== "application/json" &&
-		!manifest.value?.textTracks &&
-		!subtitleUrl.value
-	) {
+	if (textTracks.value.length === 0) {
 		return;
 	}
 	if (captions.currentTrack.value === -1) {
@@ -180,32 +200,21 @@ function setCaptionsEnabled(enabled: boolean): void {
 		}
 		return;
 	}
-	if (videoMime.value === "application/json" && manifest.value) {
-		const track = manifestTrack(captions.currentTrack.value);
-		if (!track) {
-			console.warn(
-				"DirectPlayer: invalid captions track index:",
-				captions.currentTrack.value
-			);
-			return;
-		}
-		if (track.contentType === "text/x-ass") {
-			if (enabled) {
-				activateAssTrack(captions.currentTrack.value);
-			} else {
-				assOverlay.hide();
-			}
-			return;
-		}
-		const nativeIdx = nativeTrackIndex(captions.currentTrack.value);
-		videoElem.value.textTracks[nativeIdx].mode = enabled ? "showing" : "hidden";
-		return;
-	}
-	if (captions.currentTrack.value >= videoElem.value.textTracks.length) {
+	const track = textTrack(captions.currentTrack.value);
+	if (!track) {
 		console.warn("DirectPlayer: invalid captions track index:", captions.currentTrack.value);
 		return;
 	}
-	videoElem.value.textTracks[captions.currentTrack.value].mode = enabled ? "showing" : "hidden";
+	if (track.contentType === "text/x-ass") {
+		if (enabled) {
+			activateAssTrack(captions.currentTrack.value);
+		} else {
+			assOverlay.hide();
+		}
+		return;
+	}
+	const nativeIdx = nativeTrackIndex(captions.currentTrack.value);
+	videoElem.value.textTracks[nativeIdx].mode = enabled ? "showing" : "hidden";
 }
 
 function isCaptionsEnabled(): boolean {
@@ -222,24 +231,12 @@ function getCaptionsTracks(): CaptionTrack[] {
 	if (!videoElem.value) {
 		return [];
 	}
-	if (videoMime.value === "application/json") {
-		if (!manifest.value) {
-			return [];
-		}
-	} else {
-		return subtitleUrl.value ? [{ kind: "subtitles", default: true }] : [];
-	}
-
-	const tracks: CaptionTrack[] = [];
-	for (const track of manifest.value.textTracks ?? []) {
-		tracks.push({
-			kind: "subtitles",
-			label: track.name ?? undefined,
-			srclang: track.srclang,
-			default: track.default,
-		});
-	}
-	return tracks;
+	return textTracks.value.map(track => ({
+		kind: "subtitles",
+		label: track.name ?? undefined,
+		srclang: track.srclang,
+		default: track.default,
+	}));
 }
 
 function setCaptionsTrack(track: number): void {
@@ -248,26 +245,19 @@ function setCaptionsTrack(track: number): void {
 		return;
 	}
 	console.log("DirectPlayer: setCaptionsTrack:", track);
-	if (videoMime.value === "application/json" && manifest.value) {
-		const selected = manifestTrack(track);
-		if (!selected) {
-			console.warn("DirectPlayer: invalid captions track index:", track);
-			return;
-		}
-		const nativeIdx = nativeTrackIndex(track);
-		for (let i = 0; i < videoElem.value.textTracks.length; i++) {
-			videoElem.value.textTracks[i].mode = i === nativeIdx ? "showing" : "hidden";
-		}
-		if (selected.contentType === "text/x-ass") {
-			activateAssTrack(track);
-		} else {
-			assOverlay.hide();
-		}
-		captions.currentTrack.value = track;
+	const selected = textTrack(track);
+	if (!selected) {
+		console.warn("DirectPlayer: invalid captions track index:", track);
 		return;
 	}
+	const nativeIdx = nativeTrackIndex(track);
 	for (let i = 0; i < videoElem.value.textTracks.length; i++) {
-		videoElem.value.textTracks[i].mode = i === track ? "showing" : "hidden";
+		videoElem.value.textTracks[i].mode = i === nativeIdx ? "showing" : "hidden";
+	}
+	if (selected.contentType === "text/x-ass") {
+		activateAssTrack(track);
+	} else {
+		assOverlay.hide();
 	}
 	captions.currentTrack.value = track;
 }
@@ -381,47 +371,33 @@ async function loadVideoSource() {
 
 		qualities.videoTracks.value = getVideoTracks();
 		qualities.currentVideoTrack.value = 0;
-
-		captions.captionsTracks.value = getCaptionsTracks();
-if ((manifest.value.textTracks ?? []).length > 0) {
-			// Wait for all text tracks to be inserted
-			await nextTick();
-		}
-		// The per-queue-item default subtitle track (set via the Edit Video dialog) selects
-		// which track to show by default. A URL selects that manifest track; `null`/`undefined`
-		// means no subtitles. Newly inserted <track> elements start "disabled", so we
-		// explicitly set the chosen track's mode to "showing" below.
-		let defaultTrackIdx = -1;
-		if (defaultTrack.value) {
-			defaultTrackIdx =
-				manifest.value.textTracks?.findIndex(t => t.url === defaultTrack.value) ?? -1;
-		}
-		captions.currentTrack.value = defaultTrackIdx;
-		captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
-		if (defaultTrackIdx !== -1) {
-			if (manifestTrack(defaultTrackIdx)?.contentType === "text/x-ass") {
-				// Fire-and-forget: the overlay builds itself once the video's
-				// dimensions are known, so it must not block load()/play() below.
-				activateAssTrack(defaultTrackIdx);
-			} else {
-				await nextTick();
-				videoElem.value.textTracks[nativeTrackIndex(defaultTrackIdx)].mode = "showing";
-			}
-		}
 	} else {
 		videoElem.value.src = videoUrl.value;
 
 		qualities.videoTracks.value = [];
 		qualities.currentVideoTrack.value = -1;
+	}
 
-		if (subtitleUrl.value) {
-			captions.captionsTracks.value = [{ kind: "subtitles", default: true }];
-			captions.currentTrack.value = 0;
-			captions.isCaptionsEnabled.value = true;
+	// The default subtitle track (set via the Edit Video dialog) selects which track
+	// to show by default, the same way for manifest tracks and external subtitle
+	// files. A URL selects that track; `null`/`undefined` means no subtitles. Newly
+	// inserted <track> elements start "disabled", so we explicitly set the chosen
+	// track's mode to "showing" below.
+	captions.captionsTracks.value = getCaptionsTracks();
+	let defaultTrackIdx = -1;
+	if (defaultTrack.value) {
+		defaultTrackIdx = textTracks.value.findIndex(t => t.url === defaultTrack.value);
+	}
+	captions.currentTrack.value = defaultTrackIdx;
+	captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
+	if (defaultTrackIdx !== -1) {
+		if (textTrack(defaultTrackIdx)?.contentType === "text/x-ass") {
+			// Fire-and-forget: the overlay builds itself once the video's
+			// dimensions are known, so it must not block load()/play() below.
+			activateAssTrack(defaultTrackIdx);
 		} else {
-			captions.captionsTracks.value = [];
-			captions.currentTrack.value = -1;
-			captions.isCaptionsEnabled.value = false;
+			await nextTick();
+			videoElem.value.textTracks[nativeTrackIndex(defaultTrackIdx)].mode = "showing";
 		}
 	}
 
@@ -483,8 +459,8 @@ onMounted(() => {
 	loadVideoSource();
 });
 
-watch([videoUrl, subtitleUrl], () => {
-	console.log("DirectPlayer: videoUrl or subtitleUrl changed");
+watch([videoUrl, defaultTrack], () => {
+	console.log("DirectPlayer: videoUrl or defaultTrack changed");
 	loadVideoSource();
 });
 

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -400,7 +400,9 @@ if ((manifest.value.textTracks ?? []).length > 0) {
 		captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
 		if (defaultTrackIdx !== -1) {
 			if (manifestTrack(defaultTrackIdx)?.contentType === "text/x-ass") {
-				await activateAssTrack(defaultTrackIdx);
+				// Fire-and-forget: the overlay builds itself once the video's
+				// dimensions are known, so it must not block load()/play() below.
+				activateAssTrack(defaultTrackIdx);
 			} else {
 				await nextTick();
 				videoElem.value.textTracks[nativeTrackIndex(defaultTrackIdx)].mode = "showing";

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -114,7 +114,7 @@
 				:video-url="source.src_url ?? source.id"
 				:video-mime="source.mime!"
 				:thumbnail="source.thumbnail"
-				:default-track="source.defaultSubtitleTrack"
+				:default-subtitle-track="source.defaultSubtitleTrack"
 				class="player"
 				@apiready="onApiReady"
 				@playing="onPlaying"

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -115,6 +115,7 @@
 				:video-mime="source.mime!"
 				:thumbnail="source.thumbnail"
 				:subtitle-url="source.subtitleUrl"
+				:default-track="source.defaultSubtitleTrack"
 				class="player"
 				@apiready="onApiReady"
 				@playing="onPlaying"

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -114,7 +114,6 @@
 				:video-url="source.src_url ?? source.id"
 				:video-mime="source.mime!"
 				:thumbnail="source.thumbnail"
-				:subtitle-url="source.subtitleUrl"
 				:default-track="source.defaultSubtitleTrack"
 				class="player"
 				@apiready="onApiReady"

--- a/client/src/components/players/OmniPlayer.vue
+++ b/client/src/components/players/OmniPlayer.vue
@@ -114,7 +114,7 @@
 				:video-url="source.src_url ?? source.id"
 				:video-mime="source.mime!"
 				:thumbnail="source.thumbnail"
-				:default-subtitle-track="source.defaultSubtitleTrack"
+				:default-subtitle-track="source.subtitleUrl"
 				class="player"
 				@apiready="onApiReady"
 				@playing="onPlaying"

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -192,6 +192,7 @@ export default {
 		pip: "Picture in Picture",
 		"player-settings": "Player settings",
 		subtitles: "Subtitles/CC",
+		"subtitle-load-failed": "Subtitle track could not be loaded",
 		quality: "Quality",
 		"playback-speed": "Playback speed",
 		"mute-volume": "Mute",

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -304,6 +304,12 @@ export default {
 			title: "Edit video",
 			"subtitle-url": "Subtitle URL (.vtt)",
 			"subtitle-url-supported-services": "Supported services: direct, googledrive",
+			"default-subtitle-track": "Default subtitle track",
+			"default-subtitle-track-hint":
+				"Initial track for all viewers; each viewer can change it in the player.",
+			"manifest-default": "Manifest default",
+			"no-subtitles": "None",
+			"manifest-load-failed": "Couldn't load track list from manifest",
 			tooltip: "Edit video settings",
 		},
 	},

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -307,9 +307,7 @@ export default {
 			"default-subtitle-track": "Default subtitle track",
 			"default-subtitle-track-hint":
 				"Initial track for all viewers; each viewer can change it in the player.",
-			"manifest-default": "Manifest default",
 			"no-subtitles": "None",
-			"manifest-load-failed": "Couldn't load track list from manifest",
 			tooltip: "Edit video settings",
 		},
 	},

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -302,7 +302,7 @@ export default {
 		"start-at": "Start at {timestamp}",
 		edit: {
 			title: "Edit video",
-			"subtitle-url": "Subtitle URL (.vtt)",
+			"subtitle-url": "Subtitle URL (.vtt, .ass)",
 			"subtitle-url-supported-services": "Supported services: direct, googledrive",
 			"default-subtitle-track": "Default subtitle track",
 			"default-subtitle-track-hint":

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -193,6 +193,7 @@ export default {
 		"player-settings": "Player settings",
 		subtitles: "Subtitles/CC",
 		"subtitle-load-failed": "Subtitle track could not be loaded",
+		"subtitle-unsupported": "Subtitle track format is not supported",
 		quality: "Quality",
 		"playback-speed": "Playback speed",
 		"mute-volume": "Mute",

--- a/client/tests/unit/VideoQueueItem.component.spec.ts
+++ b/client/tests/unit/VideoQueueItem.component.spec.ts
@@ -159,16 +159,16 @@ describe("VideoQueueItem component", () => {
 		expect(API.post).toHaveBeenCalledWith("/room/foo/queue", {
 			service: "youtube",
 			id: "1",
-			defaultSubtitleTrack: null,
+			subtitleUrl: null,
 		});
 	});
 
-	it("adds preview video with defaultSubtitleTrack", async () => {
+	it("adds preview video with subtitleUrl", async () => {
 		API.post.mockResolvedValue({ data: { success: true } });
 		const directVideo = {
 			...video,
 			service: "direct",
-			defaultSubtitleTrack: "https://example.com/subtitles.vtt",
+			subtitleUrl: "https://example.com/subtitles.vtt",
 		};
 		const { wrapper, store } = mountComponent(VideoQueueItem, {
 			props: { item: directVideo, isPreview: true },
@@ -183,7 +183,7 @@ describe("VideoQueueItem component", () => {
 		expect(API.post).toHaveBeenCalledWith("/room/foo/queue", {
 			service: "direct",
 			id: "1",
-			defaultSubtitleTrack: "https://example.com/subtitles.vtt",
+			subtitleUrl: "https://example.com/subtitles.vtt",
 		});
 	});
 
@@ -197,7 +197,7 @@ describe("VideoQueueItem component", () => {
 		await flush();
 
 		expect(API.delete).toHaveBeenCalledWith("/room/foo/queue", {
-			data: { service: "youtube", id: "1", defaultSubtitleTrack: null },
+			data: { service: "youtube", id: "1", subtitleUrl: null },
 		});
 	});
 
@@ -238,7 +238,7 @@ describe("VideoQueueItem component", () => {
 		const directVideo = {
 			...video,
 			service: "direct",
-			defaultSubtitleTrack: "https://example.com/subtitles.vtt",
+			subtitleUrl: "https://example.com/subtitles.vtt",
 		};
 		const { wrapper, store } = mountComponent(VideoQueueItem, {
 			props: { item: directVideo, isPreview: false },
@@ -257,7 +257,7 @@ describe("VideoQueueItem component", () => {
 		expect(API.patch).toHaveBeenCalledWith("/room/foo/queue", {
 			service: "direct",
 			id: "1",
-			defaultSubtitleTrack: "not a url",
+			subtitleUrl: "not a url",
 		});
 		expect(wrapper.find('[data-cy="btn-remove-from-queue"] svg').exists()).toBe(true);
 	});

--- a/client/tests/unit/VideoQueueItem.component.spec.ts
+++ b/client/tests/unit/VideoQueueItem.component.spec.ts
@@ -159,16 +159,16 @@ describe("VideoQueueItem component", () => {
 		expect(API.post).toHaveBeenCalledWith("/room/foo/queue", {
 			service: "youtube",
 			id: "1",
-			subtitleUrl: undefined,
+			defaultSubtitleTrack: undefined,
 		});
 	});
 
-	it("adds preview video with subtitleUrl", async () => {
+	it("adds preview video with defaultSubtitleTrack", async () => {
 		API.post.mockResolvedValue({ data: { success: true } });
 		const directVideo = {
 			...video,
 			service: "direct",
-			subtitleUrl: "https://example.com/subtitles.vtt",
+			defaultSubtitleTrack: "https://example.com/subtitles.vtt",
 		};
 		const { wrapper, store } = mountComponent(VideoQueueItem, {
 			props: { item: directVideo, isPreview: true },
@@ -183,7 +183,7 @@ describe("VideoQueueItem component", () => {
 		expect(API.post).toHaveBeenCalledWith("/room/foo/queue", {
 			service: "direct",
 			id: "1",
-			subtitleUrl: "https://example.com/subtitles.vtt",
+			defaultSubtitleTrack: "https://example.com/subtitles.vtt",
 		});
 	});
 
@@ -197,7 +197,7 @@ describe("VideoQueueItem component", () => {
 		await flush();
 
 		expect(API.delete).toHaveBeenCalledWith("/room/foo/queue", {
-			data: { service: "youtube", id: "1", subtitleUrl: undefined },
+			data: { service: "youtube", id: "1", defaultSubtitleTrack: null },
 		});
 	});
 
@@ -238,7 +238,7 @@ describe("VideoQueueItem component", () => {
 		const directVideo = {
 			...video,
 			service: "direct",
-			subtitleUrl: "https://example.com/subtitles.vtt",
+			defaultSubtitleTrack: "https://example.com/subtitles.vtt",
 		};
 		const { wrapper, store } = mountComponent(VideoQueueItem, {
 			props: { item: directVideo, isPreview: false },
@@ -257,7 +257,7 @@ describe("VideoQueueItem component", () => {
 		expect(API.patch).toHaveBeenCalledWith("/room/foo/queue", {
 			service: "direct",
 			id: "1",
-			subtitleUrl: "not a url",
+			defaultSubtitleTrack: "not a url",
 		});
 		expect(wrapper.find('[data-cy="btn-remove-from-queue"] svg').exists()).toBe(true);
 	});

--- a/client/tests/unit/VideoQueueItem.component.spec.ts
+++ b/client/tests/unit/VideoQueueItem.component.spec.ts
@@ -159,7 +159,7 @@ describe("VideoQueueItem component", () => {
 		expect(API.post).toHaveBeenCalledWith("/room/foo/queue", {
 			service: "youtube",
 			id: "1",
-			defaultSubtitleTrack: undefined,
+			defaultSubtitleTrack: null,
 		});
 	});
 

--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -18,6 +18,7 @@ export interface VideoMetadata {
 	dash_url?: string;
 	src_url?: string;
 	subtitleUrl?: string;
+	defaultSubtitleTrack?: string | null;
 }
 
 export type Video = VideoId & Partial<VideoMetadata>;
@@ -25,6 +26,11 @@ export interface QueueItemExtras {
 	startAt?: number;
 	endAt?: number;
 	subtitleUrl?: string;
+	/**
+	 * URL of the text track that should be selected by default for all viewers.
+	 * `""` means no subtitles by default, `null` or absent means use the manifest's default flag.
+	 */
+	defaultSubtitleTrack?: string | null;
 }
 
 export type VideoAdd = VideoId & QueueItemExtras;

--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -18,16 +18,17 @@ export interface VideoMetadata {
 	hls_url?: string;
 	dash_url?: string;
 	src_url?: string;
-	subtitleUrl?: string;
 	/**
 	 * The text tracks declared by a custom media manifest. Only present for
 	 * manifest (`mime === "application/json"`) items.
 	 */
 	textTracks?: CustomMediaTextTrack[];
 	/**
-	 * URL of the text track shown by default for all viewers. For manifest items
-	 * the server resolves this from the manifest's `default` track, so it is
-	 * always a concrete value: a track URL, or `null` for "no subtitles".
+	 * URL of the subtitle track shown by default for all viewers. For manifest
+	 * items the server resolves this from the manifest's `default` track, so it is
+	 * a track URL or `null` for "no subtitles". For non-manifest items it is the
+	 * URL of an external subtitle file (`.vtt` or `.ass`), or `null`/absent for
+	 * "no subtitles".
 	 */
 	defaultSubtitleTrack?: string | null;
 }
@@ -36,11 +37,11 @@ export type Video = VideoId & Partial<VideoMetadata>;
 export interface QueueItemExtras {
 	startAt?: number;
 	endAt?: number;
-	subtitleUrl?: string;
 	/**
-	 * Overrides the default subtitle track for this queue item. A track URL
-	 * selects that manifest track; `null` means "no subtitles". Absent leaves the
-	 * server-resolved default untouched.
+	 * Overrides the default subtitle track for this queue item. For manifest items
+	 * a track URL selects that manifest track; for other items it is the URL of an
+	 * external subtitle file (`.vtt` or `.ass`). `null` means "no subtitles".
+	 * Absent leaves the server-resolved default untouched.
 	 */
 	defaultSubtitleTrack?: string | null;
 }

--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -1,4 +1,5 @@
 import type { ALL_VIDEO_SERVICES } from "../constants.js";
+import type { CustomMediaTextTrack } from "./zod-schemas.js";
 
 export type VideoService = (typeof ALL_VIDEO_SERVICES)[number];
 
@@ -18,6 +19,16 @@ export interface VideoMetadata {
 	dash_url?: string;
 	src_url?: string;
 	subtitleUrl?: string;
+	/**
+	 * The text tracks declared by a custom media manifest. Only present for
+	 * manifest (`mime === "application/json"`) items.
+	 */
+	textTracks?: CustomMediaTextTrack[];
+	/**
+	 * URL of the text track shown by default for all viewers. For manifest items
+	 * the server resolves this from the manifest's `default` track, so it is
+	 * always a concrete value: a track URL, or `null` for "no subtitles".
+	 */
 	defaultSubtitleTrack?: string | null;
 }
 
@@ -27,8 +38,9 @@ export interface QueueItemExtras {
 	endAt?: number;
 	subtitleUrl?: string;
 	/**
-	 * URL of the text track that should be selected by default for all viewers.
-	 * `""` means no subtitles by default, `null` or absent means use the manifest's default flag.
+	 * Overrides the default subtitle track for this queue item. A track URL
+	 * selects that manifest track; `null` means "no subtitles". Absent leaves the
+	 * server-resolved default untouched.
 	 */
 	defaultSubtitleTrack?: string | null;
 }

--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -25,10 +25,9 @@ export interface VideoMetadata {
 	textTracks?: CustomMediaTextTrack[];
 	/**
 	 * URL of the subtitle track shown by default for all viewers. For manifest
-	 * items the server resolves this from the manifest's `default` track, so it is
-	 * a track URL or `null` for "no subtitles". For non-manifest items it is the
-	 * URL of an external subtitle file (`.vtt` or `.ass`), or `null`/absent for
-	 * "no subtitles".
+	 * items the server resolves this from the manifest's `default` track. For
+	 * non-manifest items it is the URL of an external subtitle file (`.vtt` or
+	 * `.ass`). `null` (or absent) means "no subtitles".
 	 */
 	defaultSubtitleTrack?: string | null;
 }
@@ -38,10 +37,9 @@ export interface QueueItemExtras {
 	startAt?: number;
 	endAt?: number;
 	/**
-	 * Overrides the default subtitle track for this queue item. For manifest items
-	 * a track URL selects that manifest track; for other items it is the URL of an
+	 * Sets the default subtitle track for this queue item. For manifest items a
+	 * track URL selects that manifest track; for other items it is the URL of an
 	 * external subtitle file (`.vtt` or `.ass`). `null` means "no subtitles".
-	 * Absent leaves the server-resolved default untouched.
 	 */
 	defaultSubtitleTrack?: string | null;
 }

--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -18,16 +18,12 @@ export interface VideoMetadata {
 	hls_url?: string;
 	dash_url?: string;
 	src_url?: string;
-	/**
-	 * The text tracks declared by a custom media manifest. Only present for
-	 * manifest (`mime === "application/json"`) items.
-	 */
 	textTracks?: CustomMediaTextTrack[];
 	/**
-	 * URL of the subtitle track shown by default for all viewers. For manifest
-	 * items the server resolves this from the manifest's `default` track. For
-	 * non-manifest items it is the URL of an external subtitle file (`.vtt` or
-	 * `.ass`). `null` (or absent) means "no subtitles".
+	 * URL of the subtitle track to show by default. The field is overloaded by item type:
+	 * for custom media manifest items (mime `application/json`) it must equal one of
+	 * `textTracks[].url`; for other (direct) items it is an arbitrary external subtitle URL
+	 * and is the only subtitle source. `null` and an absent field both mean "no subtitle".
 	 */
 	defaultSubtitleTrack?: string | null;
 }
@@ -36,11 +32,6 @@ export type Video = VideoId & Partial<VideoMetadata>;
 export interface QueueItemExtras {
 	startAt?: number;
 	endAt?: number;
-	/**
-	 * Sets the default subtitle track for this queue item. For manifest items a
-	 * track URL selects that manifest track; for other items it is the URL of an
-	 * external subtitle file (`.vtt` or `.ass`). `null` means "no subtitles".
-	 */
 	defaultSubtitleTrack?: string | null;
 }
 

--- a/common/models/video.ts
+++ b/common/models/video.ts
@@ -19,20 +19,15 @@ export interface VideoMetadata {
 	dash_url?: string;
 	src_url?: string;
 	textTracks?: CustomMediaTextTrack[];
-	/**
-	 * URL of the subtitle track to show by default. The field is overloaded by item type:
-	 * for custom media manifest items (mime `application/json`) it must equal one of
-	 * `textTracks[].url`; for other (direct) items it is an arbitrary external subtitle URL
-	 * and is the only subtitle source. `null` and an absent field both mean "no subtitle".
-	 */
-	defaultSubtitleTrack?: string | null;
+	subtitleUrl?: string | null;
 }
 
 export type Video = VideoId & Partial<VideoMetadata>;
 export interface QueueItemExtras {
 	startAt?: number;
 	endAt?: number;
-	defaultSubtitleTrack?: string | null;
+	/** Kept as `subtitleUrl` for persistence compat — this field is stored by name in Redis and the DB `prevQueue` column. */
+	subtitleUrl?: string | null;
 }
 
 export type VideoAdd = VideoId & QueueItemExtras;

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -53,10 +53,8 @@ const QueueItemExtrasSchema = z.object({
 	// startAt: z.number().nonnegative().optional(),
 	// endAt: z.number().positive().optional(),
 	subtitleUrl: z.string().url().optional(),
-	defaultSubtitleTrack: z
-		.union([z.string().url(), z.literal("")])
-		.nullable()
-		.optional(),
+	// `null`/absent means no default subtitle; a URL selects that manifest track.
+	defaultSubtitleTrack: z.string().url().nullable().optional(),
 });
 
 const VideoAddSchema = VideoIdSchema.extend(QueueItemExtrasSchema.shape);

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -52,9 +52,15 @@ const VideoIdSchema = z.object({
 const QueueItemExtrasSchema = z.object({
 	// startAt: z.number().nonnegative().optional(),
 	// endAt: z.number().positive().optional(),
-	// `null`/absent means no default subtitle; a URL selects a manifest track or an
-	// external subtitle file.
-	defaultSubtitleTrack: z.string().url().nullable().optional(),
+	// `null` means "no default subtitle"; a URL selects a manifest track or an
+	// external subtitle file. ""/absent are accepted for convenience and normalized
+	// to `null` so there is a single canonical "no subtitles" value.
+	defaultSubtitleTrack: z
+		.string()
+		.url()
+		.or(z.literal(""))
+		.nullish()
+		.transform(value => value || null),
 });
 
 const VideoAddSchema = VideoIdSchema.extend(QueueItemExtrasSchema.shape);

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -169,9 +169,11 @@ const CustomMediaSourceSchema = z.object({
 // 		.startsWith("audio", "contentType must be an audio MIME type"),
 // });
 
-const CustomMediaTextTrackSchema = z.object({
+export const CustomMediaTextTrackSchema = z.object({
 	url: z.string().url("text track url must be a valid URL"),
-	contentType: z.literal("text/vtt", { invalid_type_error: "contentType must be text/vtt" }),
+	contentType: z.enum(["text/vtt", "text/x-ass"], {
+		errorMap: () => ({ message: "contentType must be one of: text/vtt, text/x-ass" }),
+	}),
 	name: z
 		.string()
 		.min(1, "name must not be empty")
@@ -202,3 +204,4 @@ export const CustomMediaManifestSchema = z.object({
 });
 
 export type CustomMediaManifest = z.infer<typeof CustomMediaManifestSchema>;
+export type CustomMediaTextTrack = z.infer<typeof CustomMediaTextTrackSchema>;

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -1,6 +1,7 @@
 import { ALL_VIDEO_SERVICES, ROOM_NAME_REGEX } from "ott-common/constants.js";
 import { BehaviorOption, Role } from "ott-common/models/types.js";
 import { Visibility, QueueMode } from "ott-common/models/types.js";
+import { normalizeSubtitleTrack } from "ott-common/subtitle.js";
 import { z } from "zod";
 
 // These strings are not allowed to be used as room names.
@@ -52,15 +53,12 @@ const VideoIdSchema = z.object({
 const QueueItemExtrasSchema = z.object({
 	// startAt: z.number().nonnegative().optional(),
 	// endAt: z.number().positive().optional(),
-	// `null` means "no default subtitle"; a URL selects a manifest track or an
-	// external subtitle file. ""/absent are accepted for convenience and normalized
-	// to `null` so there is a single canonical "no subtitles" value.
 	defaultSubtitleTrack: z
 		.string()
 		.url()
 		.or(z.literal(""))
 		.nullish()
-		.transform(value => value || null),
+		.transform(normalizeSubtitleTrack),
 });
 
 const VideoAddSchema = VideoIdSchema.extend(QueueItemExtrasSchema.shape);

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -53,6 +53,10 @@ const QueueItemExtrasSchema = z.object({
 	// startAt: z.number().nonnegative().optional(),
 	// endAt: z.number().positive().optional(),
 	subtitleUrl: z.string().url().optional(),
+	defaultSubtitleTrack: z
+		.union([z.string().url(), z.literal("")])
+		.nullable()
+		.optional(),
 });
 
 const VideoAddSchema = VideoIdSchema.extend(QueueItemExtrasSchema.shape);

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -52,8 +52,8 @@ const VideoIdSchema = z.object({
 const QueueItemExtrasSchema = z.object({
 	// startAt: z.number().nonnegative().optional(),
 	// endAt: z.number().positive().optional(),
-	subtitleUrl: z.string().url().optional(),
-	// `null`/absent means no default subtitle; a URL selects that manifest track.
+	// `null`/absent means no default subtitle; a URL selects a manifest track or an
+	// external subtitle file.
 	defaultSubtitleTrack: z.string().url().nullable().optional(),
 });
 

--- a/common/models/zod-schemas.ts
+++ b/common/models/zod-schemas.ts
@@ -53,12 +53,8 @@ const VideoIdSchema = z.object({
 const QueueItemExtrasSchema = z.object({
 	// startAt: z.number().nonnegative().optional(),
 	// endAt: z.number().positive().optional(),
-	defaultSubtitleTrack: z
-		.string()
-		.url()
-		.or(z.literal(""))
-		.nullish()
-		.transform(normalizeSubtitleTrack),
+	// Named to match the persisted VideoMetadata.subtitleUrl field it feeds.
+	subtitleUrl: z.string().url().or(z.literal("")).nullish().transform(normalizeSubtitleTrack),
 });
 
 const VideoAddSchema = VideoIdSchema.extend(QueueItemExtrasSchema.shape);

--- a/common/subtitle.ts
+++ b/common/subtitle.ts
@@ -4,21 +4,33 @@ export function normalizeSubtitleTrack(value: string | null | undefined): string
 	return value || null;
 }
 
-/**
- * Guesses the content type from the URL extension, defaulting to `text/vtt`. The default is
- * intentionally permissive: the server does not validate external subtitle URLs, so an
- * unsupported file fails to render in the browser rather than being rejected.
- */
-export function inferSubtitleContentType(url: string): CustomMediaTextTrack["contentType"] {
+function subtitleUrlExtension(url: string): string | undefined {
 	const path = url.split("?")[0].split("#")[0];
-	const ext = path.split(".").pop()?.toLowerCase();
-	return ext === "ass" || ext === "ssa" ? "text/x-ass" : "text/vtt";
+	return path.split(".").pop()?.toLowerCase();
+}
+
+export function inferSubtitleContentTypeOrNull(
+	url: string,
+): CustomMediaTextTrack["contentType"] | null {
+	const ext = subtitleUrlExtension(url);
+	if (ext === "ass" || ext === "ssa") {
+		return "text/x-ass";
+	}
+	if (ext === "vtt") {
+		return "text/vtt";
+	}
+	return null;
 }
 
 export function externalSubtitleAsTextTrack(url: string): CustomMediaTextTrack {
+	const contentType = inferSubtitleContentTypeOrNull(url);
+	if (!contentType) {
+		// Callers only reach here with a server-validated url, so this is a programming error.
+		throw new Error(`Cannot build a text track for unsupported subtitle url: ${url}`);
+	}
 	return {
 		url,
-		contentType: inferSubtitleContentType(url),
+		contentType,
 		srclang: "und",
 		default: true,
 	};

--- a/common/subtitle.ts
+++ b/common/subtitle.ts
@@ -1,0 +1,25 @@
+import type { CustomMediaTextTrack } from "./models/zod-schemas.js";
+
+export function normalizeSubtitleTrack(value: string | null | undefined): string | null {
+	return value || null;
+}
+
+/**
+ * Guesses the content type from the URL extension, defaulting to `text/vtt`. The default is
+ * intentionally permissive: the server does not validate external subtitle URLs, so an
+ * unsupported file fails to render in the browser rather than being rejected.
+ */
+export function inferSubtitleContentType(url: string): CustomMediaTextTrack["contentType"] {
+	const path = url.split("?")[0].split("#")[0];
+	const ext = path.split(".").pop()?.toLowerCase();
+	return ext === "ass" || ext === "ssa" ? "text/x-ass" : "text/vtt";
+}
+
+export function externalSubtitleAsTextTrack(url: string): CustomMediaTextTrack {
+	return {
+		url,
+		contentType: inferSubtitleContentType(url),
+		srclang: "und",
+		default: true,
+	};
+}

--- a/common/subtitle.ts
+++ b/common/subtitle.ts
@@ -22,11 +22,10 @@ export function inferSubtitleContentTypeOrNull(
 	return null;
 }
 
-export function externalSubtitleAsTextTrack(url: string): CustomMediaTextTrack {
+export function externalSubtitleAsTextTrackOrNull(url: string): CustomMediaTextTrack | null {
 	const contentType = inferSubtitleContentTypeOrNull(url);
 	if (!contentType) {
-		// Callers only reach here with a server-validated url, so this is a programming error.
-		throw new Error(`Cannot build a text track for unsupported subtitle url: ${url}`);
+		return null;
 	}
 	return {
 		url,

--- a/common/subtitle.ts
+++ b/common/subtitle.ts
@@ -5,8 +5,12 @@ export function normalizeSubtitleTrack(value: string | null | undefined): string
 }
 
 function subtitleUrlExtension(url: string): string | undefined {
-	const path = url.split("?")[0].split("#")[0];
-	return path.split(".").pop()?.toLowerCase();
+	// TODO: replace with `URL.parse(url)?.pathname` once typescript is upgraded to >= 5.7,
+	// which is when `URL.parse` was added to the dom lib types.
+	if (!URL.canParse(url)) {
+		return undefined;
+	}
+	return new URL(url).pathname.split(".").pop()?.toLowerCase();
 }
 
 export function inferSubtitleContentTypeOrNull(

--- a/common/tests/unit/subtitle.spec.ts
+++ b/common/tests/unit/subtitle.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { inferSubtitleContentType } from "../../subtitle.js";
+
+describe("inferSubtitleContentType", () => {
+	it("recognizes .ass and .ssa as ASS", () => {
+		expect(inferSubtitleContentType("https://example.com/a.ass")).toEqual("text/x-ass");
+		expect(inferSubtitleContentType("https://example.com/a.ssa")).toEqual("text/x-ass");
+	});
+
+	it("ignores query strings and hash fragments when reading the extension", () => {
+		expect(inferSubtitleContentType("https://example.com/a.ass?token=1")).toEqual("text/x-ass");
+		expect(inferSubtitleContentType("https://example.com/a.vtt#t=10")).toEqual("text/vtt");
+	});
+
+	it("is case-insensitive", () => {
+		expect(inferSubtitleContentType("https://example.com/A.ASS")).toEqual("text/x-ass");
+	});
+
+	it("falls back to WebVTT for unknown extensions", () => {
+		expect(inferSubtitleContentType("https://example.com/a.srt")).toEqual("text/vtt");
+		expect(inferSubtitleContentType("https://example.com/no-extension")).toEqual("text/vtt");
+	});
+});

--- a/common/tests/unit/subtitle.spec.ts
+++ b/common/tests/unit/subtitle.spec.ts
@@ -1,23 +1,31 @@
 import { describe, it, expect } from "vitest";
-import { inferSubtitleContentType } from "../../subtitle.js";
+import { inferSubtitleContentTypeOrNull } from "../../subtitle.js";
 
-describe("inferSubtitleContentType", () => {
+describe("inferSubtitleContentTypeOrNull", () => {
 	it("recognizes .ass and .ssa as ASS", () => {
-		expect(inferSubtitleContentType("https://example.com/a.ass")).toEqual("text/x-ass");
-		expect(inferSubtitleContentType("https://example.com/a.ssa")).toEqual("text/x-ass");
+		expect(inferSubtitleContentTypeOrNull("https://example.com/a.ass")).toEqual("text/x-ass");
+		expect(inferSubtitleContentTypeOrNull("https://example.com/a.ssa")).toEqual("text/x-ass");
+	});
+
+	it("recognizes .vtt as WebVTT", () => {
+		expect(inferSubtitleContentTypeOrNull("https://example.com/a.vtt")).toEqual("text/vtt");
 	});
 
 	it("ignores query strings and hash fragments when reading the extension", () => {
-		expect(inferSubtitleContentType("https://example.com/a.ass?token=1")).toEqual("text/x-ass");
-		expect(inferSubtitleContentType("https://example.com/a.vtt#t=10")).toEqual("text/vtt");
+		expect(inferSubtitleContentTypeOrNull("https://example.com/a.ass?token=1")).toEqual(
+			"text/x-ass",
+		);
+		expect(inferSubtitleContentTypeOrNull("https://example.com/a.vtt#t=10")).toEqual("text/vtt");
+		expect(inferSubtitleContentTypeOrNull("https://example.com/a.srt?x=.vtt")).toBeNull();
 	});
 
 	it("is case-insensitive", () => {
-		expect(inferSubtitleContentType("https://example.com/A.ASS")).toEqual("text/x-ass");
+		expect(inferSubtitleContentTypeOrNull("https://example.com/A.ASS")).toEqual("text/x-ass");
 	});
 
-	it("falls back to WebVTT for unknown extensions", () => {
-		expect(inferSubtitleContentType("https://example.com/a.srt")).toEqual("text/vtt");
-		expect(inferSubtitleContentType("https://example.com/no-extension")).toEqual("text/vtt");
+	it("returns null for unsupported and unrelated formats", () => {
+		expect(inferSubtitleContentTypeOrNull("https://example.com/a.srt")).toBeNull();
+		expect(inferSubtitleContentTypeOrNull("https://example.com/a.mp3")).toBeNull();
+		expect(inferSubtitleContentTypeOrNull("https://example.com/no-extension")).toBeNull();
 	});
 });

--- a/common/tests/unit/subtitle.spec.ts
+++ b/common/tests/unit/subtitle.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { inferSubtitleContentTypeOrNull } from "../../subtitle.js";
+import {
+	externalSubtitleAsTextTrackOrNull,
+	inferSubtitleContentTypeOrNull,
+} from "../../subtitle.js";
 
 describe("inferSubtitleContentTypeOrNull", () => {
 	it("recognizes .ass and .ssa as ASS", () => {
@@ -27,5 +30,20 @@ describe("inferSubtitleContentTypeOrNull", () => {
 		expect(inferSubtitleContentTypeOrNull("https://example.com/a.srt")).toBeNull();
 		expect(inferSubtitleContentTypeOrNull("https://example.com/a.mp3")).toBeNull();
 		expect(inferSubtitleContentTypeOrNull("https://example.com/no-extension")).toBeNull();
+	});
+});
+
+describe("externalSubtitleAsTextTrackOrNull", () => {
+	it("builds a default track for supported urls", () => {
+		expect(externalSubtitleAsTextTrackOrNull("https://example.com/a.vtt")).toEqual({
+			url: "https://example.com/a.vtt",
+			contentType: "text/vtt",
+			srclang: "und",
+			default: true,
+		});
+	});
+
+	it("returns null instead of throwing for unsupported urls", () => {
+		expect(externalSubtitleAsTextTrackOrNull("https://example.com/a.srt")).toBeNull();
 	});
 });

--- a/common/tests/unit/zod-schemas.spec.ts
+++ b/common/tests/unit/zod-schemas.spec.ts
@@ -1,27 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { OttApiRequestUpdateQueueItemSchema } from "../../models/zod-schemas.js";
 
-describe("OttApiRequestUpdateQueueItemSchema defaultSubtitleTrack normalization", () => {
+describe("OttApiRequestUpdateQueueItemSchema subtitleUrl normalization", () => {
 	const base = { service: "direct", id: "foo" };
 
 	it.each([
 		["omitted", base, null],
-		["null", { ...base, defaultSubtitleTrack: null }, null],
-		["empty string", { ...base, defaultSubtitleTrack: "" }, null],
+		["null", { ...base, subtitleUrl: null }, null],
+		["empty string", { ...base, subtitleUrl: "" }, null],
 	])("normalizes %s to null", (_label, input, expected) => {
 		const parsed = OttApiRequestUpdateQueueItemSchema.parse(input);
-		expect(parsed.defaultSubtitleTrack).toEqual(expected);
+		expect(parsed.subtitleUrl).toEqual(expected);
 	});
 
 	it("rejects a non-URL string", () => {
 		expect(() =>
-			OttApiRequestUpdateQueueItemSchema.parse({ ...base, defaultSubtitleTrack: "not a url" }),
+			OttApiRequestUpdateQueueItemSchema.parse({ ...base, subtitleUrl: "not a url" }),
 		).toThrow();
 	});
 
 	it("rejects a non-string value", () => {
 		expect(() =>
-			OttApiRequestUpdateQueueItemSchema.parse({ ...base, defaultSubtitleTrack: 123 }),
+			OttApiRequestUpdateQueueItemSchema.parse({ ...base, subtitleUrl: 123 }),
 		).toThrow();
 	});
 });

--- a/common/tests/unit/zod-schemas.spec.ts
+++ b/common/tests/unit/zod-schemas.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { CustomMediaManifestSchema } from "../../models/zod-schemas.js";
+
+function buildManifest(textTracks?: unknown[]) {
+	return {
+		title: "Test Video",
+		duration: 120,
+		sources: [
+			{
+				url: "https://example.com/video.mp4",
+				contentType: "video/mp4",
+				quality: 1080,
+			},
+		],
+		textTracks,
+	};
+}
+
+describe("CustomMediaManifestSchema", () => {
+	it("should accept a manifest without text tracks", () => {
+		const result = CustomMediaManifestSchema.safeParse(buildManifest());
+		expect(result.success).toBe(true);
+	});
+
+	it("should accept a vtt text track", () => {
+		const result = CustomMediaManifestSchema.safeParse(
+			buildManifest([
+				{
+					url: "https://example.com/subs.vtt",
+					contentType: "text/vtt",
+					name: "English",
+					srclang: "en",
+					default: true,
+				},
+			]),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it("should accept an ass text track", () => {
+		const result = CustomMediaManifestSchema.safeParse(
+			buildManifest([
+				{
+					url: "https://example.com/subs.ass",
+					contentType: "text/x-ass",
+					name: "English",
+					srclang: "en",
+				},
+			]),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it("should accept a mix of vtt and ass text tracks", () => {
+		const result = CustomMediaManifestSchema.safeParse(
+			buildManifest([
+				{
+					url: "https://example.com/subs.vtt",
+					contentType: "text/vtt",
+					srclang: "en",
+					default: true,
+				},
+				{
+					url: "https://example.com/subs.ass",
+					contentType: "text/x-ass",
+					srclang: "de",
+				},
+			]),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it("should reject unsupported text track content types", () => {
+		const result = CustomMediaManifestSchema.safeParse(
+			buildManifest([
+				{
+					url: "https://example.com/subs.srt",
+					contentType: "text/srt",
+					srclang: "en",
+				},
+			]),
+		);
+		expect(result.success).toBe(false);
+	});
+});

--- a/common/tests/unit/zod-schemas.spec.ts
+++ b/common/tests/unit/zod-schemas.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { CustomMediaManifestSchema } from "../../models/zod-schemas.js";
+import {
+	CustomMediaManifestSchema,
+	OttApiRequestUpdateQueueItemSchema,
+} from "../../models/zod-schemas.js";
 
 function buildManifest(textTracks?: unknown[]) {
 	return {
@@ -80,6 +83,39 @@ describe("CustomMediaManifestSchema", () => {
 				},
 			]),
 		);
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("defaultSubtitleTrack normalization", () => {
+	function parse(input: Record<string, unknown>) {
+		return OttApiRequestUpdateQueueItemSchema.parse({
+			service: "direct",
+			id: "foo",
+			...input,
+		});
+	}
+
+	it.each([
+		["absent", {}],
+		["null", { defaultSubtitleTrack: null }],
+		["empty string", { defaultSubtitleTrack: "" }],
+	])("normalizes %s to null", (_label, input) => {
+		expect(parse(input).defaultSubtitleTrack).toBeNull();
+	});
+
+	it("passes a valid URL through unchanged", () => {
+		expect(parse({ defaultSubtitleTrack: "https://example.com/subs.ass" }).defaultSubtitleTrack).toEqual(
+			"https://example.com/subs.ass",
+		);
+	});
+
+	it("rejects a non-URL, non-empty string", () => {
+		const result = OttApiRequestUpdateQueueItemSchema.safeParse({
+			service: "direct",
+			id: "foo",
+			defaultSubtitleTrack: "not a url",
+		});
 		expect(result.success).toBe(false);
 	});
 });

--- a/common/tests/unit/zod-schemas.spec.ts
+++ b/common/tests/unit/zod-schemas.spec.ts
@@ -1,121 +1,27 @@
 import { describe, it, expect } from "vitest";
-import {
-	CustomMediaManifestSchema,
-	OttApiRequestUpdateQueueItemSchema,
-} from "../../models/zod-schemas.js";
+import { OttApiRequestUpdateQueueItemSchema } from "../../models/zod-schemas.js";
 
-function buildManifest(textTracks?: unknown[]) {
-	return {
-		title: "Test Video",
-		duration: 120,
-		sources: [
-			{
-				url: "https://example.com/video.mp4",
-				contentType: "video/mp4",
-				quality: 1080,
-			},
-		],
-		textTracks,
-	};
-}
-
-describe("CustomMediaManifestSchema", () => {
-	it("should accept a manifest without text tracks", () => {
-		const result = CustomMediaManifestSchema.safeParse(buildManifest());
-		expect(result.success).toBe(true);
-	});
-
-	it("should accept a vtt text track", () => {
-		const result = CustomMediaManifestSchema.safeParse(
-			buildManifest([
-				{
-					url: "https://example.com/subs.vtt",
-					contentType: "text/vtt",
-					name: "English",
-					srclang: "en",
-					default: true,
-				},
-			]),
-		);
-		expect(result.success).toBe(true);
-	});
-
-	it("should accept an ass text track", () => {
-		const result = CustomMediaManifestSchema.safeParse(
-			buildManifest([
-				{
-					url: "https://example.com/subs.ass",
-					contentType: "text/x-ass",
-					name: "English",
-					srclang: "en",
-				},
-			]),
-		);
-		expect(result.success).toBe(true);
-	});
-
-	it("should accept a mix of vtt and ass text tracks", () => {
-		const result = CustomMediaManifestSchema.safeParse(
-			buildManifest([
-				{
-					url: "https://example.com/subs.vtt",
-					contentType: "text/vtt",
-					srclang: "en",
-					default: true,
-				},
-				{
-					url: "https://example.com/subs.ass",
-					contentType: "text/x-ass",
-					srclang: "de",
-				},
-			]),
-		);
-		expect(result.success).toBe(true);
-	});
-
-	it("should reject unsupported text track content types", () => {
-		const result = CustomMediaManifestSchema.safeParse(
-			buildManifest([
-				{
-					url: "https://example.com/subs.srt",
-					contentType: "text/srt",
-					srclang: "en",
-				},
-			]),
-		);
-		expect(result.success).toBe(false);
-	});
-});
-
-describe("defaultSubtitleTrack normalization", () => {
-	function parse(input: Record<string, unknown>) {
-		return OttApiRequestUpdateQueueItemSchema.parse({
-			service: "direct",
-			id: "foo",
-			...input,
-		});
-	}
+describe("OttApiRequestUpdateQueueItemSchema defaultSubtitleTrack normalization", () => {
+	const base = { service: "direct", id: "foo" };
 
 	it.each([
-		["absent", {}],
-		["null", { defaultSubtitleTrack: null }],
-		["empty string", { defaultSubtitleTrack: "" }],
-	])("normalizes %s to null", (_label, input) => {
-		expect(parse(input).defaultSubtitleTrack).toBeNull();
+		["omitted", base, null],
+		["null", { ...base, defaultSubtitleTrack: null }, null],
+		["empty string", { ...base, defaultSubtitleTrack: "" }, null],
+	])("normalizes %s to null", (_label, input, expected) => {
+		const parsed = OttApiRequestUpdateQueueItemSchema.parse(input);
+		expect(parsed.defaultSubtitleTrack).toEqual(expected);
 	});
 
-	it("passes a valid URL through unchanged", () => {
-		expect(parse({ defaultSubtitleTrack: "https://example.com/subs.ass" }).defaultSubtitleTrack).toEqual(
-			"https://example.com/subs.ass",
-		);
+	it("rejects a non-URL string", () => {
+		expect(() =>
+			OttApiRequestUpdateQueueItemSchema.parse({ ...base, defaultSubtitleTrack: "not a url" }),
+		).toThrow();
 	});
 
-	it("rejects a non-URL, non-empty string", () => {
-		const result = OttApiRequestUpdateQueueItemSchema.safeParse({
-			service: "direct",
-			id: "foo",
-			defaultSubtitleTrack: "not a url",
-		});
-		expect(result.success).toBe(false);
+	it("rejects a non-string value", () => {
+		expect(() =>
+			OttApiRequestUpdateQueueItemSchema.parse({ ...base, defaultSubtitleTrack: 123 }),
+		).toThrow();
 	});
 });

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -686,7 +686,7 @@ components:
         id:
           type: string
           example: dQw4w9WgXcQ
-        defaultSubtitleTrack:
+        subtitleUrl:
           type: string
           format: uri
           nullable: true

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -694,7 +694,8 @@ components:
             URL of the subtitle track to show by default. For custom media
             manifest items this must be one of the manifest's text tracks; for
             other items it is the URL of an external subtitle file (.vtt or
-            .ass). `null` means no subtitles.
+            .ass). `null` means no subtitles; an empty string and an absent
+            field are accepted and treated the same as `null`.
       required:
         - service
         - id

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -686,10 +686,15 @@ components:
         id:
           type: string
           example: dQw4w9WgXcQ
-        subtitleUrl:
+        defaultSubtitleTrack:
           type: string
           format: uri
-          description: URL to a WebVTT subtitle file.
+          nullable: true
+          description: >-
+            URL of the subtitle track to show by default. For custom media
+            manifest items this must be one of the manifest's text tracks; for
+            other items it is the URL of an external subtitle file (.vtt or
+            .ass). `null` means no subtitles.
       required:
         - service
         - id

--- a/docs/custom-media-format.md
+++ b/docs/custom-media-format.md
@@ -42,13 +42,15 @@ Each source entry in the `sources` array is a JSON object with the following key
 Each text track entry in the `textTracks` array is a JSON object with the following keys:
 
 * `url`: A valid HTTPS URL that browsers can use to retrieve the track.
-* `contentType`: A string representing the MIME type of the track. Currently, the only supported MIME type is `text/vtt`.
+* `contentType`: A string representing the MIME type of the track. Supported values are:
+  * `text/vtt` for WebVTT tracks
+  * `text/x-ass` for Advanced SubStation Alpha (`.ass`) tracks (note: ASS has no officially registered MIME type, so `text/x-ass` is used by convention)
 * `name`: An optional string (max 20 characters) providing a display name for the text track.
 * `srclang`: A string (2-8 characters) indicating the language of the text track (e.g., `en`, `es`).
 * `default`: An optional boolean indicating whether this subtitle track should be enabled by default.
 
 **Important note regarding text tracks and CORS:**
-Browsers block requests for WebVTT tracks hosted on different domains than the current page by default. To make text tracks work cross-origin, your host needs to serve the VTT file with the `Access-Control-Allow-Origin` HTTP header.
+Browsers block requests for text tracks hosted on different domains than the current page by default. To make text tracks work cross-origin, your host needs to serve the subtitle file with the `Access-Control-Allow-Origin` HTTP header.
 
 ## Example
 
@@ -85,6 +87,12 @@ Browsers block requests for WebVTT tracks hosted on different domains than the c
       "contentType": "text/vtt",
       "name": "Español",
       "srclang": "es"
+    },
+    {
+      "url": "https://example.com/subtitles_de.ass",
+      "contentType": "text/x-ass",
+      "name": "Deutsch",
+      "srclang": "de"
     }
   ]
 }

--- a/server/api/room.ts
+++ b/server/api/room.ts
@@ -438,8 +438,7 @@ const addToQueue: RequestHandler<
 			video: {
 				service: body.service,
 				id: body.id,
-				defaultSubtitleTrack:
-					"defaultSubtitleTrack" in body ? body.defaultSubtitleTrack : undefined,
+				defaultSubtitleTrack: body.defaultSubtitleTrack,
 			},
 		};
 	}
@@ -485,14 +484,10 @@ const updateQueueItem: RequestHandler<
 		return;
 	}
 	const room = (await roommanager.getRoom(req.params.name)).unwrap();
-	const update: UpdateQueueItemRequest["update"] = {};
-	if ("defaultSubtitleTrack" in body) {
-		update.defaultSubtitleTrack = body.defaultSubtitleTrack;
-	}
 	const roomRequest: UpdateQueueItemRequest = {
 		type: RoomRequestType.UpdateQueueItemRequest,
 		video: { service: body.service, id: body.id },
-		update,
+		update: { defaultSubtitleTrack: body.defaultSubtitleTrack },
 	};
 	await room.processUnauthorizedRequest(roomRequest, { token: req.token! });
 	res.json({

--- a/server/api/room.ts
+++ b/server/api/room.ts
@@ -438,7 +438,7 @@ const addToQueue: RequestHandler<
 			video: {
 				service: body.service,
 				id: body.id,
-				defaultSubtitleTrack: body.defaultSubtitleTrack,
+				subtitleUrl: body.subtitleUrl,
 			},
 		};
 	}
@@ -487,7 +487,7 @@ const updateQueueItem: RequestHandler<
 	const roomRequest: UpdateQueueItemRequest = {
 		type: RoomRequestType.UpdateQueueItemRequest,
 		video: { service: body.service, id: body.id },
-		update: { defaultSubtitleTrack: body.defaultSubtitleTrack },
+		update: { subtitleUrl: body.subtitleUrl },
 	};
 	await room.processUnauthorizedRequest(roomRequest, { token: req.token! });
 	res.json({

--- a/server/api/room.ts
+++ b/server/api/room.ts
@@ -439,6 +439,8 @@ const addToQueue: RequestHandler<
 				service: body.service,
 				id: body.id,
 				subtitleUrl: "subtitleUrl" in body ? body.subtitleUrl : undefined,
+				defaultSubtitleTrack:
+					"defaultSubtitleTrack" in body ? body.defaultSubtitleTrack : undefined,
 			},
 		};
 	}
@@ -484,10 +486,17 @@ const updateQueueItem: RequestHandler<
 		return;
 	}
 	const room = (await roommanager.getRoom(req.params.name)).unwrap();
+	const update: UpdateQueueItemRequest["update"] = {};
+	if ("subtitleUrl" in body) {
+		update.subtitleUrl = body.subtitleUrl;
+	}
+	if ("defaultSubtitleTrack" in body) {
+		update.defaultSubtitleTrack = body.defaultSubtitleTrack;
+	}
 	const roomRequest: UpdateQueueItemRequest = {
 		type: RoomRequestType.UpdateQueueItemRequest,
 		video: { service: body.service, id: body.id },
-		update: { subtitleUrl: body.subtitleUrl },
+		update,
 	};
 	await room.processUnauthorizedRequest(roomRequest, { token: req.token! });
 	res.json({

--- a/server/api/room.ts
+++ b/server/api/room.ts
@@ -438,7 +438,6 @@ const addToQueue: RequestHandler<
 			video: {
 				service: body.service,
 				id: body.id,
-				subtitleUrl: "subtitleUrl" in body ? body.subtitleUrl : undefined,
 				defaultSubtitleTrack:
 					"defaultSubtitleTrack" in body ? body.defaultSubtitleTrack : undefined,
 			},
@@ -487,9 +486,6 @@ const updateQueueItem: RequestHandler<
 	}
 	const room = (await roommanager.getRoom(req.params.name)).unwrap();
 	const update: UpdateQueueItemRequest["update"] = {};
-	if ("subtitleUrl" in body) {
-		update.subtitleUrl = body.subtitleUrl;
-	}
 	if ("defaultSubtitleTrack" in body) {
 		update.defaultSubtitleTrack = body.defaultSubtitleTrack;
 	}

--- a/server/exceptions.ts
+++ b/server/exceptions.ts
@@ -261,6 +261,14 @@ export class UnsupportedVideoType extends OttException {
 	}
 }
 
+export class UnsupportedSubtitleType extends OttException {
+	name = "UnsupportedSubtitleType";
+
+	constructor() {
+		super("Subtitle URL must be a .vtt, .ass, or .ssa file");
+	}
+}
+
 export class ClientNotFoundInRoomException extends OttException {
 	name = "ClientNotFoundInRoomException";
 

--- a/server/exceptions.ts
+++ b/server/exceptions.ts
@@ -261,14 +261,6 @@ export class UnsupportedVideoType extends OttException {
 	}
 }
 
-export class UnsupportedSubtitleType extends OttException {
-	name = "UnsupportedSubtitleType";
-
-	constructor() {
-		super(`Subtitle URL must end with .vtt`);
-	}
-}
-
 export class ClientNotFoundInRoomException extends OttException {
 	name = "ClientNotFoundInRoomException";
 

--- a/server/room.ts
+++ b/server/room.ts
@@ -1258,6 +1258,9 @@ export class Room implements RoomState {
 				}
 				video.subtitleUrl = request.video.subtitleUrl;
 			}
+			if (request.video.defaultSubtitleTrack !== undefined) {
+				video.defaultSubtitleTrack = request.video.defaultSubtitleTrack;
+			}
 			this.queue.enqueue(video);
 			this.log.info(`Video added: ${JSON.stringify(request.video)}`);
 			this.prevQueue = null;
@@ -1694,6 +1697,9 @@ export class Room implements RoomState {
 				throw new UnsupportedSubtitleType();
 			}
 			videoToPlay.subtitleUrl = request.video.subtitleUrl;
+		}
+		if (request.video.defaultSubtitleTrack !== undefined) {
+			videoToPlay.defaultSubtitleTrack = request.video.defaultSubtitleTrack;
 		}
 		if (this.currentSource) {
 			this.currentSource.startAt = this.realPlaybackPosition;

--- a/server/room.ts
+++ b/server/room.ts
@@ -1259,8 +1259,6 @@ export class Room implements RoomState {
 		} else if (request.videos) {
 			const videos: Video[] = await InfoExtract.getManyVideoInfo(request.videos);
 
-			// Per-item default subtitle track, keyed by service+id so it survives the
-			// dedupe splice below (which shifts indices). Matches the single-add path.
 			const subtitleByKey = new Map(
 				request.videos.map(v => [`${v.service}:${v.id}`, v.defaultSubtitleTrack ?? null]),
 			);

--- a/server/room.ts
+++ b/server/room.ts
@@ -1262,8 +1262,8 @@ export class Room implements RoomState {
 				this.log.error("video was undefined, which is bad");
 				throw new Error("video was undefined");
 			}
-			assertSupportedSubtitleTrack(request.video.defaultSubtitleTrack);
-			video.defaultSubtitleTrack = request.video.defaultSubtitleTrack ?? null;
+			assertSupportedSubtitleTrack(request.video.subtitleUrl);
+			video.subtitleUrl = request.video.subtitleUrl ?? null;
 			this.queue.enqueue(video);
 			this.log.info(`Video added: ${JSON.stringify(request.video)}`);
 			this.prevQueue = null;
@@ -1271,12 +1271,12 @@ export class Room implements RoomState {
 			counterMediaQueued.labels({ service: video.service }).inc();
 		} else if (request.videos) {
 			for (const v of request.videos) {
-				assertSupportedSubtitleTrack(v.defaultSubtitleTrack);
+				assertSupportedSubtitleTrack(v.subtitleUrl);
 			}
 			const videos: Video[] = await InfoExtract.getManyVideoInfo(request.videos);
 
 			const subtitleByKey = new Map(
-				request.videos.map(v => [`${v.service}:${v.id}`, v.defaultSubtitleTrack ?? null]),
+				request.videos.map(v => [`${v.service}:${v.id}`, v.subtitleUrl ?? null]),
 			);
 
 			for (let i = 0; i < videos.length; i++) {
@@ -1285,8 +1285,7 @@ export class Room implements RoomState {
 					this.log.error("video was undefined, which is bad");
 					throw new Error("video was undefined");
 				}
-				video.defaultSubtitleTrack =
-					subtitleByKey.get(`${video.service}:${video.id}`) ?? null;
+				video.subtitleUrl = subtitleByKey.get(`${video.service}:${video.id}`) ?? null;
 				if (this.isVideoInQueue(video)) {
 					videos.splice(i--, 1);
 				}
@@ -1311,7 +1310,7 @@ export class Room implements RoomState {
 		request: UpdateQueueItemRequest,
 		context: RoomRequestContext,
 	): Promise<void> {
-		assertSupportedSubtitleTrack(request.update.defaultSubtitleTrack);
+		assertSupportedSubtitleTrack(request.update.subtitleUrl);
 		await this.queue.update(request.video, request.update);
 		this.log.info(`Queue item updated: ${JSON.stringify(request.video)}`);
 		await this.publishRoomEvent(request, context);
@@ -1698,8 +1697,8 @@ export class Room implements RoomState {
 		} else {
 			videoToPlay = await InfoExtract.getVideoInfo(request.video.service, request.video.id);
 		}
-		assertSupportedSubtitleTrack(request.video.defaultSubtitleTrack);
-		videoToPlay.defaultSubtitleTrack = request.video.defaultSubtitleTrack ?? null;
+		assertSupportedSubtitleTrack(request.video.subtitleUrl);
+		videoToPlay.subtitleUrl = request.video.subtitleUrl ?? null;
 		if (this.currentSource) {
 			this.currentSource.startAt = this.realPlaybackPosition;
 			await this.queue.pushTop(this.currentSource);

--- a/server/room.ts
+++ b/server/room.ts
@@ -55,9 +55,11 @@ import { replacer } from "ott-common/serialize.js";
 import {
 	ClientNotFoundInRoomException,
 	ImpossiblePromotionException,
+	UnsupportedSubtitleType,
 	VideoAlreadyQueuedException,
 	VideoNotFoundException,
 } from "./exceptions.js";
+import { inferSubtitleContentTypeOrNull } from "ott-common/subtitle.js";
 import storage from "./storage.js";
 import tokens, { type SessionInfo } from "./auth/tokens.js";
 import { OttException } from "ott-common/exceptions.js";
@@ -219,6 +221,16 @@ export type RoomStatePersistable = Omit<
 	| "voteCounts"
 	| "votesToSkip"
 >;
+
+/**
+ * Rejects an external subtitle url whose format we can't render. `null`/`undefined`/empty (i.e.
+ * "no subtitles") is always allowed; this only guards non-empty urls.
+ */
+function assertSupportedSubtitleTrack(url: string | null | undefined): void {
+	if (url && inferSubtitleContentTypeOrNull(url) === null) {
+		throw new UnsupportedSubtitleType();
+	}
+}
 
 export class Room implements RoomState {
 	_name = "";
@@ -1250,6 +1262,7 @@ export class Room implements RoomState {
 				this.log.error("video was undefined, which is bad");
 				throw new Error("video was undefined");
 			}
+			assertSupportedSubtitleTrack(request.video.defaultSubtitleTrack);
 			video.defaultSubtitleTrack = request.video.defaultSubtitleTrack ?? null;
 			this.queue.enqueue(video);
 			this.log.info(`Video added: ${JSON.stringify(request.video)}`);
@@ -1257,6 +1270,9 @@ export class Room implements RoomState {
 			await this.publishRoomEvent(request, context, { video });
 			counterMediaQueued.labels({ service: video.service }).inc();
 		} else if (request.videos) {
+			for (const v of request.videos) {
+				assertSupportedSubtitleTrack(v.defaultSubtitleTrack);
+			}
 			const videos: Video[] = await InfoExtract.getManyVideoInfo(request.videos);
 
 			const subtitleByKey = new Map(
@@ -1295,6 +1311,7 @@ export class Room implements RoomState {
 		request: UpdateQueueItemRequest,
 		context: RoomRequestContext,
 	): Promise<void> {
+		assertSupportedSubtitleTrack(request.update.defaultSubtitleTrack);
 		await this.queue.update(request.video, request.update);
 		this.log.info(`Queue item updated: ${JSON.stringify(request.video)}`);
 		await this.publishRoomEvent(request, context);
@@ -1681,6 +1698,7 @@ export class Room implements RoomState {
 		} else {
 			videoToPlay = await InfoExtract.getVideoInfo(request.video.service, request.video.id);
 		}
+		assertSupportedSubtitleTrack(request.video.defaultSubtitleTrack);
 		videoToPlay.defaultSubtitleTrack = request.video.defaultSubtitleTrack ?? null;
 		if (this.currentSource) {
 			this.currentSource.startAt = this.realPlaybackPosition;

--- a/server/room.ts
+++ b/server/room.ts
@@ -57,7 +57,6 @@ import {
 	ImpossiblePromotionException,
 	VideoAlreadyQueuedException,
 	VideoNotFoundException,
-	UnsupportedSubtitleType,
 } from "./exceptions.js";
 import storage from "./storage.js";
 import tokens, { type SessionInfo } from "./auth/tokens.js";
@@ -1251,13 +1250,6 @@ export class Room implements RoomState {
 				this.log.error("video was undefined, which is bad");
 				throw new Error("video was undefined");
 			}
-			if (request.video.subtitleUrl) {
-				if (request.video.subtitleUrl.split(".").pop() !== "vtt") {
-					this.log.error("subtitle URL does not end with .vtt");
-					throw new UnsupportedSubtitleType();
-				}
-				video.subtitleUrl = request.video.subtitleUrl;
-			}
 			if (request.video.defaultSubtitleTrack !== undefined) {
 				video.defaultSubtitleTrack = request.video.defaultSubtitleTrack;
 			}
@@ -1299,12 +1291,6 @@ export class Room implements RoomState {
 		request: UpdateQueueItemRequest,
 		context: RoomRequestContext,
 	): Promise<void> {
-		if (
-			request.update.subtitleUrl !== undefined &&
-			!request.update.subtitleUrl.endsWith(".vtt")
-		) {
-			throw new UnsupportedSubtitleType();
-		}
 		await this.queue.update(request.video, request.update);
 		this.log.info(`Queue item updated: ${JSON.stringify(request.video)}`);
 		await this.publishRoomEvent(request, context);
@@ -1690,13 +1676,6 @@ export class Room implements RoomState {
 			videoToPlay = item;
 		} else {
 			videoToPlay = await InfoExtract.getVideoInfo(request.video.service, request.video.id);
-		}
-		if (request.video.subtitleUrl) {
-			if (request.video.subtitleUrl.split(".").pop() !== "vtt") {
-				this.log.error("subtitle URL does not end with .vtt");
-				throw new UnsupportedSubtitleType();
-			}
-			videoToPlay.subtitleUrl = request.video.subtitleUrl;
 		}
 		if (request.video.defaultSubtitleTrack !== undefined) {
 			videoToPlay.defaultSubtitleTrack = request.video.defaultSubtitleTrack;

--- a/server/room.ts
+++ b/server/room.ts
@@ -1250,9 +1250,7 @@ export class Room implements RoomState {
 				this.log.error("video was undefined, which is bad");
 				throw new Error("video was undefined");
 			}
-			if (request.video.defaultSubtitleTrack !== undefined) {
-				video.defaultSubtitleTrack = request.video.defaultSubtitleTrack;
-			}
+			video.defaultSubtitleTrack = request.video.defaultSubtitleTrack ?? null;
 			this.queue.enqueue(video);
 			this.log.info(`Video added: ${JSON.stringify(request.video)}`);
 			this.prevQueue = null;
@@ -1261,12 +1259,20 @@ export class Room implements RoomState {
 		} else if (request.videos) {
 			const videos: Video[] = await InfoExtract.getManyVideoInfo(request.videos);
 
+			// Per-item default subtitle track, keyed by service+id so it survives the
+			// dedupe splice below (which shifts indices). Matches the single-add path.
+			const subtitleByKey = new Map(
+				request.videos.map(v => [`${v.service}:${v.id}`, v.defaultSubtitleTrack ?? null]),
+			);
+
 			for (let i = 0; i < videos.length; i++) {
 				const video = videos[i];
 				if (video === undefined) {
 					this.log.error("video was undefined, which is bad");
 					throw new Error("video was undefined");
 				}
+				video.defaultSubtitleTrack =
+					subtitleByKey.get(`${video.service}:${video.id}`) ?? null;
 				if (this.isVideoInQueue(video)) {
 					videos.splice(i--, 1);
 				}
@@ -1677,9 +1683,7 @@ export class Room implements RoomState {
 		} else {
 			videoToPlay = await InfoExtract.getVideoInfo(request.video.service, request.video.id);
 		}
-		if (request.video.defaultSubtitleTrack !== undefined) {
-			videoToPlay.defaultSubtitleTrack = request.video.defaultSubtitleTrack;
-		}
+		videoToPlay.defaultSubtitleTrack = request.video.defaultSubtitleTrack ?? null;
 		if (this.currentSource) {
 			this.currentSource.startAt = this.realPlaybackPosition;
 			await this.queue.pushTop(this.currentSource);

--- a/server/services/direct.ts
+++ b/server/services/direct.ts
@@ -135,7 +135,7 @@ export default class DirectVideoAdapter extends ServiceAdapter {
 			thumbnail: manifest.thumbnail,
 			mime: "application/json",
 			textTracks: manifest.textTracks,
-			defaultSubtitleTrack: manifest.textTracks?.find(t => t.default)?.url ?? null,
+			subtitleUrl: manifest.textTracks?.find(t => t.default)?.url ?? null,
 		};
 	}
 

--- a/server/services/direct.ts
+++ b/server/services/direct.ts
@@ -135,8 +135,6 @@ export default class DirectVideoAdapter extends ServiceAdapter {
 			thumbnail: manifest.thumbnail,
 			mime: "application/json",
 			textTracks: manifest.textTracks,
-			// Resolve the default once here so every consumer sees a concrete value
-			// (`null` when the manifest declares no default track).
 			defaultSubtitleTrack: manifest.textTracks?.find(t => t.default)?.url ?? null,
 		};
 	}

--- a/server/services/direct.ts
+++ b/server/services/direct.ts
@@ -134,6 +134,9 @@ export default class DirectVideoAdapter extends ServiceAdapter {
 			length: Math.ceil(manifest.duration),
 			thumbnail: manifest.thumbnail,
 			mime: "application/json",
+			textTracks: manifest.textTracks,
+			// Resolve the default once here so every consumer sees a concrete value.
+			defaultSubtitleTrack: manifest.textTracks?.find(t => t.default)?.url ?? null,
 		};
 	}
 

--- a/server/services/direct.ts
+++ b/server/services/direct.ts
@@ -135,7 +135,8 @@ export default class DirectVideoAdapter extends ServiceAdapter {
 			thumbnail: manifest.thumbnail,
 			mime: "application/json",
 			textTracks: manifest.textTracks,
-			// Resolve the default once here so every consumer sees a concrete value.
+			// Resolve the default once here so every consumer sees a concrete value
+			// (`null` when the manifest declares no default track).
 			defaultSubtitleTrack: manifest.textTracks?.find(t => t.default)?.url ?? null,
 		};
 	}

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -528,6 +528,32 @@ describe("Room API", () => {
 			});
 		});
 
+		it("should fail if defaultSubtitleTrack is an unsupported subtitle format", async () => {
+			await roommanager.createRoom({
+				name: "testqueue",
+				isTemporary: true,
+			});
+			const room = (await roommanager.getRoom("testqueue")).unwrap();
+			await room.queue.enqueue({ service: "direct", id: "foo" });
+
+			const resp = await request(app)
+				.patch("/api/room/testqueue/queue")
+				.auth(token, { type: "bearer" })
+				.set({ Authorization: "Bearer foobar" })
+				.send({
+					service: "direct",
+					id: "foo",
+					defaultSubtitleTrack: "https://example.com/subtitles.srt",
+				})
+				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
+				.expect(400);
+
+			expect(resp.body.success).toEqual(false);
+			expect(resp.body.error).toMatchObject({
+				name: "UnsupportedSubtitleType",
+			});
+		});
+
 		it("should fail if the request body is invalid", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -502,44 +502,6 @@ describe("Room API", () => {
 			);
 		});
 
-		it("should clear defaultSubtitleTrack to null", async () => {
-			await roommanager.createRoom({
-				name: "testqueue",
-				isTemporary: true,
-			});
-			const room = (await roommanager.getRoom("testqueue")).unwrap();
-			await room.queue.enqueue({
-				service: "direct",
-				id: "foo",
-				defaultSubtitleTrack: "https://example.com/track.de.ass",
-			});
-
-			const resp = await request(app)
-				.patch("/api/room/testqueue/queue")
-				.auth(token, { type: "bearer" })
-				.set({ Authorization: "Bearer foobar" })
-				.send({
-					service: "direct",
-					id: "foo",
-					defaultSubtitleTrack: null,
-				})
-				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
-				.expect(200);
-
-			expect(resp.body.success).toEqual(true);
-
-			const updatedRoom = (await roommanager.getRoom("testqueue")).unwrap();
-			expect(updatedRoom.queue.items).toEqual(
-				expect.arrayContaining([
-					expect.objectContaining({
-						service: "direct",
-						id: "foo",
-						defaultSubtitleTrack: null,
-					}),
-				]),
-			);
-		});
-
 		it("should fail if defaultSubtitleTrack is not a valid URL", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -468,7 +468,7 @@ describe("Room API", () => {
 			}
 		});
 
-		it("should update a queue item's defaultSubtitleTrack", async () => {
+		it("should update a queue item's subtitleUrl", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",
 				isTemporary: true,
@@ -483,7 +483,7 @@ describe("Room API", () => {
 				.send({
 					service: "direct",
 					id: "foo",
-					defaultSubtitleTrack: "https://example.com/track.de.ass",
+					subtitleUrl: "https://example.com/track.de.ass",
 				})
 				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
 				.expect(200);
@@ -496,13 +496,13 @@ describe("Room API", () => {
 					expect.objectContaining({
 						service: "direct",
 						id: "foo",
-						defaultSubtitleTrack: "https://example.com/track.de.ass",
+						subtitleUrl: "https://example.com/track.de.ass",
 					}),
 				]),
 			);
 		});
 
-		it("should fail if defaultSubtitleTrack is not a valid URL", async () => {
+		it("should fail if subtitleUrl is not a valid URL", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",
 				isTemporary: true,
@@ -517,7 +517,7 @@ describe("Room API", () => {
 				.send({
 					service: "direct",
 					id: "foo",
-					defaultSubtitleTrack: "not a url",
+					subtitleUrl: "not a url",
 				})
 				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
 				.expect(400);
@@ -528,7 +528,7 @@ describe("Room API", () => {
 			});
 		});
 
-		it("should fail if defaultSubtitleTrack is an unsupported subtitle format", async () => {
+		it("should fail if subtitleUrl is an unsupported subtitle format", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",
 				isTemporary: true,
@@ -543,7 +543,7 @@ describe("Room API", () => {
 				.send({
 					service: "direct",
 					id: "foo",
-					defaultSubtitleTrack: "https://example.com/subtitles.srt",
+					subtitleUrl: "https://example.com/subtitles.srt",
 				})
 				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
 				.expect(400);
@@ -564,7 +564,7 @@ describe("Room API", () => {
 				.patch("/api/room/testqueue/queue")
 				.auth(token, { type: "bearer" })
 				.set({ Authorization: "Bearer foobar" })
-				.send({ service: "direct", id: "foo", defaultSubtitleTrack: 123 })
+				.send({ service: "direct", id: "foo", subtitleUrl: 123 })
 				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
 				.expect(400);
 

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -528,6 +528,104 @@ describe("Room API", () => {
 			});
 		});
 
+		it("should update a queue item's defaultSubtitleTrack", async () => {
+			await roommanager.createRoom({
+				name: "testqueue",
+				isTemporary: true,
+			});
+			const room = (await roommanager.getRoom("testqueue")).unwrap();
+			await room.queue.enqueue({ service: "direct", id: "foo" });
+
+			const resp = await request(app)
+				.patch("/api/room/testqueue/queue")
+				.auth(token, { type: "bearer" })
+				.set({ Authorization: "Bearer foobar" })
+				.send({
+					service: "direct",
+					id: "foo",
+					defaultSubtitleTrack: "https://example.com/track.de.ass",
+				})
+				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
+				.expect(200);
+
+			expect(resp.body.success).toEqual(true);
+
+			const updatedRoom = (await roommanager.getRoom("testqueue")).unwrap();
+			expect(updatedRoom.queue.items).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						service: "direct",
+						id: "foo",
+						defaultSubtitleTrack: "https://example.com/track.de.ass",
+					}),
+				]),
+			);
+		});
+
+		it("should allow clearing defaultSubtitleTrack with an empty string", async () => {
+			await roommanager.createRoom({
+				name: "testqueue",
+				isTemporary: true,
+			});
+			const room = (await roommanager.getRoom("testqueue")).unwrap();
+			await room.queue.enqueue({
+				service: "direct",
+				id: "foo",
+				defaultSubtitleTrack: "https://example.com/track.de.ass",
+			});
+
+			const resp = await request(app)
+				.patch("/api/room/testqueue/queue")
+				.auth(token, { type: "bearer" })
+				.set({ Authorization: "Bearer foobar" })
+				.send({
+					service: "direct",
+					id: "foo",
+					defaultSubtitleTrack: "",
+				})
+				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
+				.expect(200);
+
+			expect(resp.body.success).toEqual(true);
+
+			const updatedRoom = (await roommanager.getRoom("testqueue")).unwrap();
+			expect(updatedRoom.queue.items).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						service: "direct",
+						id: "foo",
+						defaultSubtitleTrack: "",
+					}),
+				]),
+			);
+		});
+
+		it("should fail if defaultSubtitleTrack is not a valid URL", async () => {
+			await roommanager.createRoom({
+				name: "testqueue",
+				isTemporary: true,
+			});
+			const room = (await roommanager.getRoom("testqueue")).unwrap();
+			await room.queue.enqueue({ service: "direct", id: "foo" });
+
+			const resp = await request(app)
+				.patch("/api/room/testqueue/queue")
+				.auth(token, { type: "bearer" })
+				.set({ Authorization: "Bearer foobar" })
+				.send({
+					service: "direct",
+					id: "foo",
+					defaultSubtitleTrack: "not a url",
+				})
+				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
+				.expect(400);
+
+			expect(resp.body.success).toEqual(false);
+			expect(resp.body.error).toMatchObject({
+				name: "ZodValidationError",
+			});
+		});
+
 		it("should fail if the request body is invalid", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -562,7 +562,7 @@ describe("Room API", () => {
 			);
 		});
 
-		it("should allow clearing defaultSubtitleTrack with an empty string", async () => {
+		it("should allow clearing defaultSubtitleTrack with null", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",
 				isTemporary: true,
@@ -581,7 +581,7 @@ describe("Room API", () => {
 				.send({
 					service: "direct",
 					id: "foo",
-					defaultSubtitleTrack: "",
+					defaultSubtitleTrack: null,
 				})
 				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
 				.expect(200);
@@ -594,7 +594,7 @@ describe("Room API", () => {
 					expect.objectContaining({
 						service: "direct",
 						id: "foo",
-						defaultSubtitleTrack: "",
+						defaultSubtitleTrack: null,
 					}),
 				]),
 			);

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -468,66 +468,6 @@ describe("Room API", () => {
 			}
 		});
 
-		it("should update a queue item's subtitleUrl", async () => {
-			await roommanager.createRoom({
-				name: "testqueue",
-				isTemporary: true,
-			});
-			const room = (await roommanager.getRoom("testqueue")).unwrap();
-			await room.queue.enqueue({ service: "direct", id: "foo" });
-
-			const resp = await request(app)
-				.patch("/api/room/testqueue/queue")
-				.auth(token, { type: "bearer" })
-				.set({ Authorization: "Bearer foobar" })
-				.send({
-					service: "direct",
-					id: "foo",
-					subtitleUrl: "https://example.com/subtitles.vtt",
-				})
-				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
-				.expect(200);
-
-			expect(resp.body.success).toEqual(true);
-
-			const updatedRoom = (await roommanager.getRoom("testqueue")).unwrap();
-			expect(updatedRoom.queue.items).toEqual(
-				expect.arrayContaining([
-					expect.objectContaining({
-						service: "direct",
-						id: "foo",
-						subtitleUrl: "https://example.com/subtitles.vtt",
-					}),
-				]),
-			);
-		});
-
-		it("should fail if the subtitleUrl does not end with .vtt", async () => {
-			await roommanager.createRoom({
-				name: "testqueue",
-				isTemporary: true,
-			});
-			const room = (await roommanager.getRoom("testqueue")).unwrap();
-			await room.queue.enqueue({ service: "direct", id: "foo" });
-
-			const resp = await request(app)
-				.patch("/api/room/testqueue/queue")
-				.auth(token, { type: "bearer" })
-				.set({ Authorization: "Bearer foobar" })
-				.send({
-					service: "direct",
-					id: "foo",
-					subtitleUrl: "https://example.com/subtitles.srt",
-				})
-				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
-				.expect(400);
-
-			expect(resp.body.success).toEqual(false);
-			expect(resp.body.error).toMatchObject({
-				name: "UnsupportedSubtitleType",
-			});
-		});
-
 		it("should update a queue item's defaultSubtitleTrack", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",
@@ -636,7 +576,7 @@ describe("Room API", () => {
 				.patch("/api/room/testqueue/queue")
 				.auth(token, { type: "bearer" })
 				.set({ Authorization: "Bearer foobar" })
-				.send({ service: "direct", id: "foo", subtitleUrl: 123 })
+				.send({ service: "direct", id: "foo", defaultSubtitleTrack: 123 })
 				.expect("Content-Type", JSON_CONTENT_TYPE_REGEX)
 				.expect(400);
 

--- a/server/tests/unit/api/room.spec.ts
+++ b/server/tests/unit/api/room.spec.ts
@@ -502,7 +502,7 @@ describe("Room API", () => {
 			);
 		});
 
-		it("should allow clearing defaultSubtitleTrack with null", async () => {
+		it("should clear defaultSubtitleTrack to null", async () => {
 			await roommanager.createRoom({
 				name: "testqueue",
 				isTemporary: true,

--- a/server/tests/unit/room.spec.ts
+++ b/server/tests/unit/room.spec.ts
@@ -282,6 +282,23 @@ describe("Room", () => {
 					defaultSubtitleTrack,
 				});
 			});
+
+			it("should reject an unsupported defaultSubtitleTrack for PlayNowRequest", async () => {
+				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToPlay);
+
+				await expect(
+					room.processUnauthorizedRequest(
+						{
+							type: RoomRequestType.PlayNowRequest,
+							video: {
+								...videoToPlay,
+								defaultSubtitleTrack: "https://example.com/subtitles.srt",
+							},
+						},
+						{ token: user.token },
+					),
+				).rejects.toThrow("Subtitle URL must be a .vtt, .ass, or .ssa file");
+			});
 		});
 
 		describe("AddRequest", () => {
@@ -313,6 +330,23 @@ describe("Room", () => {
 					...videoToAdd,
 					defaultSubtitleTrack,
 				});
+			});
+
+			it("should reject an unsupported defaultSubtitleTrack for AddRequest", async () => {
+				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
+
+				await expect(
+					room.processUnauthorizedRequest(
+						{
+							type: RoomRequestType.AddRequest,
+							video: {
+								...videoToAdd,
+								defaultSubtitleTrack: "https://example.com/subtitles.srt",
+							},
+						},
+						{ token: user.token },
+					),
+				).rejects.toThrow("Subtitle URL must be a .vtt, .ass, or .ssa file");
 			});
 		});
 

--- a/server/tests/unit/room.spec.ts
+++ b/server/tests/unit/room.spec.ts
@@ -283,6 +283,27 @@ describe("Room", () => {
 				});
 			});
 
+			it("should preserve defaultSubtitleTrack from PlayNowRequest", async () => {
+				const defaultSubtitleTrack = "https://example.com/track.de.ass";
+				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToPlay);
+
+				await room.processUnauthorizedRequest(
+					{
+						type: RoomRequestType.PlayNowRequest,
+						video: {
+							...videoToPlay,
+							defaultSubtitleTrack,
+						},
+					},
+					{ token: user.token },
+				);
+
+				expect(room.currentSource).toEqual({
+					...videoToPlay,
+					defaultSubtitleTrack,
+				});
+			});
+
 			it("should reject non-vtt subtitleUrl for PlayNowRequest", async () => {
 				await expect(
 					room.processUnauthorizedRequest(
@@ -328,6 +349,28 @@ describe("Room", () => {
 				expect(room.queue.items[0]).toEqual({
 					...videoToAdd,
 					subtitleUrl,
+				});
+			});
+
+			it("should add video with defaultSubtitleTrack to queue", async () => {
+				const defaultSubtitleTrack = "https://example.com/track.de.ass";
+				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
+
+				await room.processUnauthorizedRequest(
+					{
+						type: RoomRequestType.AddRequest,
+						video: {
+							...videoToAdd,
+							defaultSubtitleTrack,
+						},
+					},
+					{ token: user.token },
+				);
+
+				expect(room.queue).toHaveLength(1);
+				expect(room.queue.items[0]).toEqual({
+					...videoToAdd,
+					defaultSubtitleTrack,
 				});
 			});
 

--- a/server/tests/unit/room.spec.ts
+++ b/server/tests/unit/room.spec.ts
@@ -282,7 +282,6 @@ describe("Room", () => {
 					defaultSubtitleTrack,
 				});
 			});
-
 		});
 
 		describe("AddRequest", () => {
@@ -315,54 +314,6 @@ describe("Room", () => {
 					defaultSubtitleTrack,
 				});
 			});
-
-			it("should default defaultSubtitleTrack to null when omitted", async () => {
-				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
-
-				await room.processUnauthorizedRequest(
-					{
-						type: RoomRequestType.AddRequest,
-						video: { ...videoToAdd },
-					},
-					{ token: user.token },
-				);
-
-				expect(room.queue).toHaveLength(1);
-				expect(room.queue.items[0]).toEqual({
-					...videoToAdd,
-					defaultSubtitleTrack: null,
-				});
-			});
-
-			it("should apply per-item defaultSubtitleTrack for a batch add", async () => {
-				const first: Video = { ...videoToAdd, id: "first" };
-				const second: Video = { ...videoToAdd, id: "second" };
-				// Returned out of request order to prove matching is by service+id, not index.
-				vi.spyOn(infoextractor, "getManyVideoInfo").mockResolvedValue([second, first]);
-
-				await room.processUnauthorizedRequest(
-					{
-						type: RoomRequestType.AddRequest,
-						videos: [
-							{ ...first, defaultSubtitleTrack: "https://example.com/first.vtt" },
-							{ ...second },
-						],
-					},
-					{ token: user.token },
-				);
-
-				expect(room.queue).toHaveLength(2);
-				expect(room.queue.items).toEqual(
-					expect.arrayContaining([
-						expect.objectContaining({
-							id: "first",
-							defaultSubtitleTrack: "https://example.com/first.vtt",
-						}),
-						expect.objectContaining({ id: "second", defaultSubtitleTrack: null }),
-					]),
-				);
-			});
-
 		});
 
 		describe("VoteRequest", () => {

--- a/server/tests/unit/room.spec.ts
+++ b/server/tests/unit/room.spec.ts
@@ -262,8 +262,8 @@ describe("Room", () => {
 				expect(room.playbackPosition).toEqual(0);
 			});
 
-			it("should preserve defaultSubtitleTrack from PlayNowRequest", async () => {
-				const defaultSubtitleTrack = "https://example.com/track.de.ass";
+			it("should preserve subtitleUrl from PlayNowRequest", async () => {
+				const subtitleUrl = "https://example.com/track.de.ass";
 				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToPlay);
 
 				await room.processUnauthorizedRequest(
@@ -271,7 +271,7 @@ describe("Room", () => {
 						type: RoomRequestType.PlayNowRequest,
 						video: {
 							...videoToPlay,
-							defaultSubtitleTrack,
+							subtitleUrl,
 						},
 					},
 					{ token: user.token },
@@ -279,11 +279,11 @@ describe("Room", () => {
 
 				expect(room.currentSource).toEqual({
 					...videoToPlay,
-					defaultSubtitleTrack,
+					subtitleUrl,
 				});
 			});
 
-			it("should reject an unsupported defaultSubtitleTrack for PlayNowRequest", async () => {
+			it("should reject an unsupported subtitleUrl for PlayNowRequest", async () => {
 				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToPlay);
 
 				await expect(
@@ -292,7 +292,7 @@ describe("Room", () => {
 							type: RoomRequestType.PlayNowRequest,
 							video: {
 								...videoToPlay,
-								defaultSubtitleTrack: "https://example.com/subtitles.srt",
+								subtitleUrl: "https://example.com/subtitles.srt",
 							},
 						},
 						{ token: user.token },
@@ -310,8 +310,8 @@ describe("Room", () => {
 				thumbnail: "test",
 				length: 10,
 			};
-			it("should add video with defaultSubtitleTrack to queue", async () => {
-				const defaultSubtitleTrack = "https://example.com/track.de.ass";
+			it("should add video with subtitleUrl to queue", async () => {
+				const subtitleUrl = "https://example.com/track.de.ass";
 				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
 
 				await room.processUnauthorizedRequest(
@@ -319,7 +319,7 @@ describe("Room", () => {
 						type: RoomRequestType.AddRequest,
 						video: {
 							...videoToAdd,
-							defaultSubtitleTrack,
+							subtitleUrl,
 						},
 					},
 					{ token: user.token },
@@ -328,11 +328,11 @@ describe("Room", () => {
 				expect(room.queue).toHaveLength(1);
 				expect(room.queue.items[0]).toEqual({
 					...videoToAdd,
-					defaultSubtitleTrack,
+					subtitleUrl,
 				});
 			});
 
-			it("should reject an unsupported defaultSubtitleTrack for AddRequest", async () => {
+			it("should reject an unsupported subtitleUrl for AddRequest", async () => {
 				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
 
 				await expect(
@@ -341,7 +341,7 @@ describe("Room", () => {
 							type: RoomRequestType.AddRequest,
 							video: {
 								...videoToAdd,
-								defaultSubtitleTrack: "https://example.com/subtitles.srt",
+								subtitleUrl: "https://example.com/subtitles.srt",
 							},
 						},
 						{ token: user.token },

--- a/server/tests/unit/room.spec.ts
+++ b/server/tests/unit/room.spec.ts
@@ -262,27 +262,6 @@ describe("Room", () => {
 				expect(room.playbackPosition).toEqual(0);
 			});
 
-			it("should preserve subtitleUrl from PlayNowRequest", async () => {
-				const subtitleUrl = "https://example.com/subtitles.vtt";
-				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToPlay);
-
-				await room.processUnauthorizedRequest(
-					{
-						type: RoomRequestType.PlayNowRequest,
-						video: {
-							...videoToPlay,
-							subtitleUrl,
-						},
-					},
-					{ token: user.token },
-				);
-
-				expect(room.currentSource).toEqual({
-					...videoToPlay,
-					subtitleUrl,
-				});
-			});
-
 			it("should preserve defaultSubtitleTrack from PlayNowRequest", async () => {
 				const defaultSubtitleTrack = "https://example.com/track.de.ass";
 				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToPlay);
@@ -304,20 +283,6 @@ describe("Room", () => {
 				});
 			});
 
-			it("should reject non-vtt subtitleUrl for PlayNowRequest", async () => {
-				await expect(
-					room.processUnauthorizedRequest(
-						{
-							type: RoomRequestType.PlayNowRequest,
-							video: {
-								...videoToPlay,
-								subtitleUrl: "https://example.com/subtitles.srt",
-							},
-						},
-						{ token: user.token },
-					),
-				).rejects.toThrow("Subtitle URL must end with .vtt");
-			});
 		});
 
 		describe("AddRequest", () => {
@@ -329,29 +294,6 @@ describe("Room", () => {
 				thumbnail: "test",
 				length: 10,
 			};
-			const subtitleUrl = "https://example.com/subtitles.vtt";
-
-			it("should add video with subtitleUrl to queue", async () => {
-				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
-
-				await room.processUnauthorizedRequest(
-					{
-						type: RoomRequestType.AddRequest,
-						video: {
-							...videoToAdd,
-							subtitleUrl,
-						},
-					},
-					{ token: user.token },
-				);
-
-				expect(room.queue).toHaveLength(1);
-				expect(room.queue.items[0]).toEqual({
-					...videoToAdd,
-					subtitleUrl,
-				});
-			});
-
 			it("should add video with defaultSubtitleTrack to queue", async () => {
 				const defaultSubtitleTrack = "https://example.com/track.de.ass";
 				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
@@ -374,22 +316,6 @@ describe("Room", () => {
 				});
 			});
 
-			it("should reject non-vtt subtitleUrl for AddRequest", async () => {
-				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
-
-				await expect(
-					room.processUnauthorizedRequest(
-						{
-							type: RoomRequestType.AddRequest,
-							video: {
-								...videoToAdd,
-								subtitleUrl: "https://example.com/subtitles.srt",
-							},
-						},
-						{ token: user.token },
-					),
-				).rejects.toThrow("Subtitle URL must end with .vtt");
-			});
 		});
 
 		describe("VoteRequest", () => {

--- a/server/tests/unit/room.spec.ts
+++ b/server/tests/unit/room.spec.ts
@@ -316,6 +316,53 @@ describe("Room", () => {
 				});
 			});
 
+			it("should default defaultSubtitleTrack to null when omitted", async () => {
+				vi.spyOn(infoextractor, "getVideoInfo").mockResolvedValue(videoToAdd);
+
+				await room.processUnauthorizedRequest(
+					{
+						type: RoomRequestType.AddRequest,
+						video: { ...videoToAdd },
+					},
+					{ token: user.token },
+				);
+
+				expect(room.queue).toHaveLength(1);
+				expect(room.queue.items[0]).toEqual({
+					...videoToAdd,
+					defaultSubtitleTrack: null,
+				});
+			});
+
+			it("should apply per-item defaultSubtitleTrack for a batch add", async () => {
+				const first: Video = { ...videoToAdd, id: "first" };
+				const second: Video = { ...videoToAdd, id: "second" };
+				// Returned out of request order to prove matching is by service+id, not index.
+				vi.spyOn(infoextractor, "getManyVideoInfo").mockResolvedValue([second, first]);
+
+				await room.processUnauthorizedRequest(
+					{
+						type: RoomRequestType.AddRequest,
+						videos: [
+							{ ...first, defaultSubtitleTrack: "https://example.com/first.vtt" },
+							{ ...second },
+						],
+					},
+					{ token: user.token },
+				);
+
+				expect(room.queue).toHaveLength(2);
+				expect(room.queue.items).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							id: "first",
+							defaultSubtitleTrack: "https://example.com/first.vtt",
+						}),
+						expect.objectContaining({ id: "second", defaultSubtitleTrack: null }),
+					]),
+				);
+			});
+
 		});
 
 		describe("VoteRequest", () => {

--- a/server/tests/unit/services/direct.spec.ts
+++ b/server/tests/unit/services/direct.spec.ts
@@ -158,7 +158,7 @@ describe("Direct", () => {
 			sources: [{ url: "https://example.com/video.mp4", contentType: "video/mp4", quality: 720 }],
 		};
 
-		it("passes text tracks through and picks the default track as defaultSubtitleTrack", async () => {
+		it("passes text tracks through and picks the default track as subtitleUrl", async () => {
 			stubManifest({
 				...baseManifest,
 				textTracks: [
@@ -175,7 +175,7 @@ describe("Direct", () => {
 			const video = await adapter.fetchManifestInfo("https://example.com/manifest.json");
 
 			expect(video.textTracks).toHaveLength(2);
-			expect(video.defaultSubtitleTrack).toEqual("https://example.com/de.ass");
+			expect(video.subtitleUrl).toEqual("https://example.com/de.ass");
 		});
 	});
 });

--- a/server/tests/unit/services/direct.spec.ts
+++ b/server/tests/unit/services/direct.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import DirectVideoAdapter from "../../../services/direct.js";
 import { FfprobeStrategy } from "../../../ffprobe.js";
 import fs from "node:fs";
@@ -135,6 +135,90 @@ describe("Direct", () => {
 				title: "Foo: The Movie",
 				length: 69420,
 			});
+		});
+	});
+
+	describe("fetchManifestInfo", () => {
+		const adapter = new DirectVideoAdapter();
+		adapter.ffprobe = new FfprobeFixtures();
+
+		function mockManifest(manifest: Record<string, unknown>) {
+			vi.spyOn(global, "fetch").mockResolvedValue({
+				ok: true,
+				status: 200,
+				json: async () => manifest,
+			} as Response);
+		}
+
+		const baseManifest = {
+			title: "Manifest Movie",
+			duration: 100,
+			sources: [{ url: "https://example.com/video.mp4", contentType: "video/mp4" }],
+		};
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		it("exposes the manifest's text tracks on the video", async () => {
+			const textTracks = [
+				{
+					url: "https://example.com/en.vtt",
+					contentType: "text/vtt",
+					name: "English",
+					srclang: "en",
+				},
+			];
+			mockManifest({ ...baseManifest, textTracks });
+			const video = await adapter.fetchVideoInfo("https://example.com/media.json");
+			expect(video.mime).toEqual("application/json");
+			expect(video.textTracks).toEqual(textTracks);
+		});
+
+		it("resolves defaultSubtitleTrack from the manifest's default track", async () => {
+			mockManifest({
+				...baseManifest,
+				textTracks: [
+					{
+						url: "https://example.com/en.vtt",
+						contentType: "text/vtt",
+						name: "English",
+						srclang: "en",
+					},
+					{
+						url: "https://example.com/de.vtt",
+						contentType: "text/vtt",
+						name: "German",
+						srclang: "de",
+						default: true,
+					},
+				],
+			});
+			const video = await adapter.fetchVideoInfo("https://example.com/media.json");
+			expect(video.defaultSubtitleTrack).toEqual("https://example.com/de.vtt");
+		});
+
+		it("resolves defaultSubtitleTrack to null when no track is marked default", async () => {
+			mockManifest({
+				...baseManifest,
+				textTracks: [
+					{
+						url: "https://example.com/en.vtt",
+						contentType: "text/vtt",
+						name: "English",
+						srclang: "en",
+					},
+				],
+			});
+			const video = await adapter.fetchVideoInfo("https://example.com/media.json");
+			expect(video.defaultSubtitleTrack).toBeNull();
+		});
+
+		it("resolves defaultSubtitleTrack to null when there are no text tracks", async () => {
+			mockManifest({ ...baseManifest });
+			const video = await adapter.fetchVideoInfo("https://example.com/media.json");
+			expect(video.textTracks).toBeUndefined();
+			expect(video.defaultSubtitleTrack).toBeNull();
 		});
 	});
 });

--- a/server/tests/unit/services/direct.spec.ts
+++ b/server/tests/unit/services/direct.spec.ts
@@ -140,85 +140,42 @@ describe("Direct", () => {
 
 	describe("fetchManifestInfo", () => {
 		const adapter = new DirectVideoAdapter();
-		adapter.ffprobe = new FfprobeFixtures();
 
-		function mockManifest(manifest: Record<string, unknown>) {
-			vi.spyOn(global, "fetch").mockResolvedValue({
-				ok: true,
-				status: 200,
-				json: async () => manifest,
-			} as Response);
+		afterEach(() => {
+			vi.unstubAllGlobals();
+		});
+
+		function stubManifest(manifest: unknown): void {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn().mockResolvedValue({ ok: true, json: async () => manifest }),
+			);
 		}
 
 		const baseManifest = {
-			title: "Manifest Movie",
+			title: "Test",
 			duration: 100,
-			sources: [{ url: "https://example.com/video.mp4", contentType: "video/mp4" }],
+			sources: [{ url: "https://example.com/video.mp4", contentType: "video/mp4", quality: 720 }],
 		};
 
-		afterEach(() => {
-			vi.restoreAllMocks();
-		});
-
-		it("exposes the manifest's text tracks on the video", async () => {
-			const textTracks = [
-				{
-					url: "https://example.com/en.vtt",
-					contentType: "text/vtt",
-					name: "English",
-					srclang: "en",
-				},
-			];
-			mockManifest({ ...baseManifest, textTracks });
-			const video = await adapter.fetchVideoInfo("https://example.com/media.json");
-			expect(video.mime).toEqual("application/json");
-			expect(video.textTracks).toEqual(textTracks);
-		});
-
-		it("resolves defaultSubtitleTrack from the manifest's default track", async () => {
-			mockManifest({
+		it("passes text tracks through and picks the default track as defaultSubtitleTrack", async () => {
+			stubManifest({
 				...baseManifest,
 				textTracks: [
+					{ url: "https://example.com/en.vtt", contentType: "text/vtt", srclang: "en" },
 					{
-						url: "https://example.com/en.vtt",
-						contentType: "text/vtt",
-						name: "English",
-						srclang: "en",
-					},
-					{
-						url: "https://example.com/de.vtt",
-						contentType: "text/vtt",
-						name: "German",
+						url: "https://example.com/de.ass",
+						contentType: "text/x-ass",
 						srclang: "de",
 						default: true,
 					},
 				],
 			});
-			const video = await adapter.fetchVideoInfo("https://example.com/media.json");
-			expect(video.defaultSubtitleTrack).toEqual("https://example.com/de.vtt");
-		});
 
-		it("resolves defaultSubtitleTrack to null when no track is marked default", async () => {
-			mockManifest({
-				...baseManifest,
-				textTracks: [
-					{
-						url: "https://example.com/en.vtt",
-						contentType: "text/vtt",
-						name: "English",
-						srclang: "en",
-					},
-				],
-			});
-			const video = await adapter.fetchVideoInfo("https://example.com/media.json");
-			expect(video.defaultSubtitleTrack).toBeNull();
-		});
+			const video = await adapter.fetchManifestInfo("https://example.com/manifest.json");
 
-		it("resolves defaultSubtitleTrack to null when there are no text tracks", async () => {
-			mockManifest({ ...baseManifest });
-			const video = await adapter.fetchVideoInfo("https://example.com/media.json");
-			expect(video.textTracks).toBeUndefined();
-			expect(video.defaultSubtitleTrack).toBeNull();
+			expect(video.textTracks).toHaveLength(2);
+			expect(video.defaultSubtitleTrack).toEqual("https://example.com/de.ass");
 		});
 	});
 });

--- a/server/videoqueue.ts
+++ b/server/videoqueue.ts
@@ -140,7 +140,7 @@ export class VideoQueue extends Dirtyable {
 		});
 	}
 
-	/** Update queue item extras (e.g. defaultSubtitleTrack) for a video already in the queue. */
+	/** Update queue item extras (e.g. subtitleUrl) for a video already in the queue. */
 	async update(video: VideoId, patch: Partial<QueueItemExtras>): Promise<void> {
 		return this.lock.protect(() => {
 			const matchIdx = this.findIndex(video);

--- a/server/videoqueue.ts
+++ b/server/videoqueue.ts
@@ -140,7 +140,7 @@ export class VideoQueue extends Dirtyable {
 		});
 	}
 
-	/** Update queue item extras (e.g. subtitleUrl) for a video already in the queue. */
+	/** Update queue item extras (e.g. defaultSubtitleTrack) for a video already in the queue. */
 	async update(video: VideoId, patch: Partial<QueueItemExtras>): Promise<void> {
 		return this.lock.protect(() => {
 			const matchIdx = this.findIndex(video);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7880,6 +7880,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assjs@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "assjs@npm:0.1.7"
+  checksum: 10c0/3a7a1f00c6b66982d62ac6a9d0dae91ff9b5f39f8a0de951f5ab20e3c32ccc21880a778181747d776590312a65f044a20109753895c52b0880854cf5701ec7d8
+  languageName: node
+  linkType: hard
+
 "astral-regex@npm:^2.0.0":
   version: 2.0.0
   resolution: "astral-regex@npm:2.0.0"
@@ -16552,6 +16559,7 @@ __metadata:
     "@vue/eslint-config-typescript": "npm:^11.0.3"
     "@vue/test-utils": "npm:2.2.1"
     "@vueuse/core": "npm:^14.3.0"
+    assjs: "npm:^0.1.7"
     axios: "npm:1.13.5"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
I added enhanced subtitle rendering via ass.js for custom-manifest videos. 

Changes in this PR:

* include ass.js for rendering ass subtitles via new component "ass-overlay.ts"
* allow multiple vtt and ass subtitle tracks for the same video
* add scrollbars to the overlay-menu for subtitle-selection, because videos can have lots of subtitles. 
* in custom-media-format-jsons  add pseudo mime type "text/x-ass" (ass files don't seem to have an official mime-type associated to them) in addition to text/vtt
* handling of default subtitle track:
  * if there is one, viewers will start viewing with this track enabled. 
  * default subtitle track can be changed while the video is in the queue
  * after it has started, viewers can change the track for themself, and the change won't be synced to other viewers
* i added some line to agents.md, because i was running claude in its webharness and it was running into problems with yarn, which it couldn't recover from. 
* the existing VTT rendering via native browser rendering was left in tact. (it was annoying to integrate both subtitle paths at the same time. I guess architecture would get much simpler if we would remove the native VTT path alltogether and instead render vtt via ass.js as well (i have not tested if ass.js actually can do vtt))


what i have not done yet:

* i have not considered database migrations for existing rooms. for my tests i usually created a clean new room. 
* i did not test against any other video sources, such as youtube. 
* i did not clean up git history (i assume you will just squash this PR)


The actual rendering is isolated to ass-overlay.ts, and seems clean enough to me. The selection of subs seems kinda messy, but i didn't find a way to make it cleaner. I think it is now cleaner that it was before though. Some feedback/guidance would be appreciated. 


I opted for ass.js, as that seemed the to be lightest library that is still being maintained. It seems jassub is more accurate and faster, but also much heaver. The other libraries i found didn't seem to be activly maintained. 

i tested with this deployment: https://ott.wotanii.de/ and this video: https://ottfiles.wotanii.de/public/2026-06-20/clock.mkv.json also i made a small watchparter with some friends, and it worked fine.


during testing i encountered some issues, which are solved now:
* the library ass.js registers a resize-hook to know when to resize the subs. but when i registed the hook before the video was actually loaded, the resizing became weird. I solved it by waiting for the video before intializing the ass-container. 
* claude had trouble running yarn install. I solved it by telling it to use bun instead. I recommend to migrate to bun, as that is in my opinion generally better than npm or yarn. 
* claude had trouble running cargo tests. I solved it by not running cargo tests, and instead deploy to my server for manual testing. clauds issue was that it could not do ipv6. 

