### PR TITLE
fix(client): wait for <track> elements to mount before setting defaul…

### DIFF
--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -298,7 +298,7 @@ async function loadVideoSource() {
 
 		captions.captionsTracks.value = getCaptionsTracks();
 		if ((manifest.value.textTracks ?? []).length > 0) {
-			// Wait for all text tracks are inserted
+			// Wait for all text tracks to be inserted
 			await nextTick();
 		}
 		const defaultTrackIdx = manifest.value.textTracks?.findIndex(t => t.default) ?? -1;

--- a/client/src/components/players/DirectPlayer.vue
+++ b/client/src/components/players/DirectPlayer.vue
@@ -297,17 +297,13 @@ async function loadVideoSource() {
 		qualities.currentVideoTrack.value = 0;
 
 		captions.captionsTracks.value = getCaptionsTracks();
-		// The browser adds newly inserted <track> elements in "disabled" mode initially,
-		// the default attribute causes them to become "showing" asynchronously.
-		// To reflect this in the UI correctly, now the default track index is read directly
-		// from the manifest data, and we explicitly set its mode to "showing"
+		if ((manifest.value.textTracks ?? []).length > 0) {
+			// Wait for all text tracks are inserted
+			await nextTick();
+		}
 		const defaultTrackIdx = manifest.value.textTracks?.findIndex(t => t.default) ?? -1;
 		captions.currentTrack.value = defaultTrackIdx;
 		captions.isCaptionsEnabled.value = defaultTrackIdx !== -1;
-		if (defaultTrackIdx !== -1) {
-			await nextTick();
-			videoElem.value.textTracks[defaultTrackIdx].mode = "showing";
-		}
 	} else {
 		videoElem.value.src = videoUrl.value;
 


### PR DESCRIPTION
In `DirectPlayer.vue`, `captions.currentTrack.value` was being assigned before the new manifest's <track> elements had actually mounted in the DOM. That assignment is watched in `OmniPlayer.vue` and synchronously triggers `setCaptionsTrack`/`setCaptionsEnabled`, which read `videoElem.value.textTracks`. So, on chrome, the list could still be empty at that point, leaving the wrong track showing as default.

Moved the `await nextTick()` earlier, before `captions.currentTrack.value` is set, so `<track>` elements exist by the time downstream watchers read textTracks..